### PR TITLE
PubNub Swift Chat SDK 0.11.0 release

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,21 @@
 name: swift-chat-sdk
 scm: github.com/pubnub/swift-chat-sdk
-version: 0.10.3
+version: 0.11.0
 schema: 1
 changelog:
+  - date: 2025-01-28
+    version: 0.11.0
+    changes:
+      - type: feature
+        text: "Add the new `update(updateAction:completion:)`method on User entity. This method can be used to update data on the server without losing intermediate updates that might have happened in the time between when the object was last received and updated."
+      - type: feature
+        text: "Add the ability to mute and unmute users on the Chat instance. There are `chat.mutedUsersManager.mute(userId:completion:)` and `chat.mutedUsersManager.unmuteUser(userId:completion:)` to mute and unmute a user, respectively."
+      - type: feature
+        text: "Add the option to automatically sync the mute list by enabling `ChatConfiguration.syncMutedUsers`."
+      - type: feature
+        text: "Add missing function to parse quoted message text into `[MessageElement]`."
+      - type: bug
+        text: "Fix the problem of overwriting custom data at regular intervals when `storeUserActivityInterval` is enabled."
   - date: 2025-01-23
     version: 0.10.3
     changes:
@@ -100,7 +113,7 @@ sdks:
           - distribution-type: source
             distribution-repository: GitHub release
             package-name: PubNubSwiftChatSDK
-            location: https://github.com/pubnub/swift-chat-sdk/archive/refs/tags/0.10.3-dev.zip
+            location: https://github.com/pubnub/swift-chat-sdk/archive/refs/tags/0.11.0-dev.zip
             supported-platforms:
               supported-operating-systems:
                 iOS:

--- a/PubNubSwiftChatSDK.xcodeproj/project.pbxproj
+++ b/PubNubSwiftChatSDK.xcodeproj/project.pbxproj
@@ -745,7 +745,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 0.10.3;
+				MARKETING_VERSION = 0.11.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS";
@@ -794,7 +794,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 0.10.3;
+				MARKETING_VERSION = 0.11.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS";

--- a/PubNubSwiftChatSDK.xcodeproj/project.pbxproj
+++ b/PubNubSwiftChatSDK.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		3D043A7A2CA6AAA000F91C05 /* ThreadChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D043A792CA6AAA000F91C05 /* ThreadChannel.swift */; };
 		3D043A7C2CAAABBD00F91C05 /* ThreadMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D043A7B2CAAABBD00F91C05 /* ThreadMessage.swift */; };
 		3D043A7E2CAC190200F91C05 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D043A7D2CAC190200F91C05 /* Constants.swift */; };
+		3D0F90CD2D479A6600986686 /* MutedUsersManagerInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D0F90CC2D479A6600986686 /* MutedUsersManagerInterface.swift */; };
 		3D2CA2362C5B9320008D2284 /* PubNubChat+Transform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D2CA2352C5B9320008D2284 /* PubNubChat+Transform.swift */; };
 		3D2CA2382C5B9ACA008D2284 /* File.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D2CA2372C5B9ACA008D2284 /* File.swift */; };
 		3D2CA23A2C5B9CF6008D2284 /* Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D2CA2392C5B9CF6008D2284 /* Dictionary.swift */; };
