### PR TITLE
PubNub Swift Chat SDK 0.9.3 release

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,9 +1,18 @@
 ---
 name: swift-chat-sdk
 scm: github.com/pubnub/swift-chat-sdk
-version: "0.9.2"
+version: "0.9.3"
 schema: 1
 changelog:
+  - date: 2024-12-18
+    version: 0.9.3
+    changes:
+      - type: bug
+        text: "Add missing initialization for `reactionsActionName` property."
+      - type: bug
+        text: "Add missing `completion:` parameter when sending a text."
+      - type: improvement
+        text: "Run `swiftformat` to uplift the codebase."
   - date: 2024-12-17
     version: 0.9.2
     changes:
@@ -68,7 +77,7 @@ sdks:
           - distribution-type: source
             distribution-repository: GitHub release
             package-name: PubNubSwiftChatSDK
-            location: https://github.com/pubnub/swift-chat-sdk/archive/refs/tags/0.9.2-dev.zip
+            location: https://github.com/pubnub/swift-chat-sdk/archive/refs/tags/0.9.3-dev.zip
             supported-platforms:
               supported-operating-systems:
                 iOS:

--- a/PubNubSwiftChatSDK.xcodeproj/project.pbxproj
+++ b/PubNubSwiftChatSDK.xcodeproj/project.pbxproj
@@ -733,7 +733,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 0.9.2;
+				MARKETING_VERSION = 0.9.3;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS";
@@ -782,7 +782,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 0.9.2;
+				MARKETING_VERSION = 0.9.3;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS";

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You will need the publish and subscribe keys to authenticate your app. Get your 
 1. Create or open your project inside Xcode.
 2. Navigate to **File -> Add Package Dependencies**.
 3. Search for `https://github.com/pubnub/swift-chat-sdk`
-4. From the **Dependency Rule** drop-down list, select **Exact**. In the version input field, type `0.9.2-dev`
+4. From the **Dependency Rule** drop-down list, select **Exact**. In the version input field, type `0.9.3-dev`
 5. Click the **Add Package** button.
 
 For more information see Apple's guide on [Adding Package Dependencies to Your App](https://developer.apple.com/documentation/xcode/adding_package_dependencies_to_your_app)

--- a/Sources/Chat.swift
+++ b/Sources/Chat.swift
@@ -10,7 +10,6 @@
 
 import Foundation
 import PubNubSDK
-import Combine
 
 /// A protocol that defines the basic structure and behavior for a chat.
 ///

