### PR TITLE
PubNub Swift Chat SDK 0.30.0 release

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         environment: [iOS]
-    timeout-minutes: 21
+    timeout-minutes: 22
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,21 @@
 name: swift-chat-sdk
 scm: github.com/pubnub/swift-chat-sdk
-version: 0.20.0
+version: 0.30.0
 schema: 1
 changelog:
+  - date: 2025-05-14
+    version: 0.30.0
+    changes:
+      - type: feature
+        text: "Deprecate `getUnreadMessagesCount(limit:page:filter:sort:)` method in Chat interface."
+      - type: feature
+        text: "Introduce `fetchUnreadMessagesCounts(limit:page:filter:sort:)` method in Chat interface."
+      - type: bug
+        text: "Fix the issue with the invalid download URL for files."
+      - type: improvement
+        text: "Remove code duplication from the `ChatImpl` constructors."
+      - type: improvement
+        text: "Add thread safety to chat mapping logic."
   - date: 2025-03-25
     version: 0.20.0
     changes:
@@ -150,7 +163,7 @@ sdks:
           - distribution-type: source
             distribution-repository: GitHub release
             package-name: PubNubSwiftChatSDK
-            location: https://github.com/pubnub/swift-chat-sdk/archive/refs/tags/0.20.0.zip
+            location: https://github.com/pubnub/swift-chat-sdk/archive/refs/tags/0.30.0.zip
             supported-platforms:
               supported-operating-systems:
                 iOS:

