### PR TITLE
PubNub Swift Chat SDK 0.11.1 release

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -3,6 +3,21 @@ scm: github.com/pubnub/swift-chat-sdk
 version: 0.11.0
 schema: 1
 changelog:
+  - date: 2025-03-10
+    version: 0.11.1
+    changes:
+      - type: feature
+        text: "Enhance entities descriptions with `CustomStringConvertible`."
+      - type: feature
+        text: "Add an optional `customPushData:` parameter to methods responsible for sending text."
+      - type: bug
+        text: "Fix the issue with incorrect handling of the APNS device token."
+      - type: bug
+        text: "The `description` property in `Channel` interface has been replaced with `channelDescription` to avoid conflicts with `CustomStringConvertible`."
+      - type: bug
+        text: "Retain the caller object by `AutoCloseable` for each entity's non-static methods."
+      - type: bug
+        text: "Add a more descriptive error message when a chat object is deallocated during initialization."
   - date: 2025-01-28
     version: 0.11.0
     changes:
@@ -113,7 +128,7 @@ sdks:
           - distribution-type: source
             distribution-repository: GitHub release
             package-name: PubNubSwiftChatSDK
-            location: https://github.com/pubnub/swift-chat-sdk/archive/refs/tags/0.11.0-dev.zip
+            location: https://github.com/pubnub/swift-chat-sdk/archive/refs/tags/0.11.1.zip
             supported-platforms:
               supported-operating-systems:
                 iOS:

--- a/Package.swift
+++ b/Package.swift
@@ -18,8 +18,8 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(url: "https://github.com/pubnub/kmp-chat", exact: "0.11.0-dev"),
-    .package(url: "https://github.com/pubnub/swift", exact: "8.3.0")
+    .package(url: "https://github.com/pubnub/kmp-chat", exact: "0.11.2-dev"),
+    .package(url: "https://github.com/pubnub/swift", exact: "9.0.0")
   ],
   targets: [
     // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/PubNubSwiftChatSDK.xcodeproj/project.pbxproj
+++ b/PubNubSwiftChatSDK.xcodeproj/project.pbxproj
@@ -749,7 +749,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 0.11.0;
+				MARKETING_VERSION = 0.11.1;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS";
@@ -798,7 +798,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 0.11.0;
+				MARKETING_VERSION = 0.11.1;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS";

--- a/PubNubSwiftChatSDK.xcodeproj/project.pbxproj
+++ b/PubNubSwiftChatSDK.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		3D043A7C2CAAABBD00F91C05 /* ThreadMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D043A7B2CAAABBD00F91C05 /* ThreadMessage.swift */; };
 		3D043A7E2CAC190200F91C05 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D043A7D2CAC190200F91C05 /* Constants.swift */; };
 		3D0F90CD2D479A6600986686 /* MutedUsersManagerInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D0F90CC2D479A6600986686 /* MutedUsersManagerInterface.swift */; };
+		3D1CE5232D79DED800617200 /* String+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1CE5222D79DED800617200 /* String+Helpers.swift */; };
+		3D2813212D7B4EF4004623A0 /* PubNubChat in Frameworks */ = {isa = PBXBuildFile; productRef = 3D2813202D7B4EF4004623A0 /* PubNubChat */; };
 		3D2CA2362C5B9320008D2284 /* PubNubChat+Transform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D2CA2352C5B9320008D2284 /* PubNubChat+Transform.swift */; };
 		3D2CA2382C5B9ACA008D2284 /* File.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D2CA2372C5B9ACA008D2284 /* File.swift */; };
 		3D2CA23A2C5B9CF6008D2284 /* Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D2CA2392C5B9CF6008D2284 /* Dictionary.swift */; };
@@ -21,7 +23,6 @@
 		3D2CA2482C621876008D2284 /* MessageActionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D2CA2472C621876008D2284 /* MessageActionType.swift */; };
 		3D334BD02C8EE9E500F8793C /* PubNub.PushService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D334BCF2C8EE9E500F8793C /* PubNub.PushService.swift */; };
 		3D334BD22C8EEAA800F8793C /* PubNub.PushEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D334BD12C8EEAA800F8793C /* PubNub.PushEnvironment.swift */; };
-		3D5B58412D10B9A100CB74D1 /* PubNubChat in Frameworks */ = {isa = PBXBuildFile; productRef = 3D5B58402D10B9A100CB74D1 /* PubNubChat */; };
 		3D79EB862D0C40ED00F7AB56 /* PubNubChat.PubNubError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D79EB852D0C40ED00F7AB56 /* PubNubChat.PubNubError.swift */; };
 		3D7BBF6F2C8893D400FBA623 /* ChatAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D7BBF6E2C8893D400FBA623 /* ChatAdapter.swift */; };
 		3D83621A2CC7B35200A21B9A /* MessageDraftChangeListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D8362192CC7B35200A21B9A /* MessageDraftChangeListener.swift */; };