--- a/Sources/ChatConfiguration.swift
+++ b/Sources/ChatConfiguration.swift
@@ -65,6 +65,7 @@ public class CustomPayloads {
     self.getMessageResponseBody = getMessageResponseBody
     self.editMessageActionName = editMessageActionName
     self.deleteMessageActionName = deleteMessageActionName
+    self.reactionsActionName = reactionsActionName
   }
 
   func transform() -> PubNubChat.CustomPayloads {

--- a/Sources/ChatImpl.swift
+++ b/Sources/ChatImpl.swift
@@ -642,15 +642,17 @@ extension ChatImpl: Chat {
     ).async(caller: self) { (result: FutureResult<ChatImpl, PubNubChat.MarkAllMessageAsReadResponse>) in
       switch result.result {
       case let .success(response):
-        completion?(.success((
-          memberships: response.memberships.compactMap {
-            MembershipImpl(membership: $0)
-          },
-          page: PubNubHashedPageBase(
-            start: response.next?.pageHash,
-            end: response.prev?.pageHash,
-            totalCount: Int(response.total)
-          ))
+        completion?(.success(
+          (
+            memberships: response.memberships.compactMap {
+              MembershipImpl(membership: $0)
+            },
+            page: PubNubHashedPageBase(
+              start: response.next?.pageHash,
+              end: response.prev?.pageHash,
+              totalCount: Int(response.total)
+            )
+          )
         ))
       case let .failure(error):
         completion?(.failure(error))

--- a/Sources/Entities/BaseChannel.swift
+++ b/Sources/Entities/BaseChannel.swift
@@ -228,7 +228,14 @@ final class BaseChannel<C: PubNubChat.Channel_, M: PubNubChat.Message>: Channel 
       quotedMessage: quotedMessage?.target.message,
       files: files?.compactMap { $0.transform() },
       usersToMention: usersToMention
-    )
+    ).async(caller: self) { (result: FutureResult<BaseChannel, PubNubChat.PNPublishResult>) in
+      switch result.result {
+      case let .success(response):
+        completion?(.success(Timetoken(response.timetoken)))
+      case let .failure(error):
+        completion?(.failure(error))
+      }
+    }
   }
 
   func invite(user: ChatType.ChatUserType, completion: ((Swift.Result<MembershipImpl, Error>) -> Void)?) {

--- a/Sources/Entities/ChannelImpl.swift
+++ b/Sources/Entities/ChannelImpl.swift
@@ -208,7 +208,7 @@ extension ChannelImpl: Channel {
     usePost: Bool = false,
     ttl: Int? = nil,
     quotedMessage: MessageImpl? = nil,
-    files: [InputFile]?,
+    files: [InputFile]? = nil,
     usersToMention: [String]? = nil,
     completion: ((Swift.Result<Timetoken, Error>) -> Void)? = nil
   ) {

--- a/Sources/Entities/ThreadChannel.swift
+++ b/Sources/Entities/ThreadChannel.swift
@@ -9,8 +9,8 @@
 //
 
 import Foundation
-import PubNubSDK
 import PubNubChat
+import PubNubSDK
 
 /// Represents an object that refers to a single thread (channel) in a chat.
 ///

--- a/Sources/Entities/ThreadMessageImpl.swift
+++ b/Sources/Entities/ThreadMessageImpl.swift
@@ -62,8 +62,8 @@ public final class ThreadMessageImpl {
   }
 }
 
-extension ThreadMessageImpl {
-  public func asMessage() -> MessageImpl {
+public extension ThreadMessageImpl {
+  func asMessage() -> MessageImpl {
     MessageImpl(message: target.message)
   }
 }

--- a/Sources/Extensions/PubNub.MembershipSortField.swift
+++ b/Sources/Extensions/PubNub.MembershipSortField.swift
@@ -18,18 +18,18 @@ extension PubNub.MembershipSortField {
     case let .object(objectSortProperty):
       switch objectSortProperty {
       case .id:
-        return ascending ? PNSortKeyPNAsc(key: PNMembershipKey.channelId) : PNSortKeyPNDesc(key: .channelId)
+        ascending ? PNSortKeyPNAsc(key: PNMembershipKey.channelId) : PNSortKeyPNDesc(key: .channelId)
       case .name:
-        return ascending ? PNSortKeyPNAsc(key: PNMembershipKey.channelName) : PNSortKeyPNDesc(key: .channelName)
+        ascending ? PNSortKeyPNAsc(key: PNMembershipKey.channelName) : PNSortKeyPNDesc(key: .channelName)
       case .updated:
-        return ascending ? PNSortKeyPNAsc(key: PNMembershipKey.channelUpdated) : PNSortKeyPNDesc(key: .channelUpdated)
+        ascending ? PNSortKeyPNAsc(key: PNMembershipKey.channelUpdated) : PNSortKeyPNDesc(key: .channelUpdated)
       case .type, .status:
-        return nil
+        nil
       }
     case .type, .status:
-      return nil
+      nil
     case .updated:
-      return ascending ? PNSortKeyPNAsc(key: PNMembershipKey.updated) : PNSortKeyPNDesc(key: .updated)
+      ascending ? PNSortKeyPNAsc(key: PNMembershipKey.updated) : PNSortKeyPNDesc(key: .updated)
     }
   }
 }

--- a/Sources/Extensions/PubNub.MembershipSortField.swift
+++ b/Sources/Extensions/PubNub.MembershipSortField.swift
@@ -18,18 +18,18 @@ extension PubNub.MembershipSortField {
     case let .object(objectSortProperty):
       switch objectSortProperty {
       case .id:
-        ascending ? PNSortKeyPNAsc(key: PNMembershipKey.channelId) : PNSortKeyPNDesc(key: .channelId)
+        return ascending ? PNSortKeyPNAsc(key: PNMembershipKey.channelId) : PNSortKeyPNDesc(key: .channelId)
       case .name:
-        ascending ? PNSortKeyPNAsc(key: PNMembershipKey.channelName) : PNSortKeyPNDesc(key: .channelName)
+        return ascending ? PNSortKeyPNAsc(key: PNMembershipKey.channelName) : PNSortKeyPNDesc(key: .channelName)
       case .updated:
-        ascending ? PNSortKeyPNAsc(key: PNMembershipKey.channelUpdated) : PNSortKeyPNDesc(key: .channelUpdated)
+        return ascending ? PNSortKeyPNAsc(key: PNMembershipKey.channelUpdated) : PNSortKeyPNDesc(key: .channelUpdated)
       case .type, .status:
-        nil
+        return nil
       }
     case .type, .status:
-      nil
+      return nil
     case .updated:
-      ascending ? PNSortKeyPNAsc(key: PNMembershipKey.updated) : PNSortKeyPNDesc(key: .updated)
+      return ascending ? PNSortKeyPNAsc(key: PNMembershipKey.updated) : PNSortKeyPNDesc(key: .updated)
     }
   }
 }

--- a/Sources/Extensions/PubNub.ObjectSortField.swift
+++ b/Sources/Extensions/PubNub.ObjectSortField.swift
@@ -16,15 +16,15 @@ extension PubNub.ObjectSortField {
   func transform() -> PNSortKey<PNKey>? {
     switch property {
     case .id:
-      ascending ? PNSortKeyPNAsc(key: .id) : PNSortKeyPNDesc(key: .id)
+      return ascending ? PNSortKeyPNAsc(key: .id) : PNSortKeyPNDesc(key: .id)
     case .name:
-      ascending ? PNSortKeyPNAsc(key: .name) : PNSortKeyPNDesc(key: .name)
+      return ascending ? PNSortKeyPNAsc(key: .name) : PNSortKeyPNDesc(key: .name)
     case .type:
-      ascending ? PNSortKeyPNAsc(key: .type) : PNSortKeyPNDesc(key: .type)
+      return ascending ? PNSortKeyPNAsc(key: .type) : PNSortKeyPNDesc(key: .type)
     case .status:
-      ascending ? PNSortKeyPNAsc(key: .status) : PNSortKeyPNDesc(key: .status)
+      return ascending ? PNSortKeyPNAsc(key: .status) : PNSortKeyPNDesc(key: .status)
     case .updated:
-      ascending ? PNSortKeyPNAsc(key: .updated) : PNSortKeyPNDesc(key: .updated)
+      return ascending ? PNSortKeyPNAsc(key: .updated) : PNSortKeyPNDesc(key: .updated)
     }
   }
 }

--- a/Sources/Extensions/PubNub.ObjectSortField.swift
+++ b/Sources/Extensions/PubNub.ObjectSortField.swift
@@ -16,15 +16,15 @@ extension PubNub.ObjectSortField {
   func transform() -> PNSortKey<PNKey>? {
     switch property {
     case .id:
-      return ascending ? PNSortKeyPNAsc(key: .id) : PNSortKeyPNDesc(key: .id)
+      ascending ? PNSortKeyPNAsc(key: .id) : PNSortKeyPNDesc(key: .id)
     case .name:
-      return ascending ? PNSortKeyPNAsc(key: .name) : PNSortKeyPNDesc(key: .name)
+      ascending ? PNSortKeyPNAsc(key: .name) : PNSortKeyPNDesc(key: .name)
     case .type:
-      return ascending ? PNSortKeyPNAsc(key: .type) : PNSortKeyPNDesc(key: .type)
+      ascending ? PNSortKeyPNAsc(key: .type) : PNSortKeyPNDesc(key: .type)
     case .status:
-      return ascending ? PNSortKeyPNAsc(key: .status) : PNSortKeyPNDesc(key: .status)
+      ascending ? PNSortKeyPNAsc(key: .status) : PNSortKeyPNDesc(key: .status)
     case .updated:
-      return ascending ? PNSortKeyPNAsc(key: .updated) : PNSortKeyPNDesc(key: .updated)
+      ascending ? PNSortKeyPNAsc(key: .updated) : PNSortKeyPNDesc(key: .updated)
     }
   }
 }

--- a/Sources/Extensions/PubNubChat.PubNubError.swift
+++ b/Sources/Extensions/PubNubChat.PubNubError.swift
@@ -11,6 +11,4 @@
 import Foundation
 import PubNubChat
 
-extension PubNubChat.PubNubError: Error {
-
-}
+extension PubNubChat.PubNubError: Error {}

--- a/Sources/MessageDraft/MessageDraft.swift
+++ b/Sources/MessageDraft/MessageDraft.swift
@@ -9,8 +9,8 @@
 //
 
 import Foundation
-import PubNubSDK
 import PubNubChat
+import PubNubSDK
 
 /// An object that refers to a single message that has not been published yet.
 public protocol MessageDraft {
@@ -123,20 +123,20 @@ public enum UserSuggestionSource {
   func transform() -> PubNubChat.MessageDraftUserSuggestionSource {
     switch self {
     case .global:
-      return .global
+      .global
     case .channel:
-      return .channel
+      .channel
     }
   }
 
   static func from(source: PubNubChat.MessageDraftUserSuggestionSource) -> UserSuggestionSource {
     switch source {
     case .global:
-      return .global
+      .global
     case .channel:
-      return .channel
+      .channel
     default:
-      return .global
+      .global
     }
   }
 }
@@ -150,34 +150,34 @@ public enum MessageElement: Equatable {
 
   static func from(element: PubNubChat.MessageElement) -> MessageElement? {
     if let plainTextElement = element as? PubNubChat.MessageElementPlainText {
-      return .plainText(text: plainTextElement.text)
+      .plainText(text: plainTextElement.text)
     } else if let linkElement = element as? PubNubChat.MessageElementLink, let target = MentionTarget.from(target: linkElement.target) {
-      return .link(text: linkElement.text, target: target)
+      .link(text: linkElement.text, target: target)
     } else {
-      return nil
+      nil
     }
   }
 
   func isLink() -> Bool {
     switch self {
     case .plainText:
-      return false
+      false
     case .link:
-      return true
+      true
     }
   }
 
   func transform() -> PubNubChat.MessageElement {
     switch self {
     case let .plainText(text):
-      return MessageElementPlainText(text: text)
+      MessageElementPlainText(text: text)
     case let .link(text, target):
-      return MessageElementLink(text: text, target: target.transform())
+      MessageElementLink(text: text, target: target.transform())
     }
   }
 }
 
-public extension Array where Element == MessageElement {
+public extension [MessageElement] {
   /// Returns `true` if the underlying Array contains any mention (user/channel)
   func containsAnyMention() -> Bool {
     reduce(into: false) { accumulatedResult, currentElement in
@@ -198,23 +198,23 @@ public enum MentionTarget: Equatable {
   func transform() -> PubNubChat.MentionTarget {
     switch self {
     case let .channel(channelId):
-      return MentionTargetChannel(channelId: channelId)
+      MentionTargetChannel(channelId: channelId)
     case let .user(userId):
-      return MentionTargetUser(userId: userId)
+      MentionTargetUser(userId: userId)
     case let .url(url):
-      return MentionTargetUrl(url: url)
+      MentionTargetUrl(url: url)
     }
   }
 
   static func from(target: PubNubChat.MentionTarget) -> MentionTarget? {
     if let channelTarget = target as? PubNubChat.MentionTargetChannel {
-      return .channel(channelId: channelTarget.channelId)
+      .channel(channelId: channelTarget.channelId)
     } else if let userTarget = target as? PubNubChat.MentionTargetUser {
-      return .user(userId: userTarget.userId)
+      .user(userId: userTarget.userId)
     } else if let urlTarget = target as? PubNubChat.MentionTargetUrl {
-      return .url(url: urlTarget.url)
+      .url(url: urlTarget.url)
     } else {
-      return nil
+      nil
     }
   }
 }
@@ -254,7 +254,7 @@ public struct SuggestedMention {
   }
 }
 
-public extension Array where Element == SuggestedMention {
+public extension [SuggestedMention] {
   /// Utility function for filtering suggestions for a specific position in the message draft text.
   ///
   /// - Parameter position: The cursor position in the message draft text

--- a/Sources/MessageDraft/MessageDraftChangeListener.swift
+++ b/Sources/MessageDraft/MessageDraftChangeListener.swift
@@ -1,5 +1,5 @@
 //
-//  MessageDraftStateListener.swift
+//  MessageDraftChangeListener.swift
 //
 //  Copyright (c) PubNub Inc.
 //  All rights reserved.
@@ -14,7 +14,6 @@ import PubNubChat
 /// A listener that can be used with ``MessageDraft/addChangeListener(_:)`` to listen for changes to the message draft
 /// text and get current mention suggestions.
 public protocol MessageDraftChangeListener: AnyObject {
-
   /// Called when there is a change in the message elements or suggested mentions.
   ///
   /// - Parameters:
@@ -27,11 +26,11 @@ public protocol MessageDraftChangeListener: AnyObject {
 ///
 /// This class allows you to handle delegate events by passing a closure, reducing the need to implement the ``MessageDraftChangeListener`` protocol.
 /// This is useful when you want to quickly handle messages without writing additional boilerplate code.
-final public class ClosureMessageDraftChangeListener: MessageDraftChangeListener {
-  let onChangeClosure: (([MessageElement], any FutureObject<[SuggestedMention]>) -> Void)
+public final class ClosureMessageDraftChangeListener: MessageDraftChangeListener {
+  let onChangeClosure: ([MessageElement], any FutureObject<[SuggestedMention]>) -> Void
 
   init(onChange: @escaping ([MessageElement], any FutureObject<[SuggestedMention]>) -> Void) {
-    self.onChangeClosure = onChange
+    onChangeClosure = onChange
   }
 
   public func onChange(messageElements: [MessageElement], suggestedMentions: any FutureObject<[SuggestedMention]>) {
@@ -60,13 +59,13 @@ class SuggestedMentionsFuture: FutureObject {
   }
 
   func async(completion: @escaping (Swift.Result<[SuggestedMention], Error>) -> Void) {
-    future.async(caller: self, callback: { (result: FutureResult<SuggestedMentionsFuture, [PubNubChat.SuggestedMention]>) in
+    future.async(caller: self) { (result: FutureResult<SuggestedMentionsFuture, [PubNubChat.SuggestedMention]>) in
       switch result.result {
       case let .success(suggestedMentions):
         completion(.success(suggestedMentions.compactMap { SuggestedMention.from(mention: $0) }))
       case let .failure(error):
         completion(.failure(error))
       }
-    })
+    }
   }
 }

--- a/Sources/MessageDraft/MessageDraftImpl.swift
+++ b/Sources/MessageDraft/MessageDraftImpl.swift
@@ -9,8 +9,8 @@
 //
 
 import Foundation
-import PubNubSDK
 import PubNubChat
+import PubNubSDK
 
 /// A concrete implementation of the ``MessageDraft`` protocol.
 ///

--- a/Sources/Miscellaneous/Constants.swift
+++ b/Sources/Miscellaneous/Constants.swift
@@ -10,4 +10,4 @@
 
 import Foundation
 
-let pubNubSwiftChatSDKVersion: String = "0.9.2"
+let pubNubSwiftChatSDKVersion: String = "0.9.3"

--- a/Sources/Miscellaneous/ErrorConstants.swift
+++ b/Sources/Miscellaneous/ErrorConstants.swift
@@ -1,5 +1,5 @@
 //
-//  Constants.swift
+//  ErrorConstants.swift
 //
 //  Copyright (c) PubNub Inc.
 //  All rights reserved.

--- a/Sources/Models/InputFile.swift
+++ b/Sources/Models/InputFile.swift
@@ -22,7 +22,7 @@ public struct InputFile {
   public var source: PubNub.FileUploadContent
 
   /// Initializes a new instance of ``InputFile`` with the provided details.
-  /// 
+  ///
   /// - Parameters:
   ///   - name: The name of the file
   ///   - type: The type or MIME type of the file (e.g., "image/jpeg", "application/pdf")
@@ -63,19 +63,19 @@ public struct InputFile {
   static func from(input: PubNubChat.InputFile) -> InputFile? {
     switch input.source {
     case let source as PubNubChat.FileUploadContent:
-      return InputFile(
+      InputFile(
         name: input.name,
         type: input.type,
         source: .file(url: source.url)
       )
     case let source as PubNubChat.DataUploadContent:
-      return InputFile(
+      InputFile(
         name: input.name,
         type: input.type,
         source: .data(source.data, contentType: source.contentType)
       )
     case let source as PubNubChat.StreamUploadContent:
-      return InputFile(
+      InputFile(
         name: input.name,
         type: input.type,
         source: .stream(
@@ -85,7 +85,7 @@ public struct InputFile {
         )
       )
     default:
-      return nil
+      nil
     }
   }
 }

--- a/Sources/Models/QuotedMessage.swift
+++ b/Sources/Models/QuotedMessage.swift
@@ -22,7 +22,7 @@ public struct QuotedMessage {
   public var userId: String
 
   /// Initializes a new instance of ``QuotedMessage`` with the provided details.
-  /// 
+  ///
   /// - Parameters:
   ///   - timetoken: Timetoken of the orginal message that you quote
   ///   - text: Original message content

--- a/Tests/ChannelIntegrationTests.swift
+++ b/Tests/ChannelIntegrationTests.swift
@@ -254,7 +254,7 @@ class ChannelIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
     XCTAssertEqual(retrievedMessage?.meta?["a"]?.codableValue.rawValue as? Int, 123)
     XCTAssertEqual(retrievedMessage?.meta?["b"]?.codableValue.rawValue as? String, "someString")
   }
-  
+
   func testChannel_SendText() throws {
     let tt = try awaitResultValue {
       channel.sendText(

--- a/Tests/ChannelIntegrationTests.swift
+++ b/Tests/ChannelIntegrationTests.swift
@@ -231,6 +231,30 @@ class ChannelIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
     XCTAssertEqual(history.messages[2].text, "Text 3")
   }
 
+  func testChannel_LegacySendText() throws {
+    let tt = try awaitResultValue {
+      channel.sendText(
+        text: "Some text to send",
+        meta: ["a": 123, "b": "someString"],
+        shouldStore: true,
+        mentionedUsers: nil,
+        referencedChannels: nil,
+        completion: $0
+      )
+    }
+
+    let retrievedMessage = try awaitResultValue(delay: 2) {
+      channel.getMessage(
+        timetoken: tt,
+        completion: $0
+      )
+    }
+
+    XCTAssertEqual(retrievedMessage?.text, "Some text to send")
+    XCTAssertEqual(retrievedMessage?.meta?["a"]?.codableValue.rawValue as? Int, 123)
+    XCTAssertEqual(retrievedMessage?.meta?["b"]?.codableValue.rawValue as? String, "someString")
+  }
+  
   func testChannel_SendText() throws {
     let tt = try awaitResultValue {
       channel.sendText(

--- a/Tests/ChannelIntegrationTests.swift
+++ b/Tests/ChannelIntegrationTests.swift
@@ -1,5 +1,5 @@
 //
-//  ChannelTests.swift
+//  ChannelIntegrationTests.swift
 //
 //  Copyright (c) PubNub Inc.
 //  All rights reserved.
@@ -9,8 +9,8 @@
 //
 
 import Foundation
-import XCTest
 import PubNubSDK
+import XCTest
 
 @testable import PubNubSwiftChatSDK
 
@@ -94,7 +94,7 @@ class ChannelIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
 
   func testChannel_Forward() throws {
     let anotherChannel = try XCTUnwrap(
-      try awaitResultValue {
+      awaitResultValue {
         chat.createChannel(
           id: randomString(),
           completion: $0
@@ -108,7 +108,7 @@ class ChannelIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
       )
     }
     let message = try XCTUnwrap(
-      try awaitResultValue(delay: 2) {
+      awaitResultValue(delay: 2) {
         anotherChannel.getMessage(
           timetoken: tt,
           completion: $0
@@ -211,7 +211,7 @@ class ChannelIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
   }
 
   func testChannel_GetHistory() throws {
-    for counter in 1...3 {
+    for counter in 1 ... 3 {
       try awaitResultValue {
         channel.sendText(
           text: "Text \(counter)",
@@ -232,19 +232,11 @@ class ChannelIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
   }
 
   func testChannel_SendText() throws {
-    var mentionedUsers = MessageMentionedUsers()
-    var referencedChannels = MessageReferencedChannels()
-
-    mentionedUsers[0] = MessageMentionedUser(id: randomString(), name: "User 1")
-    referencedChannels[0] = MessageReferencedChannel(id: randomString(), name: "Channel 1")
-
     let tt = try awaitResultValue {
       channel.sendText(
-        text: "Please welcome @User who joined the @Chann channel!",
+        text: "Some text to send",
         meta: ["a": 123, "b": "someString"],
         shouldStore: true,
-        mentionedUsers: mentionedUsers,
-        referencedChannels: referencedChannels,
         completion: $0
       )
     }
@@ -256,7 +248,7 @@ class ChannelIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
       )
     }
 
-    XCTAssertEqual(retrievedMessage?.text, "Please welcome @User who joined the @Chann channel!")
+    XCTAssertEqual(retrievedMessage?.text, "Some text to send")
     XCTAssertEqual(retrievedMessage?.meta?["a"]?.codableValue.rawValue as? Int, 123)
     XCTAssertEqual(retrievedMessage?.meta?["b"]?.codableValue.rawValue as? String, "someString")
   }
@@ -269,7 +261,7 @@ class ChannelIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
       )
     }
     let member = try XCTUnwrap(
-      try awaitResultValue {
+      awaitResultValue {
         channel.getMembers(
           completion: $0
         )
@@ -342,7 +334,7 @@ class ChannelIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
     }
 
     let memberships = try XCTUnwrap(
-      try awaitResultValue {
+      awaitResultValue {
         channel.getMembers(
           completion: $0
         )
@@ -467,7 +459,7 @@ class ChannelIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
       )
     }
     let message = try XCTUnwrap(
-      try awaitResultValue(delay: 2) {
+      awaitResultValue(delay: 2) {
         channel.getMessage(
           timetoken: tt,
           completion: $0
@@ -481,7 +473,7 @@ class ChannelIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
       )
     }
     let getPinnedMessage = try XCTUnwrap(
-      try awaitResultValue(delay: 2) {
+      awaitResultValue(delay: 2) {
         updatedChannel.getPinnedMessage(
           completion: $0
         )
@@ -502,7 +494,7 @@ class ChannelIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
       )
     }
     let message = try XCTUnwrap(
-      try awaitResultValue(delay: 2) {
+      awaitResultValue(delay: 2) {
         channel.getMessage(
           timetoken: tt,
           completion: $0
@@ -827,8 +819,8 @@ class ChannelIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
     }
 
     XCTAssertEqual(
-      users.compactMap { $0.user.name }.sorted(by: <),
-      usersToCreate.compactMap { $0.name }.sorted(by: <)
+      users.compactMap(\.user.name).sorted(by: <),
+      usersToCreate.compactMap(\.name).sorted(by: <)
     )
 
     addTeardownBlock { [unowned self] in

--- a/Tests/ChannelIntegrationTests.swift
+++ b/Tests/ChannelIntegrationTests.swift
@@ -237,11 +237,12 @@ class ChannelIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
         text: "Some text to send",
         meta: ["a": 123, "b": "someString"],
         shouldStore: true,
+        usersToMention: nil,
         completion: $0
       )
     }
 
-    let retrievedMessage = try awaitResultValue {
+    let retrievedMessage = try awaitResultValue(delay: 2) {
       channel.getMessage(
         timetoken: tt,
         completion: $0

--- a/Tests/ChatIntegrationTests.swift
+++ b/Tests/ChatIntegrationTests.swift
@@ -1,5 +1,5 @@
 //
-//  ChatTests.swift
+//  ChatIntegrationTests.swift
 //
 //  Copyright (c) PubNub Inc.
 //  All rights reserved.
@@ -81,7 +81,7 @@ class ChatIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
 
   func testChat_UpdateUser() throws {
     let newCustom: [String: JSONCodableScalar] = [
-      "someValue": 17253575019298112,
+      "someValue": 17_253_575_019_298_112,
       "someStr": "str"
     ]
     let updatedUser = try awaitResultValue {
@@ -199,7 +199,7 @@ class ChatIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
 
   func testChat_CreateChannel() throws {
     let customField: [String: JSONCodableScalar] = [
-      "someValue": 17253575019298112,
+      "someValue": 17_253_575_019_298_112,
       "someStr": "str"
     ]
     let channel = try awaitResultValue {
@@ -283,7 +283,7 @@ class ChatIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
       )
     }
     let customField: [String: JSONCodableScalar] = [
-      "someValue": 17253575019298112,
+      "someValue": 17_253_575_019_298_112,
       "someStr": "str"
     ]
     let updatedChannel = try awaitResultValue {
@@ -424,7 +424,7 @@ class ChatIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
 
   func testChat_CreatePublicConversation() throws {
     let customField: [String: JSONCodableScalar] = [
-      "someValue": 17253575019298112,
+      "someValue": 17_253_575_019_298_112,
       "someStr": "str"
     ]
     let channel = try awaitResultValue {
@@ -455,7 +455,7 @@ class ChatIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
 
   func testChat_CreateDirectConversation() throws {
     let customField: [String: JSONCodableScalar] = [
-      "someValue": 17253575019298112,
+      "someValue": 17_253_575_019_298_112,
       "someStr": "str"
     ]
     let membershipCustom: [String: JSONCodableScalar] = [
@@ -522,7 +522,7 @@ class ChatIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
     }
 
     let customField: [String: JSONCodableScalar] = [
-      "someValue": 17253575019298112,
+      "someValue": 17_253_575_019_298_112,
       "someStr": "str"
     ]
     let membershipCustom: [String: JSONCodableScalar] = [
@@ -716,7 +716,7 @@ class ChatIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
       )
     }
 
-    for _ in (1...3) {
+    for _ in 1 ... 3 {
       try awaitResultValue {
         channel.sendText(
           text: "Some new text",
@@ -726,7 +726,7 @@ class ChatIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
     }
 
     let getUnreadMessagesCount = try XCTUnwrap(
-      try awaitResultValue {
+      awaitResultValue {
         chat.getUnreadMessagesCount(
           completion: $0
         )
@@ -762,7 +762,7 @@ class ChatIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
       )
     }
 
-    for _ in (1...3) {
+    for _ in 1 ... 3 {
       try awaitResultValue {
         channel.sendText(
           text: "Some new text",
@@ -881,7 +881,7 @@ class ChatIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
     }
 
     let userMentionData = try XCTUnwrap(
-      try awaitResultValue(delay: 3) {
+      awaitResultValue(delay: 3) {
         chat.getCurrentUserMentions(
           completion: $0
         )
@@ -905,13 +905,13 @@ class ChatIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
 
   func testChat_CustomPayload() throws {
     let getMessagePublishBody: GetMessagePublishBody? = { txtContent, _, _ in
-      return ["payload": txtContent.text]
+      ["payload": txtContent.text]
     }
     let getMessageResponseBody: GetMessageResponseBody? = { value, _, _ in
       if let decodedValue = try? value.decode([String: String].self) {
-        return EventContent.TextMessageContent(text: decodedValue["payload"] ?? "")
+        EventContent.TextMessageContent(text: decodedValue["payload"] ?? "")
       } else {
-        return nil
+        nil
       }
     }
 
@@ -938,7 +938,7 @@ class ChatIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
     }
 
     let message = try XCTUnwrap(
-      try awaitResultValue(delay: 2) {
+      awaitResultValue(delay: 2) {
         channel.getHistory(
           count: 1,
           completion: $0

--- a/Tests/MembershipIntegrationTests.swift
+++ b/Tests/MembershipIntegrationTests.swift
@@ -1,5 +1,5 @@
 //
-//  MembershipTests.swift
+//  MembershipIntegrationTests.swift
 //
 //  Copyright (c) PubNub Inc.
 //  All rights reserved.
@@ -9,8 +9,8 @@
 //
 
 import Foundation
-import XCTest
 import PubNubSDK
+import XCTest
 
 @testable import PubNubSwiftChatSDK
 
@@ -47,7 +47,7 @@ final class MembershipTests: PubNubSwiftChatSDKIntegrationTests {
   func testMembership_SetLastReadMessage() throws {
     let message = MessageImpl(
       chat: chat,
-      timetoken: Timetoken(Int(Date().timeIntervalSince1970 * 10000000)),
+      timetoken: Timetoken(Int(Date().timeIntervalSince1970 * 10_000_000)),
       content: .init(text: "Lorem ipsum"),
       channelId: channel.id,
       userId: chat.currentUser.id
@@ -83,7 +83,7 @@ final class MembershipTests: PubNubSwiftChatSDKIntegrationTests {
   }
 
   func testMembership_SetLastReadMessageTimetoken() throws {
-    let timetoken = Timetoken(Int(Date().timeIntervalSince1970 * 10000000))
+    let timetoken = Timetoken(Int(Date().timeIntervalSince1970 * 10_000_000))
     let value = try awaitResultValue { membership.setLastReadMessageTimetoken(timetoken, completion: $0) }
 
     XCTAssertEqual(
@@ -93,7 +93,7 @@ final class MembershipTests: PubNubSwiftChatSDKIntegrationTests {
   }
 
   func testMembership_GetUnreadMessagesCount() throws {
-    for _ in (1...3) {
+    for _ in 1 ... 3 {
       try awaitResultValue {
         channel.sendText(
           text: "Some new text",

--- a/Tests/MessageDraftIntegrationTests.swift
+++ b/Tests/MessageDraftIntegrationTests.swift
@@ -16,11 +16,11 @@ import XCTest
 class MessageDraftIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
   private var user: UserImpl!
   private var channel: ChannelImpl!
-  
+
   override func customSetUpWitError() throws {
     let channelId = "cchnl\(randomString())"
     let userId = "uuser\(randomString())"
-    
+
     channel = try awaitResultValue {
       chat.createChannel(
         id: channelId,
@@ -34,7 +34,7 @@ class MessageDraftIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
         completion: $0
       )
     }
-    
+
     try awaitResultValue {
       channel.invite(
         user: user,
@@ -42,7 +42,7 @@ class MessageDraftIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
       )
     }
   }
-  
+
   override func customTearDownWithError() throws {
     try awaitResult { [unowned self] in
       chat.deleteUser(
@@ -57,66 +57,16 @@ class MessageDraftIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
       )
     }
   }
-  
+
   func test_MessageDraftWithUserMention() throws {
     let expectation = expectation(description: "MessageDraft")
     expectation.assertForOverFulfill = true
     expectation.expectedFulfillmentCount = 1
-        
+
     let messageDraft = channel.createMessageDraft()
-    let listener = ClosureMessageDraftChangeListener() { elements, future in
+    let listener = ClosureMessageDraftChangeListener { elements, future in
       if !elements.containsAnyMention() {
-        future.async() {
-          switch $0 {
-          case let .success(suggestedMentions):
-            if let mention = suggestedMentions.first {
-              messageDraft.insertSuggestedMention(mention: mention, text: mention.replaceWith)
-              expectation.fulfill()
-            } else {
-              XCTFail("Unexpected condition. There's no suggested mentions")
-            }
-          case let .failure(error):
-            XCTFail("Unexpected condition due to error: \(error)")
-          }
-        }
-      }      
-    }
-    
-    messageDraft.addChangeListener(listener)
-    messageDraft.update(text: "This is a @uuser")
-    
-    wait(for: [expectation], timeout: 6)
-    
-    let timetoken = try awaitResultValue {
-      messageDraft.send(completion: $0)
-    }
-    
-    let message = try awaitResultValue(delay: 3) {
-      channel.getMessage(
-        timetoken: timetoken,
-        completion: $0
-      )
-    }
-    let expectedElements: [MessageElement] = [
-      .plainText(text: "This is a "),
-      .link(text: user.id, target: .user(userId: user.id))
-    ]
-    
-    XCTAssertEqual(
-      expectedElements,
-      message?.getMessageElements() ?? []
-    )
-  }
-  
-  func test_MessageDraftWithChannelMention() throws {
-    let expectation = expectation(description: "MessageDraft")
-    expectation.assertForOverFulfill = true
-    expectation.expectedFulfillmentCount = 1
-        
-    let messageDraft = channel.createMessageDraft()
-    let listener = ClosureMessageDraftChangeListener() { elements, future in
-      if !elements.containsAnyMention() {
-        future.async() {
+        future.async {
           switch $0 {
           case let .success(suggestedMentions):
             if let mention = suggestedMentions.first {
@@ -131,16 +81,66 @@ class MessageDraftIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
         }
       }
     }
-    
+
     messageDraft.addChangeListener(listener)
-    messageDraft.update(text: "This is a #cchnl")
-    
+    messageDraft.update(text: "This is a @uuser")
+
     wait(for: [expectation], timeout: 6)
-    
+
     let timetoken = try awaitResultValue {
       messageDraft.send(completion: $0)
     }
-    
+
+    let message = try awaitResultValue(delay: 3) {
+      channel.getMessage(
+        timetoken: timetoken,
+        completion: $0
+      )
+    }
+    let expectedElements: [MessageElement] = [
+      .plainText(text: "This is a "),
+      .link(text: user.id, target: .user(userId: user.id))
+    ]
+
+    XCTAssertEqual(
+      expectedElements,
+      message?.getMessageElements() ?? []
+    )
+  }
+
+  func test_MessageDraftWithChannelMention() throws {
+    let expectation = expectation(description: "MessageDraft")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    let messageDraft = channel.createMessageDraft()
+    let listener = ClosureMessageDraftChangeListener { elements, future in
+      if !elements.containsAnyMention() {
+        future.async {
+          switch $0 {
+          case let .success(suggestedMentions):
+            if let mention = suggestedMentions.first {
+              messageDraft.insertSuggestedMention(mention: mention, text: mention.replaceWith)
+              expectation.fulfill()
+            } else {
+              XCTFail("Unexpected condition. There's no suggested mentions")
+            }
+          case let .failure(error):
+            XCTFail("Unexpected condition due to error: \(error)")
+          }
+        }
+      }
+    }
+
+    messageDraft.addChangeListener(listener)
+    messageDraft.update(text: "This is a #cchnl")
+
+    wait(for: [expectation], timeout: 6)
+
+    let timetoken = try awaitResultValue {
+      messageDraft.send(completion: $0)
+    }
+
     let message = try awaitResultValue(delay: 3) {
       channel.getMessage(
         timetoken: timetoken,
@@ -151,189 +151,189 @@ class MessageDraftIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
       .plainText(text: "This is a "),
       .link(text: channel.id, target: .channel(channelId: channel.id))
     ]
-    
+
     XCTAssertEqual(
       expectedElements,
       message?.getMessageElements() ?? []
     )
   }
-  
+
   func testMessageDraft_InsertText() {
     let expectation = expectation(description: "MessageDraft")
     expectation.assertForOverFulfill = true
     expectation.expectedFulfillmentCount = 1
-        
+
     let messageDraft = channel.createMessageDraft()
     messageDraft.update(text: "This is a #cchnl")
-    
+
     let suggestedMention = SuggestedMention(
       offset: 10,
       replaceFrom: "#cchnl",
       replaceWith: channel.name ?? "",
       target: .channel(channelId: channel.id)
     )
-    
+
     messageDraft.insertSuggestedMention(
       mention: suggestedMention,
       text: suggestedMention.replaceWith
     )
-    
-    let listener = ClosureMessageDraftChangeListener() { [unowned self] elements, future in
+
+    let listener = ClosureMessageDraftChangeListener { [unowned self] elements, _ in
       XCTAssertEqual(elements.count, 2)
       XCTAssertEqual(elements[0], .plainText(text: "Some prefix. This is a "))
       XCTAssertEqual(elements[1], .link(text: channel.name ?? "", target: .channel(channelId: channel.id)))
       expectation.fulfill()
     }
-    
+
     messageDraft.addChangeListener(listener)
     messageDraft.insertText(offset: 0, text: "Some prefix. ")
-    
+
     wait(for: [expectation], timeout: 6)
   }
-  
+
   func testMessageDraft_RemoveText() {
     let expectation = expectation(description: "MessageDraft")
     expectation.assertForOverFulfill = true
     expectation.expectedFulfillmentCount = 1
-        
+
     let messageDraft = channel.createMessageDraft()
     messageDraft.update(text: "This is a #cchnl")
-    
+
     let suggestedMention = SuggestedMention(
       offset: 10,
       replaceFrom: "#cchnl",
       replaceWith: channel.name ?? "",
       target: .channel(channelId: channel.id)
     )
-    
+
     messageDraft.insertSuggestedMention(
       mention: suggestedMention,
       text: suggestedMention.replaceWith
     )
-    
-    let listener = ClosureMessageDraftChangeListener() { [unowned self] elements, future in
+
+    let listener = ClosureMessageDraftChangeListener { [unowned self] elements, _ in
       XCTAssertEqual(elements.count, 1)
       XCTAssertEqual(elements[0], .link(text: channel.name ?? "", target: .channel(channelId: channel.id)))
       expectation.fulfill()
     }
-    
+
     messageDraft.addChangeListener(listener)
     messageDraft.removeText(offset: 0, length: 10)
-    
+
     wait(for: [expectation], timeout: 6)
   }
-  
+
   func testMessageDraft_RemoveMention() {
     let expectation = expectation(description: "MessageDraft")
     expectation.assertForOverFulfill = true
     expectation.expectedFulfillmentCount = 1
-        
+
     let messageDraft = channel.createMessageDraft()
     messageDraft.update(text: "This is a #cchnl")
-    
+
     let suggestedMention = SuggestedMention(
       offset: 10,
       replaceFrom: "#cchnl",
       replaceWith: channel.name ?? "",
       target: .channel(channelId: channel.id)
     )
-    
+
     messageDraft.insertSuggestedMention(
       mention: suggestedMention,
       text: suggestedMention.replaceWith
     )
-    
-    let listener = ClosureMessageDraftChangeListener() { [unowned self] elements, future in
+
+    let listener = ClosureMessageDraftChangeListener { [unowned self] elements, _ in
       XCTAssertEqual(elements[0], .plainText(text: "This is a \(channel.name ?? "")"))
       expectation.fulfill()
     }
-    
+
     messageDraft.addChangeListener(listener)
     messageDraft.removeMention(offset: suggestedMention.offset)
-    
+
     wait(for: [expectation], timeout: 6)
   }
-  
+
   func testMessageDraft_InsertingTextInCurrentMentionRange() {
     let expectation = expectation(description: "MessageDraft")
     expectation.assertForOverFulfill = true
     expectation.expectedFulfillmentCount = 1
-        
+
     let originalText = "This is a #cchnl"
     let messageDraft = channel.createMessageDraft()
-    
+
     messageDraft.update(text: originalText)
-    
+
     let suggestedMention = SuggestedMention(
       offset: 10,
       replaceFrom: "#cchnl",
       replaceWith: channel.name ?? "",
       target: .channel(channelId: channel.id)
     )
-    
+
     messageDraft.insertSuggestedMention(
       mention: suggestedMention,
       text: suggestedMention.replaceWith
     )
-        
-    let listener = ClosureMessageDraftChangeListener() { elements, future in
+
+    let listener = ClosureMessageDraftChangeListener { elements, _ in
       XCTAssertEqual(elements.count, 1)
       XCTAssertFalse(elements[0].isLink())
       expectation.fulfill()
     }
-    
+
     messageDraft.addChangeListener(listener)
     messageDraft.insertText(offset: 12, text: "_!!!!!_")
-    
+
     wait(for: [expectation], timeout: 6)
   }
-  
+
   func testMessageDraft_RemovingTextInCurrentMentionRange() {
     let expectation = expectation(description: "MessageDraft")
     expectation.assertForOverFulfill = true
     expectation.expectedFulfillmentCount = 1
-        
+
     let originalText = "This is a #cchnl"
     let messageDraft = channel.createMessageDraft()
-    
+
     messageDraft.update(text: originalText)
-    
+
     let suggestedMention = SuggestedMention(
       offset: 10,
       replaceFrom: "#cchnl",
       replaceWith: channel.name ?? "",
       target: .channel(channelId: channel.id)
     )
-    
+
     messageDraft.insertSuggestedMention(
       mention: suggestedMention,
       text: suggestedMention.replaceWith
     )
-        
-    let listener = ClosureMessageDraftChangeListener() { elements, future in
+
+    let listener = ClosureMessageDraftChangeListener { elements, _ in
       XCTAssertEqual(elements.count, 1)
       XCTAssertFalse(elements[0].isLink())
       expectation.fulfill()
     }
-    
+
     messageDraft.addChangeListener(listener)
     messageDraft.removeText(offset: 12, length: 5)
-    
+
     wait(for: [expectation], timeout: 6)
   }
-  
+
   func testMessageDraft_WithQuotedMessage() throws {
     let originalText = "This is some text"
     let messageDraft = channel.createMessageDraft()
-    
+
     let quotedMessage = MessageImpl(
       chat: chat,
-      timetoken: 17296737530374172,
+      timetoken: 17_296_737_530_374_172,
       content: .init(text: "Lorem ipsum"),
       channelId: channel.id,
       userId: user.id
     )
-    
+
     messageDraft.update(text: originalText)
     messageDraft.quotedMessage = quotedMessage
 
@@ -348,10 +348,10 @@ class MessageDraftIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
         completion: $0
       )
     }
-    
+
     let receivedQuotedMessage = try XCTUnwrap(message?.quotedMessage)
-    
-    XCTAssertEqual(receivedQuotedMessage.timetoken, 17296737530374172)
+
+    XCTAssertEqual(receivedQuotedMessage.timetoken, 17_296_737_530_374_172)
     XCTAssertEqual(receivedQuotedMessage.text, "Lorem ipsum")
   }
 }

--- a/Tests/MessageIntegrationTests.swift
+++ b/Tests/MessageIntegrationTests.swift
@@ -1,5 +1,5 @@
 //
-//  MessageTests.swift
+//  MessageIntegrationTests.swift
 //
 //  Copyright (c) PubNub Inc.
 //  All rights reserved.
@@ -9,8 +9,8 @@
 //
 
 import Foundation
-import XCTest
 import PubNubSDK
+import XCTest
 
 @testable import PubNubSwiftChatSDK
 
@@ -20,14 +20,14 @@ final class MessageIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
 
   override func customSetUpWitError() throws {
     channel = try XCTUnwrap(
-      try awaitResultValue {
+      awaitResultValue {
         chat.createChannel(
           id: randomString(),
           completion: $0
         )
       }
     )
-    
+
     let timetoken = try awaitResultValue {
       channel?.sendText(
         text: "text",
@@ -35,9 +35,9 @@ final class MessageIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
         completion: $0
       )
     }
-    
+
     testMessage = try XCTUnwrap(
-      try awaitResultValue(delay: 3) {
+      awaitResultValue(delay: 3) {
         channel.getMessage(
           timetoken: timetoken,
           completion: $0
@@ -57,12 +57,12 @@ final class MessageIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
   func testMessage_HasNoUserReaction() throws {
     let someMessage = MessageImpl(
       chat: chat,
-      timetoken: 17301310706849521,
+      timetoken: 17_301_310_706_849_521,
       content: .init(text: "Text text"),
       channelId: randomString(),
       userId: randomString()
     )
-    
+
     XCTAssertFalse(someMessage.hasUserReaction(reaction: "someReaction"))
   }
 
@@ -152,7 +152,7 @@ final class MessageIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
 
   func testMessage_Forward() throws {
     let anotherChannel = try XCTUnwrap(
-      try awaitResultValue {
+      awaitResultValue {
         chat.createChannel(
           id: randomString(),
           completion: $0
@@ -242,7 +242,7 @@ final class MessageIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
     }
 
     let retrievedMessage = try XCTUnwrap(
-      try awaitResultValue(delay: 3) {
+      awaitResultValue(delay: 3) {
         channel.getMessage(
           timetoken: testMessage.timetoken,
           completion: $0
@@ -281,7 +281,7 @@ final class MessageIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
       )
     }
     let message = try XCTUnwrap(
-      try awaitResultValue(delay: 3) {
+      awaitResultValue(delay: 3) {
         channel.getMessage(
           timetoken: testMessage.timetoken,
           completion: $0
@@ -293,7 +293,7 @@ final class MessageIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
     }
 
     let retrievedMessage = try XCTUnwrap(
-      try awaitResultValue(delay: 3) {
+      awaitResultValue(delay: 3) {
         channel.getMessage(
           timetoken: testMessage.timetoken,
           completion: $0
@@ -345,7 +345,7 @@ final class MessageIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
       )
     }
     let message = try XCTUnwrap(
-      try awaitResultValue(delay: 3) {
+      awaitResultValue(delay: 3) {
         channel.getMessage(
           timetoken: timetoken,
           completion: $0
@@ -389,7 +389,7 @@ final class MessageIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
       )
     }
     let message = try XCTUnwrap(
-      try awaitResultValue(delay: 3) {
+      awaitResultValue(delay: 3) {
         channel.getMessage(
           timetoken: timetoken,
           completion: $0

--- a/Tests/PubNubSwiftChatSDKIntegrationTests.swift
+++ b/Tests/PubNubSwiftChatSDKIntegrationTests.swift
@@ -1,5 +1,5 @@
 //
-//  SwiftChatSDKIntegrationTests.swift
+//  PubNubSwiftChatSDKIntegrationTests.swift
 //
 //  Copyright (c) PubNub Inc.
 //  All rights reserved.
@@ -8,17 +8,15 @@
 //  LICENSE file in the root directory of this source tree.
 //
 
-import XCTest
 import PubNubChat
-import PubNubSwiftChatSDK
 import PubNubSDK
+import PubNubSwiftChatSDK
+import XCTest
 
 class PubNubSwiftChatSDKIntegrationTests: XCTestCase {
   var chat: PubNubSwiftChatSDK.ChatImpl!
 
-  private lazy var configuration: [String: String] = {
-    readPropertyList()
-  }()
+  private lazy var configuration: [String: String] = readPropertyList()
 
   override func setUpWithError() throws {
     try super.setUpWithError()
@@ -40,9 +38,9 @@ class PubNubSwiftChatSDKIntegrationTests: XCTestCase {
   override func tearDownWithError() throws {
     try customTearDownWithError()
     try awaitResultValue { chat.deleteUser(id: chat.currentUser.id, completion: $0) }
-    
+
     chat = nil
-    
+
     try super.tearDownWithError()
   }
 }
@@ -91,12 +89,11 @@ extension PubNubSwiftChatSDKIntegrationTests {
     // Ensure length is within the desired range
     let length = max(1, min(length, 6))
     // Generate the random string
-    return String((0..<length).map { _ in letters.randomElement()! })
+    return String((0 ..< length).map { _ in letters.randomElement()! })
   }
 }
 
 extension PubNubSwiftChatSDKIntegrationTests {
-
   // Synchronously waits for an asynchronous operation that returns a `Result`
   // and retrieves the successful value
   @discardableResult
@@ -126,8 +123,8 @@ extension PubNubSwiftChatSDKIntegrationTests {
     switch try awaitResult(delay: delay, timeout: timeout, description: description, operation: operation) {
     case .success:
       fatalError("Unexpected condition")
-    case .failure(let error):
-      return error
+    case let .failure(error):
+      error
     }
   }
 
@@ -140,7 +137,6 @@ extension PubNubSwiftChatSDKIntegrationTests {
     description: String = "Waiting for the operation to complete",
     operation: (@escaping (Swift.Result<T, E>) -> Void) throws -> Void
   ) throws -> Swift.Result<T, E> {
-
     // Waits for the specified number of seconds if the call needs to be delayed
     if delay > 0 {
       wait(delay)

--- a/Tests/ThreadChannelIntegrationTests.swift
+++ b/Tests/ThreadChannelIntegrationTests.swift
@@ -1,5 +1,5 @@
 //
-//  ThreadChannelTests.swift
+//  ThreadChannelIntegrationTests.swift
 //
 //  Copyright (c) PubNub Inc.
 //  All rights reserved.
@@ -20,23 +20,23 @@ class ThreadChannelIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
 
   override func customSetUpWitError() throws {
     parentChannel = try XCTUnwrap(
-      try awaitResultValue {
+      awaitResultValue {
         chat.createChannel(
           id: randomString(),
           completion: $0
         )
       }
     )
-    
+
     let timetoken = try awaitResultValue {
       parentChannel?.sendText(
         text: "Message",
         completion: $0
       )
     }
-    
+
     let testMessage = try XCTUnwrap(
-      try awaitResultValue(delay: 3) {
+      awaitResultValue(delay: 3) {
         parentChannel.getMessage(
           timetoken: timetoken,
           completion: $0
@@ -44,7 +44,7 @@ class ThreadChannelIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
       }
     )
     threadChannel = try XCTUnwrap(
-      try awaitResultValue {
+      awaitResultValue {
         testMessage.createThread(
           completion: $0
         )
@@ -66,7 +66,7 @@ class ThreadChannelIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
 
   func testThreadChannel_PinMessageToParentChannel() throws {
     let message = try XCTUnwrap(
-      try awaitResultValue(delay: 3) {
+      awaitResultValue(delay: 3) {
         threadChannel.getHistory(
           completion: $0
         )

--- a/Tests/ThreadMessageIntegrationTests.swift
+++ b/Tests/ThreadMessageIntegrationTests.swift
@@ -1,5 +1,5 @@
 //
-//  ThreadMessageTests.swift
+//  ThreadMessageIntegrationTests.swift
 //
 //  Copyright (c) PubNub Inc.
 //  All rights reserved.
@@ -9,8 +9,8 @@
 //
 
 import Foundation
-import XCTest
 import PubNubSDK
+import XCTest
 
 @testable import PubNubSwiftChatSDK
 
@@ -22,32 +22,32 @@ class ThreadMessageIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
 
   override func customSetUpWitError() throws {
     channel = try XCTUnwrap(
-      try awaitResultValue {
+      awaitResultValue {
         chat.createChannel(
           id: randomString(),
           completion: $0
         )
       }
     )
-    
+
     let timetoken = try awaitResultValue {
       channel?.sendText(
         text: "text",
         completion: $0
       )
     }
-    
+
     let testMessage = try XCTUnwrap(
-      try awaitResultValue(delay: 3) {
+      awaitResultValue(delay: 3) {
         channel.getMessage(
           timetoken: timetoken,
           completion: $0
         )
       }
     )
-    
+
     threadChannel = try XCTUnwrap(
-      try awaitResultValue {
+      awaitResultValue {
         testMessage.createThread(
           completion: $0
         )
@@ -62,7 +62,7 @@ class ThreadMessageIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
     }
 
     threadMessage = try XCTUnwrap(
-      try awaitResultValue(delay: 3) {
+      awaitResultValue(delay: 3) {
         threadChannel.getHistory(completion: $0)
       }.messages.first
     )
@@ -143,7 +143,7 @@ class ThreadMessageIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
 
   func testThreadMessage_Forward() throws {
     let anotherChannel = try XCTUnwrap(
-      try awaitResultValue {
+      awaitResultValue {
         chat.createChannel(
           id: randomString(),
           completion: $0
@@ -243,7 +243,7 @@ class ThreadMessageIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
     expectation.expectedFulfillmentCount = 1
 
     let message = try XCTUnwrap(
-      try awaitResultValue(delay: 3) {
+      awaitResultValue(delay: 3) {
         threadChannel.getHistory(completion: $0)
       }.messages.first
     )
@@ -278,7 +278,7 @@ class ThreadMessageIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
     expectation.expectedFulfillmentCount = 1
 
     let message = try XCTUnwrap(
-      try awaitResultValue(delay: 2) {
+      awaitResultValue(delay: 2) {
         threadChannel.getHistory(completion: $0)
       }.messages.first
     )

--- a/Tests/UserIntegrationTests.swift
+++ b/Tests/UserIntegrationTests.swift
@@ -1,5 +1,5 @@
 //
-//  UserTests.swift
+//  UserIntegrationTests.swift
 //
 //  Copyright (c) PubNub Inc.
 //  All rights reserved.
@@ -9,8 +9,8 @@
 //
 
 import Foundation
-import XCTest
 import PubNubSDK
+import XCTest
 
 @testable import PubNubSwiftChatSDK
 
@@ -46,7 +46,7 @@ final class UserIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
       try awaitResult { chat.deleteUser(
         id: user.id,
         completion: $0
-      )}
+      ) }
     }
   }
 
@@ -125,10 +125,10 @@ final class UserIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
         completion: $0
       )
     }
-    
+
     XCTAssertNil(deletedUser)
   }
-  
+
   func testUser_SoftDelete() throws {
     let createdUser = try awaitResultValue {
       chat.createUser(
@@ -142,7 +142,7 @@ final class UserIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
         completion: $0
       )
     }
-    
+
     XCTAssertEqual(
       createdUser.id,
       deletedUser?.id
@@ -225,8 +225,8 @@ final class UserIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
       )
     }
 
-    XCTAssertEqual((try XCTUnwrap(resultValue.memberships.first)).user.id, chat.currentUser.id)
-    XCTAssertEqual((try XCTUnwrap(resultValue.memberships.first)).channel.id, channel.id)
+    XCTAssertEqual(try (XCTUnwrap(resultValue.memberships.first)).user.id, chat.currentUser.id)
+    XCTAssertEqual(try (XCTUnwrap(resultValue.memberships.first)).channel.id, channel.id)
 
     addTeardownBlock { [unowned self] in
       try awaitResultValue {
@@ -309,7 +309,7 @@ final class UserIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
       }
     }
 
-    try [firstUser, secondUser].forEach { user in
+    for user in [firstUser, secondUser] {
       try awaitResultValue(delay: 3) {
         user.update(
           name: randomString(),


### PR DESCRIPTION
refactor(project): run `swiftformat` to uplift the codebase
fix(custom-payloads): add missing initialization for `reactionsActionName` property
fix(channel): add missing `completion:` parameter when sending a text