--- a/Package.swift
+++ b/Package.swift
@@ -18,8 +18,8 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(url: "https://github.com/pubnub/kmp-chat", exact: "0.12.1-swift"),
-    .package(url: "https://github.com/pubnub/swift", exact: "9.0.1")
+    .package(url: "https://github.com/pubnub/kmp-chat", exact: "0.13.1-swift"),
+    .package(url: "https://github.com/pubnub/swift", exact: "9.1.0")
   ],
   targets: [
     // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/PubNubSwiftChatSDK.xcodeproj/project.pbxproj
+++ b/PubNubSwiftChatSDK.xcodeproj/project.pbxproj
@@ -951,7 +951,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 0.20.0;
+				MARKETING_VERSION = 0.30.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS";
@@ -1000,7 +1000,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 0.20.0;
+				MARKETING_VERSION = 0.30.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS";

--- a/PubNubSwiftChatSDK.xcodeproj/project.pbxproj
+++ b/PubNubSwiftChatSDK.xcodeproj/project.pbxproj
@@ -1113,7 +1113,7 @@
 			repositoryURL = "https://github.com/pubnub/kmp-chat";
 			requirement = {
 				kind = exactVersion;
-				version = "0.12.1-swift";
+				version = "0.13.1-swift";
 			};
 		};
 		3DCF7DFA2CD0FFCC00889326 /* XCRemoteSwiftPackageReference "swift" */ = {
@@ -1121,7 +1121,7 @@
 			repositoryURL = "https://github.com/pubnub/swift";
 			requirement = {
 				kind = exactVersion;
-				version = 9.0.1;
+				version = 9.1.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/Chat.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/Chat.md
@@ -74,6 +74,8 @@
 - ``GetUnreadMessagesCount``
 - ``getUnreadMessagesCount(limit:page:filter:sort:)``
 - ``getUnreadMessagesCount(limit:page:filter:sort:completion:)``
+- ``fetchUnreadMessagesCounts(limit:page:filter:sort:)``
+- ``fetchUnreadMessagesCounts(limit:page:filter:sort:completion:)``
 - ``markAllMessagesAsRead(limit:page:filter:sort:)``
 - ``markAllMessagesAsRead(limit:page:filter:sort:completion:)``
 

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ChatImpl.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ChatImpl.md
@@ -75,6 +75,8 @@
 - ``GetUnreadMessagesCount``
 - ``getUnreadMessagesCount(limit:page:filter:sort:)``
 - ``getUnreadMessagesCount(limit:page:filter:sort:completion:)``
+- ``fetchUnreadMessagesCounts(limit:page:filter:sort:)``
+- ``fetchUnreadMessagesCounts(limit:page:filter:sort:completion:)``
 - ``markAllMessagesAsRead(limit:page:filter:sort:)``
 - ``markAllMessagesAsRead(limit:page:filter:sort:completion:)``
 

--- a/Sources/Chat+AsyncAwait.swift
+++ b/Sources/Chat+AsyncAwait.swift
@@ -571,6 +571,7 @@ public extension Chat {
   ///   - filter: Expression used to filter the results. Returns only these channels whose properties satisfy the given expression are returned
   ///   - sort: A collection to specify the sort order
   /// - Returns: An array of ``GetUnreadMessagesCount`` representing unread messages for the current user in a given channel
+  @available(*, deprecated, message: "Use `fetchUnreadMessagesCounts(limit:page:filter:sort:)` instead")
   func getUnreadMessagesCount(
     limit: Int? = nil,
     page: PubNubHashedPage? = nil,
@@ -579,6 +580,38 @@ public extension Chat {
   ) async throws -> [GetUnreadMessagesCount<ChannelImpl, MembershipImpl>] {
     try await withCheckedThrowingContinuation { continuation in
       getUnreadMessagesCount(
+        limit: limit,
+        page: page,
+        filter: filter,
+        sort: sort
+      ) {
+        switch $0 {
+        case let .success(unreadMessagesCount):
+          continuation.resume(returning: unreadMessagesCount)
+        case let .failure(error):
+          continuation.resume(throwing: error)
+        }
+      }
+    }
+  }
+
+  /// Returns info on all messages you didn't read on all joined channels. You can display this number on UI in the channel list of your chat app.
+  ///
+  /// - Parameters:
+  ///   - limit: Number of objects to return in response. The maximum value is 100
+  ///   - page: Object used for pagination to define which previous or next result page you want to fetch
+  ///   - filter: Expression used to filter the results. Returns only these channels whose properties satisfy the given expression are returned
+  ///   - sort: A collection to specify the sort order
+  ///   - completion: The async `Result` of the method call
+  /// - Returns: A Tuple containing an `Array` of unread messages for the current user across all joined channels, and the next pagination `PubNubHashedPage` (if one exists)
+  func fetchUnreadMessagesCounts(
+    limit: Int? = nil,
+    page: PubNubHashedPage? = nil,
+    filter: String? = nil,
+    sort: [PubNub.MembershipSortField] = []
+  ) async throws -> (countsByChannel: [GetUnreadMessagesCount<ChannelImpl, MembershipImpl>], page: PubNubHashedPage?) {
+    try await withCheckedThrowingContinuation { continuation in
+      fetchUnreadMessagesCounts(
         limit: limit,
         page: page,
         filter: filter,

--- a/Sources/Chat.swift
+++ b/Sources/Chat.swift
@@ -414,12 +414,31 @@ public protocol Chat: AnyObject {
   ///   - completion: The async `Result` of the method call
   ///     - **Success**: An array of ``GetUnreadMessagesCount`` representing unread messages for the current user in a given channel
   ///     - **Failure**: An `Error` describing the failure
+  @available(*, deprecated, message: "Use `fetchUnreadMessagesCounts(limit:page:filter:sort:completion:)` instead")
   func getUnreadMessagesCount(
     limit: Int?,
     page: PubNubHashedPage?,
     filter: String?,
     sort: [PubNub.MembershipSortField],
     completion: ((Swift.Result<[GetUnreadMessagesCount<ChannelImpl, MembershipImpl>], Error>) -> Void)?
+  )
+
+  /// Returns info on all messages you didn't read on all joined channels. You can display this number on UI in the channel list of your chat app.
+  ///
+  /// - Parameters:
+  ///   - limit: Number of objects to return in response. The maximum value is 100
+  ///   - page: Object used for pagination to define which previous or next result page you want to fetch
+  ///   - filter: Expression used to filter the results. Returns only these channels whose properties satisfy the given expression are returned
+  ///   - sort: A collection to specify the sort order
+  ///   - completion: The async `Result` of the method call
+  ///     - **Success**: A Tuple containing an `Array` of unread messages for the current user across all joined channels, and the next pagination `PubNubHashedPage` (if one exists)
+  ///     - **Failure**: An `Error` describing the failure
+  func fetchUnreadMessagesCounts(
+    limit: Int?,
+    page: PubNubHashedPage?,
+    filter: String?,
+    sort: [PubNub.MembershipSortField],
+    completion: ((Swift.Result<(countsByChannel: [GetUnreadMessagesCount<ChannelImpl, MembershipImpl>], page: PubNubHashedPage?), Error>) -> Void)?
   )
 
   /// Allows you to mark as read all messages you didn't read on all joined channels.

--- a/Sources/ChatImpl.swift
+++ b/Sources/ChatImpl.swift
@@ -626,6 +626,7 @@ extension ChatImpl: Chat {
     page: PubNubHashedPage? = nil,
     filter: String? = nil,
     sort: [PubNub.MembershipSortField] = [],
+    // swiftlint:disable:next line_length
     completion: ((Swift.Result<(countsByChannel: [GetUnreadMessagesCount<ChannelImpl, MembershipImpl>], page: PubNubHashedPage?), Error>) -> Void)? = nil
   ) {
     chat.fetchUnreadMessagesCounts(

--- a/Sources/Miscellaneous/Constants.swift
+++ b/Sources/Miscellaneous/Constants.swift
@@ -10,4 +10,4 @@
 
 import Foundation
 
-let pubNubSwiftChatSDKVersion: String = "0.20.0"
+let pubNubSwiftChatSDKVersion: String = "0.30.0"

--- a/Tests/AsyncAwait/ChatAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/ChatAsyncIntegrationTests.swift
@@ -482,9 +482,13 @@ class ChatAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
     try await channel2.invite(user: chat.currentUser)
     try await channel3.invite(user: chat.currentUser)
 
+    try await Task.sleep(nanoseconds: 2_000_000_000)
+
     try await channel.sendText(text: "Some new text")
     try await channel2.sendText(text: "Some new text")
     try await channel3.sendText(text: "Some new text")
+
+    try await Task.sleep(nanoseconds: 2_000_000_000)
 
     let firstFetchResponse = try await chat.fetchUnreadMessagesCounts(limit: 1)
     let firstPage = try XCTUnwrap(firstFetchResponse.page)

--- a/Tests/AsyncAwait/ChatAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/ChatAsyncIntegrationTests.swift
@@ -468,7 +468,46 @@ class ChatAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
     XCTAssertEqual(getUnreadMessagesCount?.membership.user.id, chat.currentUser.id)
 
     addTeardownBlock { [unowned self] in
+      _ = try? await channel.leave()
       _ = try? await chat.deleteChannel(id: channel.id)
+    }
+  }
+
+  func testChatAsync_FetchUnreadMessagesCounts() async throws {
+    let channel = try await chat.createChannel(id: randomString())
+    let channel2 = try await chat.createChannel(id: randomString())
+    let channel3 = try await chat.createChannel(id: randomString())
+
+    try await channel.invite(user: chat.currentUser)
+    try await channel2.invite(user: chat.currentUser)
+    try await channel3.invite(user: chat.currentUser)
+
+    try await channel.sendText(text: "Some new text")
+    try await channel2.sendText(text: "Some new text")
+    try await channel3.sendText(text: "Some new text")
+
+    let firstFetchResponse = try await chat.fetchUnreadMessagesCounts(limit: 1)
+    let firstPage = try XCTUnwrap(firstFetchResponse.page)
+
+    XCTAssertEqual(firstFetchResponse.countsByChannel.count, 1)
+    XCTAssertTrue(firstFetchResponse.countsByChannel.allSatisfy { $0.count == 1 })
+
+    let secondFetchResponse = try await chat.fetchUnreadMessagesCounts(page: firstPage)
+    let secondPage = try XCTUnwrap(secondFetchResponse.page)
+
+    XCTAssertEqual(secondFetchResponse.countsByChannel.count, 2)
+    XCTAssertTrue(secondFetchResponse.countsByChannel.allSatisfy { $0.count == 1 })
+
+    let thirdFetchResponse = try await chat.fetchUnreadMessagesCounts(page: secondPage)
+    XCTAssertTrue(thirdFetchResponse.countsByChannel.isEmpty)
+
+    addTeardownBlock { [unowned self] in
+      _ = try? await channel.leave()
+      _ = try? await channel2.leave()
+      _ = try? await channel3.leave()
+      _ = try? await chat.deleteChannel(id: channel.id)
+      _ = try? await chat.deleteChannel(id: channel2.id)
+      _ = try? await chat.deleteChannel(id: channel3.id)
     }
   }
 

--- a/Tests/ChatIntegrationTests.swift
+++ b/Tests/ChatIntegrationTests.swift
@@ -759,6 +759,11 @@ class ChatIntegrationTests: BaseClosureIntegrationTestCase {
 
     addTeardownBlock { [unowned self] in
       try awaitResult {
+        channel.leave(
+          completion: $0
+        )
+      }
+      try awaitResult {
         chat.deleteChannel(
           id: channel.id,
           completion: $0


### PR DESCRIPTION
fix(files): fix the issue with the invalid download URL for files
feat(chat): deprecate `getUnreadMessagesCount(limit:page:filter:sort:)` method in Chat interface
feat(chat): introduce `fetchUnreadMessagesCounts(limit:page:filter:sort:)` method in Chat interface
refactor(chat): remove code duplication from the `ChatImpl` constructors
refactor(chat): add thread safety to chat mapping logic