@@ -114,6 +115,7 @@
 		3D043A7D2CAC190200F91C05 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		3D0F90CC2D479A6600986686 /* MutedUsersManagerInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutedUsersManagerInterface.swift; sourceTree = "<group>"; };
 		3D1C44A52C918A2200E68446 /* PubNubSwiftChatSDK_Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = PubNubSwiftChatSDK_Info.plist; sourceTree = "<group>"; };
+		3D1CE5222D79DED800617200 /* String+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Helpers.swift"; sourceTree = "<group>"; };
 		3D2CA2352C5B9320008D2284 /* PubNubChat+Transform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PubNubChat+Transform.swift"; sourceTree = "<group>"; };
 		3D2CA2372C5B9ACA008D2284 /* File.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = File.swift; sourceTree = "<group>"; };
 		3D2CA2392C5B9CF6008D2284 /* Dictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dictionary.swift; sourceTree = "<group>"; };
@@ -194,7 +196,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3D5B58412D10B9A100CB74D1 /* PubNubChat in Frameworks */,
+				3D2813212D7B4EF4004623A0 /* PubNubChat in Frameworks */,
 				3DCF7DFC2CD0FFCC00889326 /* PubNubSDK in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -308,6 +310,7 @@
 				3D7BBF6E2C8893D400FBA623 /* ChatAdapter.swift */,
 				3D842D232C9DC0AA005C0B55 /* ErrorConstants.swift */,
 				3D043A7D2CAC190200F91C05 /* Constants.swift */,
+				3D1CE5222D79DED800617200 /* String+Helpers.swift */,
 			);
 			path = Miscellaneous;
 			sourceTree = "<group>";
@@ -412,7 +415,7 @@
 			name = PubNubSwiftChatSDK;
 			packageProductDependencies = (
 				3DCF7DFB2CD0FFCC00889326 /* PubNubSDK */,
-				3D5B58402D10B9A100CB74D1 /* PubNubChat */,
+				3D2813202D7B4EF4004623A0 /* PubNubChat */,
 			);
 			productName = PubNubChatSDK;
 			productReference = 3DB73A072C4FE13C007FE249 /* PubNubSwiftChatSDK.framework */;
@@ -466,7 +469,7 @@
 			mainGroup = 3DB739FD2C4FE13B007FE249;
 			packageReferences = (
 				3DCF7DFA2CD0FFCC00889326 /* XCRemoteSwiftPackageReference "swift" */,
-				3D5B583F2D10B9A100CB74D1 /* XCRemoteSwiftPackageReference "kmp-chat" */,
+				3D28131F2D7B4EF4004623A0 /* XCRemoteSwiftPackageReference "kmp-chat" */,
 			);
 			productRefGroup = 3DB73A082C4FE13C007FE249 /* Products */;
 			projectDirPath = "";
@@ -542,6 +545,7 @@
 				3DB73A6B2C57B9D8007FE249 /* GetUnreadMessagesCount.swift in Sources */,
 				3DB49E212C761BD1006356ED /* AutoCloseable.swift in Sources */,
 				3DB73A532C53A20C007FE249 /* MessageImpl.swift in Sources */,
+				3D1CE5232D79DED800617200 /* String+Helpers.swift in Sources */,
 				3DB73A672C57A8C5007FE249 /* CreateGroupConversationResult.swift in Sources */,
 				3DB2A8B52C807E2A00167058 /* MembershipImpl.swift in Sources */,
 				3DB2A8B92C80993B00167058 /* ChannelType.swift in Sources */,
@@ -893,12 +897,12 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		3D5B583F2D10B9A100CB74D1 /* XCRemoteSwiftPackageReference "kmp-chat" */ = {
+		3D28131F2D7B4EF4004623A0 /* XCRemoteSwiftPackageReference "kmp-chat" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/pubnub/kmp-chat/";
+			repositoryURL = "https://github.com/pubnub/kmp-chat";
 			requirement = {
 				kind = exactVersion;
-				version = "0.11.0-dev";
+				version = "0.11.2-dev";
 			};
 		};
 		3DCF7DFA2CD0FFCC00889326 /* XCRemoteSwiftPackageReference "swift" */ = {
@@ -906,15 +910,15 @@
 			repositoryURL = "https://github.com/pubnub/swift";
 			requirement = {
 				kind = exactVersion;
-				version = 8.3.0;
+				version = 9.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		3D5B58402D10B9A100CB74D1 /* PubNubChat */ = {
+		3D2813202D7B4EF4004623A0 /* PubNubChat */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 3D5B583F2D10B9A100CB74D1 /* XCRemoteSwiftPackageReference "kmp-chat" */;
+			package = 3D28131F2D7B4EF4004623A0 /* XCRemoteSwiftPackageReference "kmp-chat" */;
 			productName = PubNubChat;
 		};
 		3DCF7DFB2CD0FFCC00889326 /* PubNubSDK */ = {

--- a/Sources/ChatConfiguration.swift
+++ b/Sources/ChatConfiguration.swift
@@ -256,7 +256,12 @@ public struct PushNotificationsConfig {
   /// These push notifications are messages with a provider-specific payload that the Chat SDK automatically attaches  to every message.
   /// Chat SDK includes a default payload setup for ``deviceGateway`` in every message sent to the registered channels.
   public var sendPushes: Bool
-  /// Refers to the unique identifier assigned to a specific mobile device by a platform's push notification service
+  /// Refers to the unique identifier assigned to a specific mobile device by a platform's push notification service.
+  ///
+  /// - If using **Firebase Cloud Messaging (FCM)**, assign the **raw FCM token**, which is already of `String` type.
+  /// - If using **Apple Push Notification Service (APNS)**, assign the **hex-encoded device token**.
+  ///
+  /// - Note: You can easily convert the `Data` token to hexadecimal String using the `hexEncodedString()` extension method provided in the `PubNubSDK` module.
   public var deviceToken: String?
   /// Option for receiving push notifications on Android (FCM) or iOS (APNS or APNS2) devices
   public var deviceGateway: PubNub.PushService

--- a/Sources/ChatImpl.swift
+++ b/Sources/ChatImpl.swift
@@ -140,7 +140,7 @@ extension ChatImpl: Chat {
         if let caller = result.caller {
           completion?(.success(caller))
         } else {
-          completion?(.failure(ChatError(message: objectNoLongerExists)))
+          completion?(.failure(ChatError(message: chatNoLongerExists)))
         }
       case let .failure(error):
         completion?(.failure(error))
@@ -552,7 +552,8 @@ extension ChatImpl: Chat {
             )
           }
         }
-      )
+      ),
+      owner: self
     )
   }
 