@@ -111,6 +112,7 @@
 		3D043A792CA6AAA000F91C05 /* ThreadChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadChannel.swift; sourceTree = "<group>"; };
 		3D043A7B2CAAABBD00F91C05 /* ThreadMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadMessage.swift; sourceTree = "<group>"; };
 		3D043A7D2CAC190200F91C05 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		3D0F90CC2D479A6600986686 /* MutedUsersManagerInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutedUsersManagerInterface.swift; sourceTree = "<group>"; };
 		3D1C44A52C918A2200E68446 /* PubNubSwiftChatSDK_Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = PubNubSwiftChatSDK_Info.plist; sourceTree = "<group>"; };
 		3D2CA2352C5B9320008D2284 /* PubNubChat+Transform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PubNubChat+Transform.swift"; sourceTree = "<group>"; };
 		3D2CA2372C5B9ACA008D2284 /* File.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = File.swift; sourceTree = "<group>"; };
@@ -208,6 +210,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		3D0F90CB2D479A5700986686 /* MutedUsers */ = {
+			isa = PBXGroup;
+			children = (
+				3D0F90CC2D479A6600986686 /* MutedUsersManagerInterface.swift */,
+			);
+			path = MutedUsers;
+			sourceTree = "<group>";
+		};
 		3D9A17922CC156F100F3F8AB /* MessageDraft */ = {
 			isa = PBXGroup;
 			children = (
@@ -280,6 +290,7 @@
 				3DB73A252C4FE1F6007FE249 /* Chat.swift */,
 				3DB73A7A2C57EA29007FE249 /* ChatImpl.swift */,
 				3DB73A242C4FE1F6007FE249 /* ChatConfiguration.swift */,
+				3D0F90CB2D479A5700986686 /* MutedUsers */,
 				3D9A17922CC156F100F3F8AB /* MessageDraft */,
 				3DB73A432C511D36007FE249 /* Models */,
 				3DB73A3A2C50F415007FE249 /* Entities */,
@@ -514,6 +525,7 @@
 				3DB73A632C579938007FE249 /* PubNub.ObjectSortField.swift in Sources */,
 				3DB73A732C57CE9E007FE249 /* PubNubChat.RestrictionType.swift in Sources */,
 				3DB73A262C4FE1F6007FE249 /* ChatConfiguration.swift in Sources */,
+				3D0F90CD2D479A6600986686 /* MutedUsersManagerInterface.swift in Sources */,
 				3D2CA2482C621876008D2284 /* MessageActionType.swift in Sources */,
 				3DB73A272C4FE1F6007FE249 /* Chat.swift in Sources */,
 				3DB73A472C51353B007FE249 /* MessageMentionedUser.swift in Sources */,
@@ -886,7 +898,7 @@
 			repositoryURL = "https://github.com/pubnub/kmp-chat/";
 			requirement = {
 				kind = exactVersion;
-				version = "0.10.1-dev";
+				version = "0.11.0-dev";
 			};
 		};
 		3DCF7DFA2CD0FFCC00889326 /* XCRemoteSwiftPackageReference "swift" */ = {
@@ -894,7 +906,7 @@
 			repositoryURL = "https://github.com/pubnub/swift";
 			requirement = {
 				kind = exactVersion;
-				version = 8.2.4;
+				version = 8.3.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You will need the publish and subscribe keys to authenticate your app. Get your 
 1. Create or open your project inside Xcode.
 2. Navigate to **File -> Add Package Dependencies**.
 3. Search for `https://github.com/pubnub/swift-chat-sdk`
-4. From the **Dependency Rule** drop-down list, select **Exact**. In the version input field, type `0.10.2-dev`
+4. From the **Dependency Rule** drop-down list, select **Exact**. In the version input field, type `0.11.0-dev`
 5. Click the **Add Package** button.
 
 For more information see Apple's guide on [Adding Package Dependencies to Your App](https://developer.apple.com/documentation/xcode/adding_package_dependencies_to_your_app)

--- a/Sources/Chat.swift
+++ b/Sources/Chat.swift
@@ -42,6 +42,14 @@ public protocol Chat: AnyObject {
   /// A type of action you added to your Message object whenever a reaction is added to a published message, like "reacted". The default value is "reactions"
   var reactionsActionName: String { get }
 
+  /// An object for manipulating the list of muted users.
+  ///
+  /// The list is local to this instance of Chat (it is not persisted anywhere) unless ``ChatConfiguration/syncMutedUsers`` is enabled, in which case it will be synced
+  /// using App Context for the current user.
+  ///
+  /// Please note that this is not a server-side moderation mechanism, but rather a way to ignore messages from certain users on the client.
+  var mutedUsersManager: MutedUsersManagerInterface { get }
+
   /// Initializes the current instance and performs any necessary setup.
   ///
   /// This method must be called before invoking any other operations

--- a/Sources/ChatConfiguration.swift
+++ b/Sources/ChatConfiguration.swift
@@ -172,6 +172,23 @@ public struct ChatConfiguration {
   /// Property that lets you define your custom message payload to be sent and/or received by Chat SDK on one or all channels, whenever it differs from the default `message.text` Chat SDK payload.
   /// It also lets you configure your own message actions whenever a message is edited or deleted
   public var customPayloads: CustomPayloads?
+  /// Enable automatic syncing of the ``MutedUsersManager`` data with App Context, using the current `userId` as the key.
+  ///
+  ///  Specifically, the data is saved in the `custom` object of the following User in App Context:
+  ///
+  /// ```
+  /// PN_PRIV.{userId}.mute.1
+  /// ```
+  ///
+  /// where `{userId}` is the current PubNubConfiguration's `userId`
+  ///
+  /// If using Access Manager, the access token must be configured with the appropriate rights to subscribe to that
+  /// channel, and get, update, and delete the App Context User with that id.
+  ///
+  /// Due to App Context size limits, the number of muted users is limited to around 200 and will result in sync errors
+  /// when the limit is exceeded. The list will not sync until its size is reduced.
+  ///
+  public var syncMutedUsers: Bool
 
   /// Creates a new ``ChatConfiguration`` object
   ///
@@ -184,6 +201,7 @@ public struct ChatConfiguration {
   ///   - rateLimitFactor: The so-called "exponential backoff" which multiplicatively decreases the rate at which messages are published on channels
   ///   - rateLimitPerChannel: Client-side limit that states the rate at which messages can be published on a given channel type
   ///   - customPayloads: Custom message payload to be sent and/or received by Chat SDK
+  ///   - syncMutedUsers: A boolean value that controls syncing of muted users
   public init(
     logLevel: LogLevel = .off,
     typingTimeout: Int = 5,
@@ -192,7 +210,8 @@ public struct ChatConfiguration {
     pushNotificationsConfig: PushNotificationsConfig = .init(),
     rateLimitFactor: Int = 2,
     rateLimitPerChannel: [ChannelType: Int64] = ChannelType.allCases.reduce(into: [ChannelType: Int64]()) { res, type in res[type] = 0 },
-    customPayloads: CustomPayloads? = nil
+    customPayloads: CustomPayloads? = nil,
+    syncMutedUsers: Bool = false
   ) {
     self.logLevel = logLevel
     self.typingTimeout = typingTimeout
@@ -202,6 +221,7 @@ public struct ChatConfiguration {
     self.rateLimitFactor = rateLimitFactor
     self.rateLimitPerChannel = rateLimitPerChannel
     self.customPayloads = customPayloads
+    self.syncMutedUsers = syncMutedUsers
   }
 
   func transform() -> any PubNubChat.ChatConfiguration {
@@ -219,7 +239,8 @@ public struct ChatConfiguration {
       ),
       rateLimitFactor: Int32(rateLimitFactor),
       rateLimitPerChannel: rateLimitPerChannel.transform(),
-      customPayloads: customPayloads?.transform()
+      customPayloads: customPayloads?.transform(),
+      syncMutedUsers: syncMutedUsers
     )
   }
 }

--- a/Sources/ChatConfiguration.swift
+++ b/Sources/ChatConfiguration.swift
@@ -172,7 +172,7 @@ public struct ChatConfiguration {
   /// Property that lets you define your custom message payload to be sent and/or received by Chat SDK on one or all channels, whenever it differs from the default `message.text` Chat SDK payload.
   /// It also lets you configure your own message actions whenever a message is edited or deleted
   public var customPayloads: CustomPayloads?
-  /// Enable automatic syncing of the ``MutedUsersManager`` data with App Context, using the current `userId` as the key.
+  /// Enable automatic syncing of the ``MutedUsersManagerInterface`` data with App Context, using the current `userId` as the key.
   ///
   ///  Specifically, the data is saved in the `custom` object of the following User in App Context:
   ///

--- a/Sources/ChatImpl.swift
+++ b/Sources/ChatImpl.swift
@@ -20,12 +20,9 @@ import PubNubSDK
 /// This class inherits all the documentation for methods defined in the ``Chat`` protocol.
 /// Refer to the ``Chat`` protocol for details on how individual methods work.
 public final class ChatImpl {
-  /// Allows you to access any Swift SDK method. For example, if you want to call a method available in the
-  /// App Context API, you'd use `pubNub.allUUIDMetadata(include:filter:sort:limit:page:custom:completion)`
   public let pubNub: PubNub
-  /// Contains chat app configuration settings, such as ``LogLevel`` or typing timeout
-  /// that you can provide when initializing your chat app with the init method
   public let config: ChatConfiguration
+  public let mutedUsersManager: any MutedUsersManagerInterface
 
   let chat: PubNubChat.ChatImpl
 
@@ -41,6 +38,7 @@ public final class ChatImpl {
     pubNub = PubNub(configuration: pubNubConfiguration)
     config = chatConfiguration
     chat = ChatImpl.createKMPChat(from: pubNub, config: chatConfiguration)
+    mutedUsersManager = MutedUsersManagerImpl(underlying: chat.mutedUsersManager)
 
     pubNub.setConsumer(identifier: "chat-sdk", value: "CA-SWIFT/\(pubNubSwiftChatSDKVersion)")
     // Creates an association between KMP chat and the current instance
@@ -51,6 +49,7 @@ public final class ChatImpl {
     self.pubNub = pubNub
     config = configuration
     chat = ChatImpl.createKMPChat(from: pubNub, config: configuration)
+    mutedUsersManager = MutedUsersManagerImpl(underlying: chat.mutedUsersManager)
 
     pubNub.setConsumer(identifier: "chat-sdk", value: "CA-SWIFT/\(pubNubSwiftChatSDKVersion)")
     // Creates an association between KMP chat and the current instance

--- a/Sources/Entities/User.swift
+++ b/Sources/Entities/User.swift
@@ -35,6 +35,8 @@ public protocol User {
   var type: String? { get }
   /// The last updated timestamp for the object
   var updated: String? { get }
+  /// The entity tag (`ETag`) that was returned by the server with this User object. It is a random string that changes with each data update.
+  var eTag: String? { get }
   /// Timestamp for the last time the user information was updated or modified
   var lastActiveTimestamp: TimeInterval? { get }
   /// Indicates whether the user is currently (at the time of obtaining this ``User`` object) active
@@ -73,6 +75,24 @@ public protocol User {
     status: String?,
     type: String?,
     completion: ((Swift.Result<ChatType.ChatUserType, Error>) -> Void)?
+  )
+
+  /// Updates the metadata of the user with information provided in `updateAction`
+  ///
+  /// Please note that `updateAction` will be called **at least** once with the current data from the `User` object in
+  /// the argument. Inside `updateAction`, new values for `User` fields should be computed and returned as a closure result.
+  ///
+  /// In case the user's information has changed on the server since the original User object was retrieved, the `updateAction` will be called again
+  /// with new User data that represents the current server state. This might happen multiple times until either new data is saved successfully, or the request fails.
+  ///
+  /// - Parameters:
+  ///   - updateAction: A function for computing new values for the `User` fields based on the provided `User` argument and returning changes to apply
+  ///   - completion: The async `Result` of the method call
+  ///     - **Success**: The updated user object with its metadata
+  ///     - **Failure**: An `Error` describing the failure
+  func update(
+    updateAction: @escaping (ChatType.ChatUserType) -> [PubNubMetadataChange<PubNubUserMetadata>],
+    completion: ((Swift.Result<UserImpl, Error>) -> Void)?
   )
 
   /// Deletes the user. If soft deletion is enabled, the user's data is retained but marked as inactive.

--- a/Sources/Miscellaneous/Constants.swift
+++ b/Sources/Miscellaneous/Constants.swift
@@ -10,4 +10,4 @@
 
 import Foundation
 
-let pubNubSwiftChatSDKVersion: String = "0.10.3"
+let pubNubSwiftChatSDKVersion: String = "0.11.0"

--- a/Sources/Models/QuotedMessage.swift
+++ b/Sources/Models/QuotedMessage.swift
@@ -41,3 +41,10 @@ public struct QuotedMessage {
     )
   }
 }
+
+public extension QuotedMessage {
+  /// Returns an array of `MessageElement`representing plain text or additional information such as user mentions, channel references and links
+  func getMessageElements() -> [MessageElement] {
+    transform().getMessageElements().compactMap { MessageElement.from(element: $0) }
+  }
+}

--- a/Sources/MutedUsers/MutedUsersManagerInterface.swift
+++ b/Sources/MutedUsers/MutedUsersManagerInterface.swift
@@ -1,0 +1,92 @@
+//
+//  MutedUsersManagerInterface.swift
+//
+//  Copyright (c) PubNub Inc.
+//  All rights reserved.
+//
+//  This source code is licensed under the license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import PubNubChat
+
+/// Defines a protocol for an object capable of muting and unmuting users.
+public protocol MutedUsersManagerInterface {
+  /// The current set of muted users.
+  var mutedUsers: Set<String> { get }
+
+  /// Add a user to the list of muted users
+  ///
+  /// - Parameters:
+  ///   - userId: The ID of the user to mute
+  ///   - completion: The `Result` of an asynchronous call:
+  ///     - **Success**: The operation succeeded, returns nothing
+  ///     - **Failure**: An `Error` describing the failure
+  func muteUser(userId: String, completion: ((Swift.Result<Void, Error>) -> Void)?)
+
+  /// Removes a user from the list of muted users
+  ///
+  /// - Parameters:
+  ///   - userId: The ID of the muted user
+  ///   - completion: The `Result` of an asynchronous call:
+  ///     - **Success**: The operation succeeded, returns nothing
+  ///     - **Failure**: An `Error` describing the failure
+  func unmuteUser(userId: String, completion: ((Swift.Result<Void, Error>) -> Void)?)
+}
+
+/// Provides a default implementation for ``MutedUsersManagerInterface`` methods requiring a completion handler,
+/// allowing the completion handler to be `nil` by default. This simplifies usage for cases where no action is needed after the method completes.
+extension MutedUsersManagerInterface {
+  /// Add a user to the list of muted users
+  ///
+  /// - Parameter userId: The ID of the user to mute
+  func muteUser(userId: String) {
+    muteUser(userId: userId, completion: nil)
+  }
+
+  /// Removes a user from the list of muted users
+  ///
+  /// - Parameter userId: The ID of the muted user
+  func unmuteUser(userId: String) {
+    unmuteUser(userId: userId, completion: nil)
+  }
+}
+
+class MutedUsersManagerImpl: MutedUsersManagerInterface {
+  let underlying: PubNubChat.MutedUsersManager
+
+  init(underlying: PubNubChat.MutedUsersManager) {
+    self.underlying = underlying
+  }
+
+  var mutedUsers: Set<String> {
+    underlying.mutedUsers
+  }
+
+  func muteUser(userId: String, completion: ((Swift.Result<Void, Error>) -> Void)? = nil) {
+    underlying.muteUser(userId: userId).async(
+      caller: self
+    ) { (result: FutureResult<MutedUsersManagerImpl, PubNubChat.KotlinUnit>) in
+      switch result.result {
+      case .success:
+        completion?(.success(()))
+      case let .failure(error):
+        completion?(.failure(error))
+      }
+    }
+  }
+
+  func unmuteUser(userId: String, completion: ((Swift.Result<Void, Error>) -> Void)? = nil) {
+    underlying.unmuteUser(userId: userId).async(
+      caller: self
+    ) { (result: FutureResult<MutedUsersManagerImpl, PubNubChat.KotlinUnit>) in
+      switch result.result {
+      case .success:
+        completion?(.success(()))
+      case let .failure(error):
+        completion?(.failure(error))
+      }
+    }
+  }
+}

--- a/Tests/ChannelIntegrationTests.swift
+++ b/Tests/ChannelIntegrationTests.swift
@@ -135,7 +135,7 @@ class ChannelIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
       try awaitResult { chat.deleteChannel(
         id: anotherChannel.id,
         completion: $0
-      )}
+      ) }
     }
   }
 

--- a/Tests/ChatIntegrationTests.swift
+++ b/Tests/ChatIntegrationTests.swift
@@ -958,4 +958,30 @@ class ChatIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
       }
     }
   }
+
+  func testChat_MutedUsers() throws {
+    let userToMute = randomString()
+
+    try awaitResultValue {
+      chat.mutedUsersManager.muteUser(
+        userId: userToMute,
+        completion: $0
+      )
+    }
+
+    XCTAssertEqual(
+      chat.mutedUsersManager.mutedUsers, [userToMute]
+    )
+
+    try awaitResultValue {
+      chat.mutedUsersManager.unmuteUser(
+        userId: userToMute,
+        completion: $0
+      )
+    }
+
+    XCTAssertTrue(
+      chat.mutedUsersManager.mutedUsers.isEmpty
+    )
+  }
 }


### PR DESCRIPTION
feat(user): add the new `update(updateAction:completion:)`method on User entity. This method can be used to update data on the server without losing intermediate updates that might have happened in the time between when the object was last received and updated.

feat(chat): add the ability to mute and unmute users on the Chat instance. There are `chat.mutedUsersManager.mute(userId:completion:)` and `chat.mutedUsersManager.unmuteUser(userId:completion:)` to mute and unmute a user, respectively.

feat(chat): add the option to automatically sync the mute list by enabling `ChatConfiguration.syncMutedUsers`

feat(quoted-message): add missing function to parse quoted message text into `[MessageElement]`

fix(chat): fix the problem of overwriting custom data at regular intervals when `storeUserActivityInterval` is enabled