--- a/Sources/Entities/BaseChannel.swift
+++ b/Sources/Entities/BaseChannel.swift
@@ -18,7 +18,7 @@ final class BaseChannel<C: PubNubChat.Channel_, M: PubNubChat.Message>: Channel 
   var id: String { channel.id }
   var name: String? { channel.name }
   var custom: [String: JSONCodableScalar]? { channel.custom?.mapToScalars() }
-  var description: String? { channel.description_ }
+  var channelDescription: String? { channel.description_ }
   var updated: String? { channel.updated }
   var status: String? { channel.status }
   var type: ChannelType? { channel.type?.transform() }
@@ -123,7 +123,8 @@ final class BaseChannel<C: PubNubChat.Channel_, M: PubNubChat.Message>: Channel 
         if let typingUserIdentifiers = $0 as? [String], self != nil {
           callback(typingUserIdentifiers)
         }
-      }
+      },
+      owner: self
     )
   }
 
@@ -298,11 +299,14 @@ final class BaseChannel<C: PubNubChat.Channel_, M: PubNubChat.Message>: Channel 
   }
 
   func connect(callback: @escaping (ChatType.ChatMessageType) -> Void) -> AutoCloseable {
-    AutoCloseableImpl(channel.connect { [weak self] in
-      if self != nil, let message = $0 as? M {
-        callback(MessageImpl(message: message))
-      }
-    })
+    AutoCloseableImpl(
+      channel.connect { [weak self] in
+        if self != nil, let message = $0 as? M {
+          callback(MessageImpl(message: message))
+        }
+      },
+      owner: self
+    )
   }
 
   func join(
@@ -319,7 +323,7 @@ final class BaseChannel<C: PubNubChat.Channel_, M: PubNubChat.Message>: Channel 
       case let .success(joinRes):
         completion?(.success((
           membership: MembershipImpl(membership: joinRes.membership),
-          disconnect: AutoCloseableImpl(joinRes.disconnect)
+          disconnect: AutoCloseableImpl(joinRes.disconnect, owner: result.caller)
         )))
       case let .failure(error):
         completion?(.failure(error))
@@ -433,7 +437,8 @@ final class BaseChannel<C: PubNubChat.Channel_, M: PubNubChat.Message>: Channel 
             callback(nil)
           }
         }
-      }
+      },
+      owner: self
     )
   }
 
@@ -447,7 +452,8 @@ final class BaseChannel<C: PubNubChat.Channel_, M: PubNubChat.Message>: Channel 
             }
           )
         }
-      }
+      },
+      owner: self
     )
   }
 
@@ -504,7 +510,8 @@ final class BaseChannel<C: PubNubChat.Channel_, M: PubNubChat.Message>: Channel 
         if let userIds = $0 as? Set<String>, self != nil {
           callback(userIds)
         }
-      }
+      },
+      owner: self
     )
   }
 
@@ -575,7 +582,8 @@ final class BaseChannel<C: PubNubChat.Channel_, M: PubNubChat.Message>: Channel 
             )
           )
         }
-      }
+      },
+      owner: self
     )
   }
 

--- a/Sources/Entities/BaseChannel.swift
+++ b/Sources/Entities/BaseChannel.swift
@@ -186,6 +186,7 @@ final class BaseChannel<C: PubNubChat.Channel_, M: PubNubChat.Message>: Channel 
     textLinks: [TextLink]?,
     quotedMessage: ChatType.ChatMessageType?,
     files: [InputFile]?,
+    customPushData: [String: String]? = nil,
     completion: ((Swift.Result<Timetoken, Error>) -> Void)?
   ) {
     channel.sendText(
@@ -198,7 +199,8 @@ final class BaseChannel<C: PubNubChat.Channel_, M: PubNubChat.Message>: Channel 
       referencedChannels: referencedChannels?.transform(),
       textLinks: textLinks?.compactMap { $0.transform() },
       quotedMessage: quotedMessage?.target.message,
-      files: files?.compactMap { $0.transform() }
+      files: files?.compactMap { $0.transform() },
+      customPushData: customPushData
     ).async(caller: self) { (result: FutureResult<BaseChannel, PubNubChat.PNPublishResult>) in
       switch result.result {
       case let .success(response):
@@ -218,6 +220,7 @@ final class BaseChannel<C: PubNubChat.Channel_, M: PubNubChat.Message>: Channel 
     quotedMessage: MessageImpl?,
     files: [InputFile]?,
     usersToMention: [String]? = nil,
+    customPushData: [String: String]? = nil,
     completion: ((Swift.Result<Timetoken, any Error>) -> Void)?
   ) {
     channel.sendText(
@@ -228,7 +231,8 @@ final class BaseChannel<C: PubNubChat.Channel_, M: PubNubChat.Message>: Channel 
       ttl: ttl?.asKotlinInt,
       quotedMessage: quotedMessage?.target.message,
       files: files?.compactMap { $0.transform() },
-      usersToMention: usersToMention
+      usersToMention: usersToMention,
+      customPushData: customPushData
     ).async(caller: self) { (result: FutureResult<BaseChannel, PubNubChat.PNPublishResult>) in
       switch result.result {
       case let .success(response):

--- a/Sources/Entities/BaseMessage.swift
+++ b/Sources/Entities/BaseMessage.swift
@@ -203,7 +203,8 @@ extension BaseMessage: Message {
         if let message = $0 as? M, self != nil {
           completion(BaseMessage(message: message))
         }
-      }
+      },
+      owner: self
     )
   }
 

--- a/Sources/Entities/Channel.swift
+++ b/Sources/Entities/Channel.swift
@@ -192,6 +192,7 @@ public protocol Channel: CustomStringConvertible {
     textLinks: [TextLink]?,
     quotedMessage: ChatType.ChatMessageType?,
     files: [InputFile]?,
+    customPushData: [String: String]?,
     completion: ((Swift.Result<Timetoken, Error>) -> Void)?
   )
 
@@ -223,6 +224,7 @@ public protocol Channel: CustomStringConvertible {
     quotedMessage: ChatType.ChatMessageType?,
     files: [InputFile]?,
     usersToMention: [String]?,
+    customPushData: [String: String]?,
     completion: ((Swift.Result<Timetoken, Error>) -> Void)?
   )
 

--- a/Sources/Entities/Channel.swift
+++ b/Sources/Entities/Channel.swift
@@ -12,7 +12,7 @@ import Foundation
 import PubNubSDK
 
 /// Channel is an object that refers to a single chat room.
-public protocol Channel {
+public protocol Channel: CustomStringConvertible {
   associatedtype ChatType: Chat
   associatedtype MessageType: Message
   associatedtype MessageDraftType: MessageDraft
@@ -26,7 +26,7 @@ public protocol Channel {
   /// Any custom properties or metadata associated with the channel in the form of a map of key-value pairs
   var custom: [String: JSONCodableScalar]? { get }
   /// Brief description or summary of the channel's purpose or content
-  var description: String? { get }
+  var channelDescription: String? { get }
   /// The last updated timestamp for the object
   var updated: String? { get }
   /// Current status of the channel, like online, offline, or archived
@@ -471,6 +471,24 @@ public protocol Channel {
     userLimit: Int,
     channelLimit: Int
   ) -> MessageDraftType
+}
 
+/// Extension to conform to `CustomStringConvertible` for custom string representation.
+/// Provides a readable description of the object for debugging and logging purposes
+public extension Channel {
+  var description: String {
+    String.formattedDescription(
+      self,
+      arguments: [
+        ("id", id),
+        ("name", name ?? "nil"),
+        ("custom", custom ?? "nil"),
+        ("channelDescription", channelDescription ?? "nil"),
+        ("updated", updated ?? "nil"),
+        ("status", status ?? "nil"),
+        ("type", type ?? "nil")
+      ]
+    )
+  }
   // swiftlint:disable:next file_length
 }

--- a/Sources/Entities/ChannelImpl.swift
+++ b/Sources/Entities/ChannelImpl.swift
@@ -184,6 +184,7 @@ extension ChannelImpl: Channel {
     textLinks: [TextLink]? = nil,
     quotedMessage: MessageImpl? = nil,
     files: [InputFile]? = nil,
+    customPushData: [String: String]? = nil,
     completion: ((Swift.Result<Timetoken, Error>) -> Void)? = nil
   ) {
     target.sendText(
@@ -210,6 +211,7 @@ extension ChannelImpl: Channel {
     quotedMessage: MessageImpl? = nil,
     files: [InputFile]? = nil,
     usersToMention: [String]? = nil,
+    customPushData: [String: String]? = nil,
     completion: ((Swift.Result<Timetoken, Error>) -> Void)? = nil
   ) {
     target.sendText(

--- a/Sources/Entities/ChannelImpl.swift
+++ b/Sources/Entities/ChannelImpl.swift
@@ -67,7 +67,7 @@ extension ChannelImpl: Channel {
   public var id: String { target.id }
   public var name: String? { target.name }
   public var custom: [String: JSONCodableScalar]? { target.custom }
-  public var description: String? { target.description }
+  public var channelDescription: String? { target.channelDescription }
   public var updated: String? { target.updated }
   public var status: String? { target.status }
   public var type: ChannelType? { target.type }

--- a/Sources/Entities/Membership.swift
+++ b/Sources/Entities/Membership.swift
@@ -12,7 +12,7 @@ import Foundation
 import PubNubSDK
 
 /// Membership is an object that refers to a single user-channel relationship in a chat.
-public protocol Membership {
+public protocol Membership: CustomStringConvertible {
   associatedtype ChatType: Chat
 
   /// Reference to the main Chat object
@@ -98,4 +98,24 @@ public protocol Membership {
   func streamUpdates(
     callback: @escaping ((ChatType.ChatMembershipType?) -> Void)
   ) -> AutoCloseable
+}
+
+/// Extension to conform to `CustomStringConvertible` for custom string representation.
+/// Provides a readable description of the object for debugging and logging purposes
+public extension Membership {
+  var description: String {
+    String.formattedDescription(
+      self,
+      arguments: [
+        ("channel", channel),
+        ("user", user),
+        ("custom", custom ?? "nil"),
+        ("status", status ?? "nil"),
+        ("type", type ?? "nil"),
+        ("eTag", eTag ?? "nil"),
+        ("updated", updated ?? "nil"),
+        ("lastReadMessageTimetoken", lastReadMessageTimetoken ?? "nil")
+      ]
+    )
+  }
 }

--- a/Sources/Entities/MembershipImpl.swift
+++ b/Sources/Entities/MembershipImpl.swift
@@ -145,7 +145,8 @@ extension MembershipImpl: Membership {
             callback(nil)
           }
         }
-      }
+      },
+      owner: self
     )
   }
 }

--- a/Sources/Entities/Message.swift
+++ b/Sources/Entities/Message.swift
@@ -12,7 +12,7 @@ import Foundation
 import PubNubSDK
 
 /// Represents an object that refers to a single message in a chat.
-public protocol Message {
+public protocol Message: CustomStringConvertible {
   associatedtype ChatType: Chat
 
   /// Reference to the main Chat object
@@ -29,8 +29,8 @@ public protocol Message {
   var actions: [String: [String: [Action]]]? { get }
   /// Extra information added to the message giving additional context
   var meta: [String: JSONCodable]? { get }
-  /// List of mentioned users with IDs and names
 
+  /// List of mentioned users with IDs and names
   @available(*, deprecated, message: "Use `Message.getMessageElements()` instead")
   var mentionedUsers: MessageMentionedUsers? { get }
   /// List of referenced channels with IDs and names
@@ -210,4 +210,22 @@ public protocol Message {
   /// Use this on the receiving end if a message was sent using ``MessageDraft`` to parse the `Message` text into parts
   /// representing plain text or additional information such as user mentions, channel references and links.
   func getMessageElements() -> [MessageElement]
+}
+
+/// Extension to conform to `CustomStringConvertible` for custom string representation.
+/// Provides a readable description of the object for debugging and logging purposes
+public extension Message {
+  var description: String {
+    String.formattedDescription(
+      self,
+      arguments: [
+        ("timetoken", timetoken),
+        ("content", content),
+        ("channelId", channelId),
+        ("userId", userId),
+        ("actions", actions ?? "nil"),
+        ("meta", meta ?? "nil")
+      ]
+    )
+  }
 }

--- a/Sources/Entities/ThreadChannel.swift
+++ b/Sources/Entities/ThreadChannel.swift
@@ -44,3 +44,24 @@ public protocol ThreadChannel: Channel {
     completion: ((Swift.Result<ChatType.ChatChannelType, Error>) -> Void)?
   )
 }
+
+/// Extension to conform to `CustomStringConvertible` for custom string representation.
+/// Provides a readable description of the object for debugging and logging purposes
+public extension ThreadChannel {
+  var description: String {
+    String.formattedDescription(
+      self,
+      arguments: [
+        ("id", id),
+        ("name", name ?? "nil"),
+        ("custom", custom ?? "nil"),
+        ("channelDescription", channelDescription ?? "nil"),
+        ("updated", updated ?? "nil"),
+        ("status", status ?? "nil"),
+        ("type", type ?? "nil"),
+        ("parentChannelId", parentChannelId),
+        ("parentMessage", parentMessage)
+      ]
+    )
+  }
+}

--- a/Sources/Entities/ThreadChannelImpl.swift
+++ b/Sources/Entities/ThreadChannelImpl.swift
@@ -70,7 +70,7 @@ extension ThreadChannelImpl: ThreadChannel {
   public var id: String { target.id }
   public var name: String? { target.name }
   public var custom: [String: JSONCodableScalar]? { target.custom }
-  public var description: String? { target.description }
+  public var channelDescription: String? { target.channelDescription }
   public var updated: String? { target.updated }
   public var status: String? { target.status }
   public var type: ChannelType? { target.type }

--- a/Sources/Entities/ThreadChannelImpl.swift
+++ b/Sources/Entities/ThreadChannelImpl.swift
@@ -216,6 +216,7 @@ extension ThreadChannelImpl: ThreadChannel {
     textLinks: [TextLink]? = nil,
     quotedMessage: MessageImpl? = nil,
     files: [InputFile]? = nil,
+    customPushData: [String: String]? = nil,
     completion: ((Swift.Result<Timetoken, Error>) -> Void)? = nil
   ) {
     target.sendText(
@@ -242,6 +243,7 @@ extension ThreadChannelImpl: ThreadChannel {
     quotedMessage: MessageImpl? = nil,
     files: [InputFile]?,
     usersToMention: [String]? = nil,
+    customPushData: [String: String]? = nil,
     completion: ((Swift.Result<Timetoken, Error>) -> Void)? = nil
   ) {
     target.sendText(

--- a/Sources/Entities/ThreadMessage.swift
+++ b/Sources/Entities/ThreadMessage.swift
@@ -47,3 +47,22 @@ public protocol ThreadMessage: Message {
     completion: ((Swift.Result<ChatType.ChatChannelType, Error>) -> Void)?
   )
 }
+
+/// Extension to conform to `CustomStringConvertible` for custom string representation.
+/// Provides a readable description of the object for debugging and logging purposes
+public extension ThreadMessage {
+  var description: String {
+    String.formattedDescription(
+      self,
+      arguments: [
+        ("timetoken", timetoken),
+        ("content", content),
+        ("channelId", channelId),
+        ("userId", userId),
+        ("actions", actions ?? "nil"),
+        ("meta", meta ?? "nil"),
+        ("parentChannelId", parentChannelId)
+      ]
+    )
+  }
+}

--- a/Sources/Entities/User.swift
+++ b/Sources/Entities/User.swift
@@ -12,7 +12,7 @@ import Foundation
 import PubNubSDK
 
 /// Represents an object that refers to a single user in a chat, including details about the user's identity, metadata, and actions they can perform.
-public protocol User {
+public protocol User: CustomStringConvertible {
   associatedtype ChatType: Chat
 
   /// Reference to the main chat object
@@ -165,4 +165,27 @@ public protocol User {
   func active(
     completion: ((Swift.Result<Bool, Error>) -> Void)?
   )
+}
+
+/// Extension to conform to `CustomStringConvertible` for custom string representation.
+/// Provides a readable description of the object for debugging and logging purposes
+public extension User {
+  var description: String {
+    String.formattedDescription(
+      self, arguments: [
+        ("id", id),
+        ("name", name ?? "nil"),
+        ("externalId", externalId ?? "nil"),
+        ("profileUrl", profileUrl ?? "nil"),
+        ("email", email ?? "nil"),
+        ("custom", custom ?? "nil"),
+        ("status", status ?? "nil"),
+        ("type", type ?? "nil"),
+        ("updated", updated ?? "nil"),
+        ("eTag", eTag ?? "nil"),
+        ("lastActiveTimestamp", lastActiveTimestamp ?? "nil"),
+        ("active", lastActiveTimestamp ?? "active")
+      ]
+    )
+  }
 }

--- a/Sources/Entities/UserImpl.swift
+++ b/Sources/Entities/UserImpl.swift
@@ -249,7 +249,8 @@ extension UserImpl: User {
             callback(nil)
           }
         }
-      }
+      },
+      owner: self
     )
   }
 

--- a/Sources/Miscellaneous/AutoCloseable.swift
+++ b/Sources/Miscellaneous/AutoCloseable.swift
@@ -25,6 +25,7 @@ class AutoCloseableImpl {
   init?(_ underlying: PubNubChat.KotlinAutoCloseable?, owner: AnyObject? = nil) {
     if let underlying {
       self.underlying = underlying
+      self.owner = owner
     } else {
       return nil
     }
@@ -32,6 +33,7 @@ class AutoCloseableImpl {
 
   init(_ underlying: PubNubChat.KotlinAutoCloseable, owner: AnyObject? = nil) {
     self.underlying = underlying
+    self.owner = owner
   }
 
   private var owner: AnyObject? {

--- a/Sources/Miscellaneous/Constants.swift
+++ b/Sources/Miscellaneous/Constants.swift
@@ -10,4 +10,4 @@
 
 import Foundation
 
-let pubNubSwiftChatSDKVersion: String = "0.11.0"
+let pubNubSwiftChatSDKVersion: String = "0.11.1"

--- a/Sources/Miscellaneous/ErrorConstants.swift
+++ b/Sources/Miscellaneous/ErrorConstants.swift
@@ -10,4 +10,5 @@
 
 import Foundation
 
-let objectNoLongerExists = "Object no longer exists"
+// swiftlint:disable:next line_length
+let chatNoLongerExists = "Chat instance was deallocated during its initialization. Ensure you retain a strong reference to the chat object to prevent it from being deallocated unexpectedly"

--- a/Sources/Miscellaneous/String+Helpers.swift
+++ b/Sources/Miscellaneous/String+Helpers.swift
@@ -1,0 +1,23 @@
+//
+//  String+Helpers.swift
+//
+//  Copyright (c) PubNub Inc.
+//  All rights reserved.
+//
+//  This source code is licensed under the license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+
+/// Creates a formatted description of an instance and its key-value attributes
+/// and returns a formatted string in the form of `TypeName(key: value, key: value)`
+extension String {
+  static func formattedDescription(_ instance: Any, arguments: @autoclosure () -> [(String, Any)] = []) -> String {
+    formattedDescription(String(describing: type(of: instance)), arguments: arguments())
+  }
+
+  static func formattedDescription(_ prefix: String, arguments: @autoclosure () -> [(String, Any)] = []) -> String {
+    "\(prefix)(\(arguments().map { "\($0.0): \(String(describing: $0.1))" }.joined(separator: ", ")))"
+  }
+}

--- a/Sources/Models/EventContent.swift
+++ b/Sources/Models/EventContent.swift
@@ -15,7 +15,7 @@ import PubNubSDK
 /// Represents the content of various types of events emitted during chat operations.
 public class EventContent {
   /// Represents a report event, which is used to report a message or user to the admin.
-  public class Report: EventContent {
+  public class Report: EventContent, CustomStringConvertible {
     /// The text of the report, if provided
     public let text: String?
     /// The reason for reporting the message or user
@@ -48,10 +48,25 @@ public class EventContent {
       self.reportedMessageChannelId = reportedMessageChannelId
       self.reportedUserId = reportedUserId
     }
+
+    /// Extension to conform to `CustomStringConvertible` for custom string representation.
+    /// Provides a readable description of the object for debugging and logging purposes
+    public var description: String {
+      String.formattedDescription(
+        self,
+        arguments: [
+          ("text", text ?? "nil"),
+          ("reason", reason),
+          ("reportedMessageTimetoken", reportedMessageTimetoken ?? "nil"),
+          ("reportedMessageChannelId", reportedMessageChannelId ?? "nil"),
+          ("reportedUserId", reportedUserId ?? "nil")
+        ]
+      )
+    }
   }
 
   /// Represents a typing event that indicates whether a user is typing.
-  public class Typing: EventContent {
+  public class Typing: EventContent, CustomStringConvertible {
     /// A boolean value indicating whether the user is typing (true) or not (false)
     public let value: Bool
 
@@ -61,10 +76,16 @@ public class EventContent {
     public init(value: Bool) {
       self.value = value
     }
+
+    /// Extension to conform to `CustomStringConvertible` for custom string representation.
+    /// Provides a readable description of the object for debugging and logging purposes
+    public var description: String {
+      String.formattedDescription(self, arguments: [("value", value)])
+    }
   }
 
   /// Represents a receipt event, indicating that a message was read.
-  public class Receipt: EventContent {
+  public class Receipt: EventContent, CustomStringConvertible {
     /// The timetoken of the message for which the receipt is being acknowledged
     public let messageTimetoken: Timetoken
 
@@ -74,10 +95,16 @@ public class EventContent {
     public init(messageTimetoken: Timetoken) {
       self.messageTimetoken = messageTimetoken
     }
+
+    /// Extension to conform to `CustomStringConvertible` for custom string representation.
+    /// Provides a readable description of the object for debugging and logging purposes
+    public var description: String {
+      String.formattedDescription(self, arguments: [("messageTimetoken", messageTimetoken)])
+    }
   }
 
   /// Represents a mention event, which indicates that a user was mentioned in a message.
-  public class Mention: EventContent {
+  public class Mention: EventContent, CustomStringConvertible {
     /// The timetoken of the message in which the user was mentioned
     public let messageTimetoken: Timetoken
     /// The ID of the channel where the mention occurred
@@ -96,10 +123,23 @@ public class EventContent {
       self.channel = channel
       self.parentChannel = parentChannel
     }
+
+    /// Extension to conform to `CustomStringConvertible` for custom string representation.
+    /// Provides a readable description of the object for debugging and logging purposes
+    public var description: String {
+      String.formattedDescription(
+        self,
+        arguments: [
+          ("messageTimetoken", messageTimetoken),
+          ("channel", channel),
+          ("parentChannel", parentChannel ?? "nil")
+        ]
+      )
+    }
   }
 
   /// Represents an invite event, which is used when a user is invited to join a channel.
-  public class Invite: EventContent {
+  public class Invite: EventContent, CustomStringConvertible {
     /// The type of the channel
     public let channelType: ChannelType
     /// The ID of the channel to which the user is invited
@@ -114,10 +154,22 @@ public class EventContent {
       self.channelType = channelType
       self.channelId = channelId
     }
+
+    /// Extension to conform to `CustomStringConvertible` for custom string representation.
+    /// Provides a readable description of the object for debugging and logging purposes
+    public var description: String {
+      String.formattedDescription(
+        self,
+        arguments: [
+          ("channelType", channelType),
+          ("channelId", channelId)
+        ]
+      )
+    }
   }
 
   /// Represents a custom event with arbitrary data.
-  public class Custom: EventContent {
+  public class Custom: EventContent, CustomStringConvertible {
     /// A map containing key-value pairs of custom data associated with the event
     public let data: [String: Any]
     /// The method by which the event was emitted
@@ -132,10 +184,22 @@ public class EventContent {
       self.data = data
       self.method = method
     }
+
+    /// Extension to conform to `CustomStringConvertible` for custom string representation.
+    /// Provides a readable description of the object for debugging and logging purposes
+    public var description: String {
+      String.formattedDescription(
+        self,
+        arguments: [
+          ("data", data),
+          ("method", method)
+        ]
+      )
+    }
   }
 
   /// Represents a moderation event, which is triggered when a restriction is applied to a user.
-  public class Moderation: EventContent {
+  public class Moderation: EventContent, CustomStringConvertible {
     /// The ID of the channel where the moderation event occurred
     public let channelId: String
     /// The type of restriction applied (e.g., ban, mute)
@@ -154,10 +218,23 @@ public class EventContent {
       self.restriction = restriction
       self.reason = reason
     }
+
+    /// Extension to conform to `CustomStringConvertible` for custom string representation.
+    /// Provides a readable description of the object for debugging and logging purposes
+    public var description: String {
+      String.formattedDescription(
+        self,
+        arguments: [
+          ("channelId", channelId),
+          ("restriction", restriction),
+          ("reason", reason ?? "nil")
+        ]
+      )
+    }
   }
 
   /// Represents a text message event, containing the message text and any associated files.
-  public class TextMessageContent: EventContent {
+  public class TextMessageContent: EventContent, CustomStringConvertible {
     /// The text content of the message
     public let text: String
     /// A list of ``File`` objects attached to the given ``PubNubSwiftChatSDK/EventContent/TextMessageContent``, if any
@@ -171,6 +248,18 @@ public class EventContent {
     public init(text: String, files: [File]? = nil) {
       self.text = text
       self.files = files
+    }
+
+    /// Extension to conform to `CustomStringConvertible` for custom string representation.
+    /// Provides a readable description of the object for debugging and logging purposes
+    public var description: String {
+      String.formattedDescription(
+        self,
+        arguments: [
+          ("text", text),
+          ("files", files ?? "nil")
+        ]
+      )
     }
 
     func transform() -> PubNubChat.EventContent.TextMessageContent {
@@ -189,7 +278,7 @@ public class EventContent {
   }
 
   /// Represents a message with an unknown format, used to handle cases where the message format doesn't match known types.
-  public class UnknownMessageFormat: EventContent {
+  public class UnknownMessageFormat: EventContent, CustomStringConvertible {
     /// The raw JSON element representing the message with the unknown format
     public let element: Any?
 
@@ -197,6 +286,12 @@ public class EventContent {
     /// - Parameter element: The raw JSON element representing the message with the unknown format
     public init(element: Any? = nil) {
       self.element = element
+    }
+
+    /// Extension to conform to `CustomStringConvertible` for custom string representation.
+    /// Provides a readable description of the object for debugging and logging purposes
+    public var description: String {
+      String.formattedDescription(self, arguments: [("element", element ?? "nil")])
     }
   }
 }
@@ -343,4 +438,6 @@ extension EventContent {
       KClassConstants.Companion.shared.unknownMessageFormat
     }
   }
+
+  // swiftlint:disable:next file_length
 }

--- a/Tests/ChatIntegrationTests.swift
+++ b/Tests/ChatIntegrationTests.swift
@@ -215,7 +215,7 @@ class ChatIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
     }
 
     XCTAssertEqual(channel.name, "ChannelName")
-    XCTAssertEqual(channel.description, "ChannelDescription")
+    XCTAssertEqual(channel.channelDescription, "ChannelDescription")
     XCTAssertEqual(channel.type, .unknown)
     XCTAssertEqual(channel.status, "status")
     XCTAssertEqual(channel.custom?.mapValues { $0.scalarValue }, customField.mapValues { $0.scalarValue })
@@ -301,7 +301,7 @@ class ChatIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
     XCTAssertEqual(updatedChannel.id, channel.id)
     XCTAssertEqual(updatedChannel.name, "NewName")
     XCTAssertEqual(updatedChannel.custom?.mapValues { $0.scalarValue }, customField.mapValues { $0.scalarValue })
-    XCTAssertEqual(updatedChannel.description, "NewDescription")
+    XCTAssertEqual(updatedChannel.channelDescription, "NewDescription")
     XCTAssertEqual(updatedChannel.status, "status")
     XCTAssertEqual(updatedChannel.type, .unknown)
 
@@ -438,7 +438,7 @@ class ChatIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
     }
 
     XCTAssertEqual(channel.name, "ChannelName")
-    XCTAssertEqual(channel.description, "ChannelDescription")
+    XCTAssertEqual(channel.channelDescription, "ChannelDescription")
     XCTAssertEqual(channel.custom?.mapValues { $0.scalarValue }, customField.mapValues { $0.scalarValue })
     XCTAssertEqual(channel.status, "status")
     XCTAssertEqual(channel.type, .public)
@@ -484,7 +484,7 @@ class ChatIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
     }
 
     XCTAssertEqual(resultValue.channel.name, "ChannelName")
-    XCTAssertEqual(resultValue.channel.description, "ChannelDescription")
+    XCTAssertEqual(resultValue.channel.channelDescription, "ChannelDescription")
     XCTAssertEqual(resultValue.channel.custom?.mapValues { $0.scalarValue }, customField.mapValues { $0.scalarValue })
     XCTAssertEqual(resultValue.channel.status, "status")
     XCTAssertEqual(resultValue.channel.type, .direct)
@@ -543,7 +543,7 @@ class ChatIntegrationTests: PubNubSwiftChatSDKIntegrationTests {
     }
 
     XCTAssertEqual(resultValue.channel.name, "ChannelName")
-    XCTAssertEqual(resultValue.channel.description, "ChannelDescription")
+    XCTAssertEqual(resultValue.channel.channelDescription, "ChannelDescription")
     XCTAssertEqual(resultValue.channel.custom?.mapValues { $0.scalarValue }, customField.mapValues { $0.scalarValue })
     XCTAssertEqual(resultValue.channel.status, "status")
     XCTAssertEqual(resultValue.channel.type, .group)


### PR DESCRIPTION
fix(configuration): fix the issue with incorrect handling of the APNS device token
feat(entities): enhance entities descriptions with `CustomStringConvertible`
fix(channel): the `description` property in `Channel` interface has been replaced with `channelDescription` to avoid conflicts with `CustomStringConvertible`
fix(entities): retain the caller object by `AutoCloseable` for each entity's non-static methods
fix(chat): add a more descriptive error message when a chat object is deallocated during initialization
feat(channel): add an optional `customPushData:` parameter to methods responsible for sending text