### PR TITLE
Add Chat SDK improvements

### DIFF
--- a/PubNubSwiftChatSDK.xcodeproj/project.pbxproj
+++ b/PubNubSwiftChatSDK.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		3D0F90D52D48DEC700986686 /* MutedUsersManagerInterface+AsyncAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D0F90D42D48DEC700986686 /* MutedUsersManagerInterface+AsyncAwait.swift */; };
 		3D1CE5232D79DED800617200 /* String+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1CE5222D79DED800617200 /* String+Helpers.swift */; };
 		3D1E67D72E3CBC84001454C1 /* ConnectionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1E67D62E3CBC84001454C1 /* ConnectionStatus.swift */; };
+		3D1E67D92E3CBCA0001454C1 /* MessageReaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1E67D82E3CBCA0001454C1 /* MessageReaction.swift */; };
 		3D27B8D02D2D9A61003AD459 /* ThreadChannelAsyncIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D27B8CF2D2D9A61003AD459 /* ThreadChannelAsyncIntegrationTests.swift */; };
 		3D27B8D22D2D9BBB003AD459 /* ThreadChannel+AsyncAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D27B8D12D2D9BBB003AD459 /* ThreadChannel+AsyncAwait.swift */; };
 		3D27B8D42D2EAEA6003AD459 /* MessageDraftAsyncIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D27B8D32D2EAEA5003AD459 /* MessageDraftAsyncIntegrationTests.swift */; };
@@ -155,6 +156,7 @@
 		3D0F90D42D48DEC700986686 /* MutedUsersManagerInterface+AsyncAwait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MutedUsersManagerInterface+AsyncAwait.swift"; sourceTree = "<group>"; };
 		3D1CE5222D79DED800617200 /* String+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Helpers.swift"; sourceTree = "<group>"; };
 		3D1E67D62E3CBC84001454C1 /* ConnectionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionStatus.swift; sourceTree = "<group>"; };
+		3D1E67D82E3CBCA0001454C1 /* MessageReaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageReaction.swift; sourceTree = "<group>"; };
 		3D27B8CF2D2D9A61003AD459 /* ThreadChannelAsyncIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadChannelAsyncIntegrationTests.swift; sourceTree = "<group>"; };
 		3D27B8D12D2D9BBB003AD459 /* ThreadChannel+AsyncAwait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ThreadChannel+AsyncAwait.swift"; sourceTree = "<group>"; };
 		3D27B8D32D2EAEA5003AD459 /* MessageDraftAsyncIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageDraftAsyncIntegrationTests.swift; sourceTree = "<group>"; };
@@ -505,6 +507,7 @@
 				3DB2A8B82C80993B00167058 /* ChannelType.swift */,
 				3DB2A8BE2C809B1F00167058 /* EmitEventMethod.swift */,
 				3D1E67D62E3CBC84001454C1 /* ConnectionStatus.swift */,
+				3D1E67D82E3CBCA0001454C1 /* MessageReaction.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -699,6 +702,7 @@
 				3D2CA2382C5B9ACA008D2284 /* File.swift in Sources */,
 				3DB5A3192E2F900B001741C8 /* ChannelGroupImpl.swift in Sources */,
 				3D1E67D72E3CBC84001454C1 /* ConnectionStatus.swift in Sources */,
+				3D1E67D92E3CBCA0001454C1 /* MessageReaction.swift in Sources */,
 				3DB73A752C57D073007FE249 /* PubNubChat.Event.swift in Sources */,
 				3D2CA2362C5B9320008D2284 /* PubNubChat+Transform.swift in Sources */,
 				3DB73A492C513578007FE249 /* MessageReferencedChannel.swift in Sources */,

--- a/PubNubSwiftChatSDK.xcodeproj/project.pbxproj
+++ b/PubNubSwiftChatSDK.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		3D1CE5232D79DED800617200 /* String+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1CE5222D79DED800617200 /* String+Helpers.swift */; };
 		3D1E67D72E3CBC84001454C1 /* ConnectionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1E67D62E3CBC84001454C1 /* ConnectionStatus.swift */; };
 		3D1E67D92E3CBCA0001454C1 /* MessageReaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1E67D82E3CBCA0001454C1 /* MessageReaction.swift */; };
+		3D1E67DA2E3CBCB0001454C1 /* ReadReceipt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1E67DB2E3CBCB0001454C1 /* ReadReceipt.swift */; };
 		3D27B8D02D2D9A61003AD459 /* ThreadChannelAsyncIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D27B8CF2D2D9A61003AD459 /* ThreadChannelAsyncIntegrationTests.swift */; };
 		3D27B8D22D2D9BBB003AD459 /* ThreadChannel+AsyncAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D27B8D12D2D9BBB003AD459 /* ThreadChannel+AsyncAwait.swift */; };
 		3D27B8D42D2EAEA6003AD459 /* MessageDraftAsyncIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D27B8D32D2EAEA5003AD459 /* MessageDraftAsyncIntegrationTests.swift */; };
@@ -157,6 +158,7 @@
 		3D1CE5222D79DED800617200 /* String+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Helpers.swift"; sourceTree = "<group>"; };
 		3D1E67D62E3CBC84001454C1 /* ConnectionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionStatus.swift; sourceTree = "<group>"; };
 		3D1E67D82E3CBCA0001454C1 /* MessageReaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageReaction.swift; sourceTree = "<group>"; };
+		3D1E67DB2E3CBCB0001454C1 /* ReadReceipt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadReceipt.swift; sourceTree = "<group>"; };
 		3D27B8CF2D2D9A61003AD459 /* ThreadChannelAsyncIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadChannelAsyncIntegrationTests.swift; sourceTree = "<group>"; };
 		3D27B8D12D2D9BBB003AD459 /* ThreadChannel+AsyncAwait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ThreadChannel+AsyncAwait.swift"; sourceTree = "<group>"; };
 		3D27B8D32D2EAEA5003AD459 /* MessageDraftAsyncIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageDraftAsyncIntegrationTests.swift; sourceTree = "<group>"; };
@@ -508,6 +510,7 @@
 				3DB2A8BE2C809B1F00167058 /* EmitEventMethod.swift */,
 				3D1E67D62E3CBC84001454C1 /* ConnectionStatus.swift */,
 				3D1E67D82E3CBCA0001454C1 /* MessageReaction.swift */,
+				3D1E67DB2E3CBCB0001454C1 /* ReadReceipt.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -703,6 +706,7 @@
 				3DB5A3192E2F900B001741C8 /* ChannelGroupImpl.swift in Sources */,
 				3D1E67D72E3CBC84001454C1 /* ConnectionStatus.swift in Sources */,
 				3D1E67D92E3CBCA0001454C1 /* MessageReaction.swift in Sources */,
+				3D1E67DA2E3CBCB0001454C1 /* ReadReceipt.swift in Sources */,
 				3DB73A752C57D073007FE249 /* PubNubChat.Event.swift in Sources */,
 				3D2CA2362C5B9320008D2284 /* PubNubChat+Transform.swift in Sources */,
 				3DB73A492C513578007FE249 /* MessageReferencedChannel.swift in Sources */,

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/Channel.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/Channel.md
@@ -10,6 +10,8 @@
 - ``streamUpdatesOn(channels:callback:)``
 - ``streamReadReceipts()``
 - ``streamReadReceipts(callback:)``
+- ``fetchReadReceipts(limit:page:filter:sort:)``
+- ``fetchReadReceipts(limit:page:filter:sort:completion:)``
 - ``streamMessageReports()``
 - ``streamMessageReports(callback:)``
 - ``streamPresence()``

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/Channel.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/Channel.md
@@ -52,6 +52,10 @@
 - ``inviteMultiple(users:completion:)``
 - ``getMembers(limit:page:filter:sort:)``
 - ``getMembers(limit:page:filter:sort:completion:)``
+- ``hasMember(userId:)``
+- ``hasMember(userId:completion:)``
+- ``getMember(userId:)``
+- ``getMember(userId:completion:)``
 
 ### Sending a text
 

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/Channel.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/Channel.md
@@ -35,8 +35,8 @@
 
 ### Presence Management
 
-- ``whoIsPresent()``
-- ``whoIsPresent(completion:)``
+- ``whoIsPresent(limit:offset:)``
+- ``whoIsPresent(limit:offset:completion:)``
 - ``isPresent(userId:)``
 - ``isPresent(userId:completion:)``
 - ``join(custom:)``

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ChannelImpl.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ChannelImpl.md
@@ -10,6 +10,8 @@
 - ``streamUpdatesOn(channels:callback:)``
 - ``streamReadReceipts()``
 - ``streamReadReceipts(callback:)``
+- ``fetchReadReceipts(limit:page:filter:sort:)``
+- ``fetchReadReceipts(limit:page:filter:sort:completion:)``
 - ``streamMessageReports()``
 - ``streamMessageReports(callback:)``
 - ``streamPresence()``

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ChannelImpl.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ChannelImpl.md
@@ -52,6 +52,10 @@
 - ``inviteMultiple(users:completion:)``
 - ``getMembers(limit:page:filter:sort:)``
 - ``getMembers(limit:page:filter:sort:completion:)``
+- ``hasMember(userId:)``
+- ``hasMember(userId:completion:)``
+- ``getMember(userId:)``
+- ``getMember(userId:completion:)``
 
 ### Sending a text
 

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ChannelImpl.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ChannelImpl.md
@@ -35,8 +35,8 @@
 
 ### Presence Management
 
-- ``whoIsPresent()``
-- ``whoIsPresent(completion:)``
+- ``whoIsPresent(limit:offset:)``
+- ``whoIsPresent(limit:offset:completion:)``
 - ``isPresent(userId:)``
 - ``isPresent(userId:completion:)``
 - ``join(custom:)``

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/Membership.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/Membership.md
@@ -1,0 +1,24 @@
+# ``PubNubSwiftChatSDK/Membership``
+
+## Topics
+
+### Receiving Updates
+
+- ``streamUpdates()``
+- ``streamUpdates(callback:)``
+- ``streamUpdatesOn(memberships:)``
+- ``streamUpdatesOn(memberships:callback:)``
+
+### Read Receipts
+
+- ``setLastReadMessage(message:)``
+- ``setLastReadMessage(message:completion:)``
+- ``setLastReadMessageTimetoken(_:)``
+- ``setLastReadMessageTimetoken(_:completion:)``
+- ``getUnreadMessagesCount()``
+- ``getUnreadMessagesCount(completion:)``
+
+### Updating Membership
+
+- ``update(custom:)``
+- ``update(custom:completion:)``

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/MembershipImpl.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/MembershipImpl.md
@@ -1,0 +1,24 @@
+# ``PubNubSwiftChatSDK/MembershipImpl``
+
+## Topics
+
+### Receiving Updates
+
+- ``streamUpdates()``
+- ``streamUpdates(callback:)``
+- ``streamUpdatesOn(memberships:)``
+- ``streamUpdatesOn(memberships:callback:)``
+
+### Read Receipts
+
+- ``setLastReadMessage(message:)``
+- ``setLastReadMessage(message:completion:)``
+- ``setLastReadMessageTimetoken(_:)``
+- ``setLastReadMessageTimetoken(_:completion:)``
+- ``getUnreadMessagesCount()``
+- ``getUnreadMessagesCount(completion:)``
+
+### Updating Membership
+
+- ``update(custom:)``
+- ``update(custom:completion:)``

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ThreadChannel.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ThreadChannel.md
@@ -1,0 +1,10 @@
+# ``PubNubSwiftChatSDK/ThreadChannel``
+
+## Topics
+
+### Pinning Messages to Parent Channel
+
+- ``pinMessageToParentChannel(message:)``
+- ``pinMessageToParentChannel(message:completion:)``
+- ``unpinMessageFromParentChannel()``
+- ``unpinMessageFromParentChannel(completion:)``

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ThreadChannelImpl.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ThreadChannelImpl.md
@@ -1,0 +1,10 @@
+# ``PubNubSwiftChatSDK/ThreadChannelImpl``
+
+## Topics
+
+### Pinning Messages to Parent Channel
+
+- ``pinMessageToParentChannel(message:)``
+- ``pinMessageToParentChannel(message:completion:)``
+- ``unpinMessageFromParentChannel()``
+- ``unpinMessageFromParentChannel(completion:)``

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ThreadMessage.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ThreadMessage.md
@@ -1,0 +1,10 @@
+# ``PubNubSwiftChatSDK/ThreadMessage``
+
+## Topics
+
+### Pinning to Parent Channel
+
+- ``pinToParentChannel()``
+- ``pinToParentChannel(completion:)``
+- ``unpinFromParentChannel()``
+- ``unpinFromParentChannel(completion:)``

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ThreadMessageImpl.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ThreadMessageImpl.md
@@ -1,0 +1,10 @@
+# ``PubNubSwiftChatSDK/ThreadMessageImpl``
+
+## Topics
+
+### Pinning to Parent Channel
+
+- ``pinToParentChannel()``
+- ``pinToParentChannel(completion:)``
+- ``unpinFromParentChannel()``
+- ``unpinFromParentChannel(completion:)``

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/User.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/User.md
@@ -1,0 +1,35 @@
+# ``PubNubSwiftChatSDK/User``
+
+## Topics
+
+### Receiving Updates
+
+- ``streamUpdates()``
+- ``streamUpdates(callback:)``
+- ``streamUpdatesOn(users:)``
+- ``streamUpdatesOn(users:callback:)``
+
+### Update and Delete a User
+
+- ``update(name:externalId:profileUrl:email:custom:status:type:)``
+- ``update(name:externalId:profileUrl:email:custom:status:type:completion:)``
+- ``update(updateAction:)``
+- ``update(updateAction:completion:)``
+- ``delete(soft:)``
+- ``delete(soft:completion:)``
+
+### Presence Management
+
+- ``wherePresent()``
+- ``wherePresent(completion:)``
+- ``isPresentOn(channelId:)``
+- ``isPresentOn(channelId:completion:)``
+
+### Memberships Management
+
+- ``getMemberships(limit:page:filter:sort:)``
+- ``getMemberships(limit:page:filter:sort:completion:)``
+- ``isMemberOf(channelId:)``
+- ``isMemberOf(channelId:completion:)``
+- ``getMembership(channelId:)``
+- ``getMembership(channelId:completion:)``

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/UserImpl.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/UserImpl.md
@@ -1,0 +1,35 @@
+# ``PubNubSwiftChatSDK/UserImpl``
+
+## Topics
+
+### Receiving Updates
+
+- ``streamUpdates()``
+- ``streamUpdates(callback:)``
+- ``streamUpdatesOn(users:)``
+- ``streamUpdatesOn(users:callback:)``
+
+### Update and Delete a User
+
+- ``update(name:externalId:profileUrl:email:custom:status:type:)``
+- ``update(name:externalId:profileUrl:email:custom:status:type:completion:)``
+- ``update(updateAction:)``
+- ``update(updateAction:completion:)``
+- ``delete(soft:)``
+- ``delete(soft:completion:)``
+
+### Presence Management
+
+- ``wherePresent()``
+- ``wherePresent(completion:)``
+- ``isPresentOn(channelId:)``
+- ``isPresentOn(channelId:completion:)``
+
+### Memberships Management
+
+- ``getMemberships(limit:page:filter:sort:)``
+- ``getMemberships(limit:page:filter:sort:completion:)``
+- ``isMemberOf(channelId:)``
+- ``isMemberOf(channelId:completion:)``
+- ``getMembership(channelId:)``
+- ``getMembership(channelId:completion:)``

--- a/Snippets/ChannelSnippets.swift
+++ b/Snippets/ChannelSnippets.swift
@@ -672,3 +672,43 @@ func pinMessageToChannel() {
   }
   // snippet.end
 }
+
+// MARK: - Check if User is Channel Member
+
+func hasMember() {
+  // snippet.channels.hasMember
+  // Assumes a "ChatImpl" reference named "chat"
+  Task {
+    if let channel = try await chat.getChannel(channelId: "support") {
+      let isMember = try await channel.hasMember(userId: "support_agent_15")
+      if isMember {
+        debugPrint("User 'support_agent_15' is a member of the 'support' channel")
+      } else {
+        debugPrint("User 'support_agent_15' is not a member of the 'support' channel")
+      }
+    } else {
+      debugPrint("Channel not found")
+    }
+  }
+  // snippet.end
+}
+
+// MARK: - Get Specific Channel Member
+
+func getMember() {
+  // snippet.channels.getMember
+  // Assumes a "ChatImpl" reference named "chat"
+  Task {
+    if let channel = try await chat.getChannel(channelId: "support") {
+      if let membership = try await channel.getMember(userId: "support_agent_15") {
+        debugPrint("Found membership for user: \(membership.user.id)")
+        debugPrint("Membership custom data: \(String(describing: membership.custom))")
+      } else {
+        debugPrint("User 'support_agent_15' is not a member of the 'support' channel")
+      }
+    } else {
+      debugPrint("Channel not found")
+    }
+  }
+  // snippet.end
+}

--- a/Snippets/MessageSnippets.swift
+++ b/Snippets/MessageSnippets.swift
@@ -1270,9 +1270,7 @@ func streamReadReceiptsAsyncStream() {
   Task {
     if let channel = try await chat.getChannel(channelId: "support") {
       for await readReceipt in channel.streamReadReceipts() {
-        readReceipt.forEach { (userId, timetoken) in
-          debugPrint("User \(userId) has read up to timetoken: \(timetoken)")
-        }
+        debugPrint("User \(readReceipt.userId) has read up to timetoken: \(readReceipt.lastReadTimetoken)")
       }
     } else {
       debugPrint("Channel not found")
@@ -1286,11 +1284,8 @@ func streamReadReceiptsAsyncStream() {
 func streamReadReceiptsClosure() {
   // snippet.messages.readReceipts.closure
   // Assumes a "ChannelImpl" reference named "channel"
-  autoCloseable = channel.streamReadReceipts { receipts in
-    print("Read Receipts Received:")
-    receipts.forEach { (userId, timetoken) in
-      print("User \(userId) has read up to timetoken: \(timetoken)")
-    }
+  autoCloseable = channel.streamReadReceipts { readReceipt in
+    print("User \(readReceipt.userId) has read up to timetoken: \(readReceipt.lastReadTimetoken)")
   }
   // snippet.end
 }
@@ -1303,13 +1298,12 @@ func fetchReadReceipts() {
   Task {
     if let channel = try await chat.getChannel(channelId: "support") {
       let result = try await channel.fetchReadReceipts()
-      // Dictionary mapping user IDs to the timetoken they have read up to
       let receipts = result.receipts
       // Use for subsequent call: channel.fetchReadReceipts(page: nextPage)
       let nextPage = result.page
 
-      receipts.forEach { (userId, timetoken) in
-        print("User \(userId) has read up to timetoken: \(timetoken)")
+      receipts.forEach { receipt in
+        print("User \(receipt.userId) has read up to timetoken: \(receipt.lastReadTimetoken)")
       }
     }
   }

--- a/Snippets/MessageSnippets.swift
+++ b/Snippets/MessageSnippets.swift
@@ -1270,8 +1270,8 @@ func streamReadReceiptsAsyncStream() {
   Task {
     if let channel = try await chat.getChannel(channelId: "support") {
       for await readReceipt in channel.streamReadReceipts() {
-        readReceipt.forEach { (messageTimetoken, users) in
-          debugPrint("Message timetoken: \(messageTimetoken) was read by users: \(users)")
+        readReceipt.forEach { (userId, timetoken) in
+          debugPrint("User \(userId) has read up to timetoken: \(timetoken)")
         }
       }
     } else {
@@ -1288,8 +1288,29 @@ func streamReadReceiptsClosure() {
   // Assumes a "ChannelImpl" reference named "channel"
   autoCloseable = channel.streamReadReceipts { receipts in
     print("Read Receipts Received:")
-    receipts.forEach { (messageTimetoken, users) in
-      print("Message Timetoken: \(messageTimetoken) was read by users: \(users)")
+    receipts.forEach { (userId, timetoken) in
+      print("User \(userId) has read up to timetoken: \(timetoken)")
+    }
+  }
+  // snippet.end
+}
+
+// MARK: - Fetch Read Receipts
+
+func fetchReadReceipts() {
+  // snippet.messages.readReceipts.fetch
+  // Assumes a "ChatImpl" reference named "chat"
+  Task {
+    if let channel = try await chat.getChannel(channelId: "support") {
+      let result = try await channel.fetchReadReceipts()
+      // Dictionary mapping user IDs to the timetoken they have read up to
+      let receipts = result.receipts
+      // Use for subsequent call: channel.fetchReadReceipts(page: nextPage)
+      let nextPage = result.page
+
+      receipts.forEach { (userId, timetoken) in
+        print("User \(userId) has read up to timetoken: \(timetoken)")
+      }
     }
   }
   // snippet.end

--- a/Snippets/UserSnippets.swift
+++ b/Snippets/UserSnippets.swift
@@ -383,6 +383,44 @@ func streamPresence() {
   // snippet.end
 }
 
+// MARK: - Channel Membership
+
+func isMemberOf() {
+  // snippet.users.isMemberOf
+  // Assumes a "ChatImpl" reference named "chat"
+  Task {
+    if let user = try await chat.getUser(userId: "support_agent_15") {
+      let isMember = try await user.isMemberOf(channelId: "support")
+      if isMember {
+        debugPrint("User 'support_agent_15' is a member of the 'support' channel")
+      } else {
+        debugPrint("User 'support_agent_15' is not a member of the 'support' channel")
+      }
+    } else {
+      debugPrint("User not found")
+    }
+  }
+  // snippet.end
+}
+
+func getMembership() {
+  // snippet.users.getMembership
+  // Assumes a "ChatImpl" reference named "chat"
+  Task {
+    if let user = try await chat.getUser(userId: "support_agent_15") {
+      if let membership = try await user.getMembership(channelId: "support") {
+        debugPrint("Found membership in channel: \(membership.channel.id)")
+        debugPrint("Membership custom data: \(String(describing: membership.custom))")
+      } else {
+        debugPrint("User 'support_agent_15' is not a member of the 'support' channel")
+      }
+    } else {
+      debugPrint("User not found")
+    }
+  }
+  // snippet.end
+}
+
 // MARK: - Global Presence
 
 func checkUserActive() {

--- a/Sources/Chat/Chat.swift
+++ b/Sources/Chat/Chat.swift
@@ -448,6 +448,8 @@ public protocol Chat: AnyObject {
 
   /// Allows you to mark as read all messages you didn't read on all joined channels.
   ///
+  /// This method emits a read receipt event on each affected channel, unless ``ChatConfiguration/emitReadReceiptEvents`` is set to `false` for the channel's type.
+  ///
   /// - Parameters:
   ///   - limit: Number of objects to return in response. The maximum value is 100
   ///   - page: Object used for pagination to define which previous or next result page you want to fetch

--- a/Sources/Chat/ChatConfiguration.swift
+++ b/Sources/Chat/ChatConfiguration.swift
@@ -190,6 +190,9 @@ public struct ChatConfiguration {
   ///
   public var syncMutedUsers: Bool
 
+  /// Specifies whether read receipt events should be emitted, per channel type. Defaults to `true` for all channel types except `.public`, which defaults to `false`
+  public var emitReadReceiptEvents: [ChannelType: Bool]
+
   /// Creates a new ``ChatConfiguration`` object
   ///
   /// - Parameters:
@@ -202,6 +205,7 @@ public struct ChatConfiguration {
   ///   - rateLimitPerChannel: Client-side limit that states the rate at which messages can be published on a given channel type
   ///   - customPayloads: Custom message payload to be sent and/or received by Chat SDK
   ///   - syncMutedUsers: A boolean value that controls syncing of muted users
+  ///   - emitReadReceiptEvents: Per-channel-type dictionary for emitting read receipt events. Defaults to `true` for all channel types except `.public`
   public init(
     logLevel: LogLevel = .off,
     typingTimeout: Int = 5,
@@ -211,7 +215,8 @@ public struct ChatConfiguration {
     rateLimitFactor: Int = 2,
     rateLimitPerChannel: [ChannelType: Int64] = ChannelType.allCases.reduce(into: [ChannelType: Int64]()) { res, type in res[type] = 0 },
     customPayloads: CustomPayloads? = nil,
-    syncMutedUsers: Bool = false
+    syncMutedUsers: Bool = false,
+    emitReadReceiptEvents: [ChannelType: Bool] = [.direct: true, .group: true, .public: false, .unknown: true]
   ) {
     self.logLevel = logLevel
     self.typingTimeout = typingTimeout
@@ -222,6 +227,7 @@ public struct ChatConfiguration {
     self.rateLimitPerChannel = rateLimitPerChannel
     self.customPayloads = customPayloads
     self.syncMutedUsers = syncMutedUsers
+    self.emitReadReceiptEvents = emitReadReceiptEvents
   }
 
   func transform() -> any PubNubChat.ChatConfiguration {
@@ -240,6 +246,7 @@ public struct ChatConfiguration {
       rateLimitFactor: Int32(rateLimitFactor),
       rateLimitPerChannel: rateLimitPerChannel.transform(),
       customPayloads: customPayloads?.transform(),
+      emitReadReceiptEvents: emitReadReceiptEvents.transform(),
       syncMutedUsers: syncMutedUsers
     )
   }

--- a/Sources/Entities/BaseChannel.swift
+++ b/Sources/Entities/BaseChannel.swift
@@ -479,19 +479,39 @@ final class BaseChannel<C: PubNubChat.Channel_, M: PubNubChat.Message>: Channel 
     )
   }
 
-  func streamReadReceipts(callback: @escaping (([Timetoken: [String]]) -> Void)) -> AutoCloseable {
+  func streamReadReceipts(callback: @escaping (([String: Timetoken]) -> Void)) -> AutoCloseable {
     AutoCloseableImpl(
       channel.streamReadReceipts { [weak self] in
         if self != nil {
-          callback(
-            $0.reduce(into: [Timetoken: [String]]()) { res, currentItem in
-              res[Timetoken(currentItem.key.uint64Value)] = currentItem.value
-            }
-          )
+          callback($0.mapValues {
+            Timetoken($0.uint64Value)
+          })
         }
       },
       owner: self
     )
+  }
+
+  func fetchReadReceipts(
+    limit: Int?,
+    page: PubNubHashedPage?,
+    filter: String?,
+    sort: [PubNub.MembershipSortField],
+    completion: ((Swift.Result<(receipts: [String: Timetoken], page: PubNubHashedPage?), Error>) -> Void)?
+  ) {
+    getMembers(limit: limit, page: page, filter: filter, sort: sort) { result in
+      switch result {
+      case let .success((memberships, page)):
+        let receipts = memberships.reduce(into: [String: Timetoken]()) { result, membership in
+          if let timetoken = membership.lastReadMessageTimetoken {
+            result[membership.user.id] = timetoken
+          }
+        }
+        completion?(.success((receipts: receipts, page: page)))
+      case let .failure(error):
+        completion?(.failure(error))
+      }
+    }
   }
 
   func getFiles(

--- a/Sources/Entities/BaseChannel.swift
+++ b/Sources/Entities/BaseChannel.swift
@@ -305,6 +305,36 @@ final class BaseChannel<C: PubNubChat.Channel_, M: PubNubChat.Message>: Channel 
     }
   }
 
+  func hasMember(userId: String, completion: ((Swift.Result<Bool, Error>) -> Void)?) {
+    channel.hasMember(
+      userId: userId
+    ).async(caller: self) { (result: FutureResult<BaseChannel, Bool>) in
+      switch result.result {
+      case let .success(hasMember):
+        completion?(.success(hasMember))
+      case let .failure(error):
+        completion?(.failure(error))
+      }
+    }
+  }
+
+  func getMember(userId: String, completion: ((Swift.Result<ChatType.ChatMembershipType?, Error>) -> Void)?) {
+    channel.getMember(
+      userId: userId
+    ).async(caller: self) { (result: FutureResult<BaseChannel, PubNubChat.Membership?>) in
+      switch result.result {
+      case let .success(membership):
+        if let membership {
+          completion?(.success(MembershipImpl(membership: membership, chat: result.caller.chat)))
+        } else {
+          completion?(.success(nil))
+        }
+      case let .failure(error):
+        completion?(.failure(error))
+      }
+    }
+  }
+
   func connect(callback: @escaping (ChatType.ChatMessageType) -> Void) -> AutoCloseable {
     AutoCloseableImpl(
       channel.connect { [weak self] in

--- a/Sources/Entities/BaseChannel.swift
+++ b/Sources/Entities/BaseChannel.swift
@@ -479,13 +479,11 @@ final class BaseChannel<C: PubNubChat.Channel_, M: PubNubChat.Message>: Channel 
     )
   }
 
-  func streamReadReceipts(callback: @escaping (([String: Timetoken]) -> Void)) -> AutoCloseable {
+  func streamReadReceipts(callback: @escaping (([ReadReceipt]) -> Void)) -> AutoCloseable {
     AutoCloseableImpl(
       channel.streamReadReceipts { [weak self] in
         if self != nil {
-          callback($0.mapValues {
-            Timetoken($0.uint64Value)
-          })
+          callback([$0.transform()])
         }
       },
       owner: self
@@ -497,17 +495,24 @@ final class BaseChannel<C: PubNubChat.Channel_, M: PubNubChat.Message>: Channel 
     page: PubNubHashedPage?,
     filter: String?,
     sort: [PubNub.MembershipSortField],
-    completion: ((Swift.Result<(receipts: [String: Timetoken], page: PubNubHashedPage?), Error>) -> Void)?
+    completion: ((Swift.Result<(receipts: [ReadReceipt], page: PubNubHashedPage?), Error>) -> Void)?
   ) {
-    getMembers(limit: limit, page: page, filter: filter, sort: sort) { result in
-      switch result {
-      case let .success((memberships, page)):
-        let receipts = memberships.reduce(into: [String: Timetoken]()) { result, membership in
-          if let timetoken = membership.lastReadMessageTimetoken {
-            result[membership.user.id] = timetoken
-          }
-        }
-        completion?(.success((receipts: receipts, page: page)))
+    channel.fetchReadReceipts(
+      limit: limit?.asKotlinInt,
+      page: page?.transform(),
+      filter: filter,
+      sort: sort.compactMap { $0.transform() }
+    ).async(caller: self) { (result: FutureResult<BaseChannel, PubNubChat.ReadReceiptsResponse>) in
+      switch result.result {
+      case let .success(response):
+        completion?(.success((
+          receipts: response.receipts.transform(),
+          page: PubNubHashedPageBase(
+            start: response.next?.pageHash,
+            end: response.prev?.pageHash,
+            totalCount: Int(response.total)
+          ))
+        ))
       case let .failure(error):
         completion?(.failure(error))
       }

--- a/Sources/Entities/BaseChannel.swift
+++ b/Sources/Entities/BaseChannel.swift
@@ -479,11 +479,11 @@ final class BaseChannel<C: PubNubChat.Channel_, M: PubNubChat.Message>: Channel 
     )
   }
 
-  func streamReadReceipts(callback: @escaping (([ReadReceipt]) -> Void)) -> AutoCloseable {
+  func streamReadReceipts(callback: @escaping ((ReadReceipt) -> Void)) -> AutoCloseable {
     AutoCloseableImpl(
       channel.streamReadReceipts { [weak self] in
         if self != nil {
-          callback([$0.transform()])
+          callback($0.transform())
         }
       },
       owner: self

--- a/Sources/Entities/BaseMessage.swift
+++ b/Sources/Entities/BaseMessage.swift
@@ -45,7 +45,7 @@ extension BaseMessage: Message {
   public var hasThread: Bool { message.hasThread }
   public var type: String { message.type }
   public var files: [File] { message.files.transform() }
-  public var reactions: [String: [Action]] { message.reactions.transform() }
+  public var reactions: [MessageReaction] { message.reactions.transform() }
   public var textLinks: [TextLink]? { message.textLinks?.transform() }
   public var error: Error? { message.error }
 

--- a/Sources/Entities/Channel+AsyncAwait.swift
+++ b/Sources/Entities/Channel+AsyncAwait.swift
@@ -525,7 +525,7 @@ public extension Channel {
   }
 
   /// Lets you get a read confirmation status for messages you published on a channel.
-  func streamReadReceipts() -> AsyncStream<[String: Timetoken]> {
+  func streamReadReceipts() -> AsyncStream<[ReadReceipt]> {
     AsyncStream { continuation in
       let autoCloseable = streamReadReceipts {
         continuation.yield($0)
@@ -543,13 +543,13 @@ public extension Channel {
   ///   - page: Object used for pagination to define which previous or next result page you want to fetch
   ///   - filter: Expression used to filter the results. Returns only these members whose properties satisfy the given expression
   ///   - sort: A collection to specify the sort order
-  /// - Returns: A `Tuple` containing a dictionary mapping user IDs to the timetoken they have read up to, and the next pagination `PubNubHashedPage` (if one exists)
+  /// - Returns: A `Tuple` containing an array of ``ReadReceipt``, and the next pagination `PubNubHashedPage` (if one exists)
   func fetchReadReceipts(
     limit: Int? = nil,
     page: PubNubHashedPage? = nil,
     filter: String? = nil,
     sort: [PubNub.MembershipSortField] = []
-  ) async throws -> (receipts: [String: Timetoken], page: PubNubHashedPage?) {
+  ) async throws -> (receipts: [ReadReceipt], page: PubNubHashedPage?) {
     try await withCheckedThrowingContinuation { continuation in
       fetchReadReceipts(limit: limit, page: page, filter: filter, sort: sort) {
         switch $0 {

--- a/Sources/Entities/Channel+AsyncAwait.swift
+++ b/Sources/Entities/Channel+AsyncAwait.swift
@@ -323,6 +323,40 @@ public extension Channel {
     }
   }
 
+  /// Checks if a specific user is a member of this channel.
+  ///
+  /// - Parameter userId: Unique identifier of the user to check
+  /// - Returns: A `Bool` value indicating whether the user is a member of this channel
+  func hasMember(userId: String) async throws -> Bool {
+    try await withCheckedThrowingContinuation { continuation in
+      hasMember(userId: userId) {
+        switch $0 {
+        case let .success(hasMember):
+          continuation.resume(returning: hasMember)
+        case let .failure(error):
+          continuation.resume(throwing: error)
+        }
+      }
+    }
+  }
+
+  /// Retrieves the membership of a specific user in this channel.
+  ///
+  /// - Parameter userId: Unique identifier of the user whose membership to retrieve
+  /// - Returns: The user's ``Membership`` in this channel, or `nil` if not a member
+  func getMember(userId: String) async throws -> ChatType.ChatMembershipType? {
+    try await withCheckedThrowingContinuation { continuation in
+      getMember(userId: userId) {
+        switch $0 {
+        case let .success(membership):
+          continuation.resume(returning: membership)
+        case let .failure(error):
+          continuation.resume(throwing: error)
+        }
+      }
+    }
+  }
+
   /// Watch the ``Channel`` content without a need to join the ``Channel``.
   ///
   /// - Returns: An asynchronous stream that produces a new value every time a new message is published on the current channel

--- a/Sources/Entities/Channel+AsyncAwait.swift
+++ b/Sources/Entities/Channel+AsyncAwait.swift
@@ -525,7 +525,7 @@ public extension Channel {
   }
 
   /// Lets you get a read confirmation status for messages you published on a channel.
-  func streamReadReceipts() -> AsyncStream<[ReadReceipt]> {
+  func streamReadReceipts() -> AsyncStream<ReadReceipt> {
     AsyncStream { continuation in
       let autoCloseable = streamReadReceipts {
         continuation.yield($0)

--- a/Sources/Entities/Channel+AsyncAwait.swift
+++ b/Sources/Entities/Channel+AsyncAwait.swift
@@ -303,7 +303,7 @@ public extension Channel {
   ///   - limit: Number of objects to return in response
   ///   - page: Object used for pagination to define which previous or next result page you want to fetch
   ///   - filter: Expression used to filter the results. Returns only these members whose properties satisfy the given expression
-  ///   - sort: A collection to specify the sort order. Available options are id, name, and updated
+  ///   - sort: A collection to specify the sort order
   /// - Returns: A `Tuple` containing an array of the members of the channel, and the next pagination `PubNubHashedPage` (if one exists)
   func getMembers(
     limit: Int? = nil,
@@ -525,13 +525,39 @@ public extension Channel {
   }
 
   /// Lets you get a read confirmation status for messages you published on a channel.
-  func streamReadReceipts() -> AsyncStream<[Timetoken: [String]]> {
+  func streamReadReceipts() -> AsyncStream<[String: Timetoken]> {
     AsyncStream { continuation in
       let autoCloseable = streamReadReceipts {
         continuation.yield($0)
       }
       continuation.onTermination = { _ in
         autoCloseable.close()
+      }
+    }
+  }
+
+  /// Fetches the read receipts for members of this channel.
+  ///
+  /// - Parameters:
+  ///   - limit: Number of objects to return in response
+  ///   - page: Object used for pagination to define which previous or next result page you want to fetch
+  ///   - filter: Expression used to filter the results. Returns only these members whose properties satisfy the given expression
+  ///   - sort: A collection to specify the sort order
+  /// - Returns: A `Tuple` containing a dictionary mapping user IDs to the timetoken they have read up to, and the next pagination `PubNubHashedPage` (if one exists)
+  func fetchReadReceipts(
+    limit: Int? = nil,
+    page: PubNubHashedPage? = nil,
+    filter: String? = nil,
+    sort: [PubNub.MembershipSortField] = []
+  ) async throws -> (receipts: [String: Timetoken], page: PubNubHashedPage?) {
+    try await withCheckedThrowingContinuation { continuation in
+      fetchReadReceipts(limit: limit, page: page, filter: filter, sort: sort) {
+        switch $0 {
+        case let .success(result):
+          continuation.resume(returning: result)
+        case let .failure(error):
+          continuation.resume(throwing: error)
+        }
       }
     }
   }

--- a/Sources/Entities/Channel.swift
+++ b/Sources/Entities/Channel.swift
@@ -273,7 +273,7 @@ public protocol Channel: CustomStringConvertible {
   ///   - limit: Number of objects to return in response
   ///   - page: Object used for pagination to define which previous or next result page you want to fetch
   ///   - filter: Expression used to filter the results. Returns only these members whose properties satisfy the given expression
-  ///   - sort: A collection to specify the sort order. Available options are id, name, and updated
+  ///   - sort: A collection to specify the sort order
   ///   - completion: The async `Result` of the method call
   ///     - **Success**: A `Tuple` containing an array of the members of the channel, and the next pagination `PubNubHashedPage` (if one exists)
   ///     - **Failure**: An `Error` describing the failure
@@ -428,11 +428,29 @@ public protocol Channel: CustomStringConvertible {
   /// - Important: Keep a strong reference to the returned ``AutoCloseable`` object as long as you want to receive updates. If ``AutoCloseable`` is deallocated,
   /// the stream will be canceled, and no further items will be produced. You can also stop receiving updates manually by calling ``AutoCloseable/close()``.
   ///
-  /// - Parameter callback: Defines the custom behavior to be executed when receiving a read confirmation status on the joined channel.
+  /// - Parameter callback: Defines the custom behavior to be executed when receiving a read confirmation status on the joined channel. The callback receives a dictionary mapping user IDs to the timetoken they have read up to.
   /// - Returns: AutoCloseable Interface you can call to stop listening for message read receipts and clean up resources by invoking the close() method
   func streamReadReceipts(
-    callback: @escaping (([Timetoken: [String]]) -> Void)
+    callback: @escaping (([String: Timetoken]) -> Void)
   ) -> AutoCloseable
+
+  /// Fetches the read receipts for members of this channel.
+  ///
+  /// - Parameters:
+  ///   - limit: Number of objects to return in response
+  ///   - page: Object used for pagination to define which previous or next result page you want to fetch
+  ///   - filter: Expression used to filter the results. Returns only these members whose properties satisfy the given expression
+  ///   - sort: A collection to specify the sort order
+  ///   - completion: The async `Result` of the method call
+  ///     - **Success**: A `Tuple` containing a dictionary mapping user IDs to the timetoken they have read up to, and the next pagination `PubNubHashedPage` (if one exists)
+  ///     - **Failure**: An `Error` describing the failure
+  func fetchReadReceipts(
+    limit: Int?,
+    page: PubNubHashedPage?,
+    filter: String?,
+    sort: [PubNub.MembershipSortField],
+    completion: ((Swift.Result<(receipts: [String: Timetoken], page: PubNubHashedPage?), Error>) -> Void)?
+  )
 
   /// Returns all files attached to messages on a given channel.
   ///

--- a/Sources/Entities/Channel.swift
+++ b/Sources/Entities/Channel.swift
@@ -428,10 +428,10 @@ public protocol Channel: CustomStringConvertible {
   /// - Important: Keep a strong reference to the returned ``AutoCloseable`` object as long as you want to receive updates. If ``AutoCloseable`` is deallocated,
   /// the stream will be canceled, and no further items will be produced. You can also stop receiving updates manually by calling ``AutoCloseable/close()``.
   ///
-  /// - Parameter callback: Defines the custom behavior to be executed when receiving a read confirmation status on the joined channel. The callback receives a dictionary mapping user IDs to the timetoken they have read up to.
+  /// - Parameter callback: Defines the custom behavior to be executed when receiving read receipts on the joined channel
   /// - Returns: AutoCloseable Interface you can call to stop listening for message read receipts and clean up resources by invoking the close() method
   func streamReadReceipts(
-    callback: @escaping (([String: Timetoken]) -> Void)
+    callback: @escaping (([ReadReceipt]) -> Void)
   ) -> AutoCloseable
 
   /// Fetches the read receipts for members of this channel.
@@ -442,14 +442,14 @@ public protocol Channel: CustomStringConvertible {
   ///   - filter: Expression used to filter the results. Returns only these members whose properties satisfy the given expression
   ///   - sort: A collection to specify the sort order
   ///   - completion: The async `Result` of the method call
-  ///     - **Success**: A `Tuple` containing a dictionary mapping user IDs to the timetoken they have read up to, and the next pagination `PubNubHashedPage` (if one exists)
+  ///     - **Success**: A `Tuple` containing an array of ``ReadReceipt``, and the next pagination `PubNubHashedPage` (if one exists)
   ///     - **Failure**: An `Error` describing the failure
   func fetchReadReceipts(
     limit: Int?,
     page: PubNubHashedPage?,
     filter: String?,
     sort: [PubNub.MembershipSortField],
-    completion: ((Swift.Result<(receipts: [String: Timetoken], page: PubNubHashedPage?), Error>) -> Void)?
+    completion: ((Swift.Result<(receipts: [ReadReceipt], page: PubNubHashedPage?), Error>) -> Void)?
   )
 
   /// Returns all files attached to messages on a given channel.

--- a/Sources/Entities/Channel.swift
+++ b/Sources/Entities/Channel.swift
@@ -431,7 +431,7 @@ public protocol Channel: CustomStringConvertible {
   /// - Parameter callback: Defines the custom behavior to be executed when receiving read receipts on the joined channel
   /// - Returns: AutoCloseable Interface you can call to stop listening for message read receipts and clean up resources by invoking the close() method
   func streamReadReceipts(
-    callback: @escaping (([ReadReceipt]) -> Void)
+    callback: @escaping ((ReadReceipt) -> Void)
   ) -> AutoCloseable
 
   /// Fetches the read receipts for members of this channel.

--- a/Sources/Entities/Channel.swift
+++ b/Sources/Entities/Channel.swift
@@ -285,6 +285,30 @@ public protocol Channel: CustomStringConvertible {
     completion: ((Swift.Result<(memberships: [ChatType.ChatMembershipType], page: PubNubHashedPage?), Error>) -> Void)?
   )
 
+  /// Checks if a specific user is a member of this channel.
+  ///
+  /// - Parameters:
+  ///   - userId: Unique identifier of the user to check
+  ///   - completion: The async `Result` of the method call
+  ///     - **Success**: A `Bool` value indicating whether the user is a member of this channel
+  ///     - **Failure**: An `Error` describing the failure
+  func hasMember(
+    userId: String,
+    completion: ((Swift.Result<Bool, Error>) -> Void)?
+  )
+
+  /// Retrieves the membership of a specific user in this channel.
+  ///
+  /// - Parameters:
+  ///   - userId: Unique identifier of the user whose membership to retrieve
+  ///   - completion: The async `Result` of the method call
+  ///     - **Success**: The user's ``Membership`` in this channel, or `nil` if not a member
+  ///     - **Failure**: An `Error` describing the failure
+  func getMember(
+    userId: String,
+    completion: ((Swift.Result<ChatType.ChatMembershipType?, Error>) -> Void)?
+  )
+
   /// Watch the ``Channel`` content without a need to join the ``Channel``.
   ///
   /// - Important: Keep a strong reference to the returned ``AutoCloseable`` object as long as you want to receive updates. If ``AutoCloseable`` is deallocated,

--- a/Sources/Entities/ChannelImpl.swift
+++ b/Sources/Entities/ChannelImpl.swift
@@ -354,9 +354,25 @@ extension ChannelImpl: Channel {
     )
   }
 
-  public func streamReadReceipts(callback: @escaping (([Timetoken: [String]]) -> Void)) -> AutoCloseable {
+  public func streamReadReceipts(callback: @escaping (([String: Timetoken]) -> Void)) -> AutoCloseable {
     target.streamReadReceipts(
       callback: callback
+    )
+  }
+
+  public func fetchReadReceipts(
+    limit: Int? = nil,
+    page: PubNubHashedPage? = nil,
+    filter: String? = nil,
+    sort: [PubNub.MembershipSortField] = [],
+    completion: ((Swift.Result<(receipts: [String: Timetoken], page: PubNubHashedPage?), Error>) -> Void)? = nil
+  ) {
+    target.fetchReadReceipts(
+      limit: limit,
+      page: page,
+      filter: filter,
+      sort: sort,
+      completion: completion
     )
   }
 

--- a/Sources/Entities/ChannelImpl.swift
+++ b/Sources/Entities/ChannelImpl.swift
@@ -354,7 +354,7 @@ extension ChannelImpl: Channel {
     )
   }
 
-  public func streamReadReceipts(callback: @escaping (([String: Timetoken]) -> Void)) -> AutoCloseable {
+  public func streamReadReceipts(callback: @escaping (([ReadReceipt]) -> Void)) -> AutoCloseable {
     target.streamReadReceipts(
       callback: callback
     )
@@ -365,7 +365,7 @@ extension ChannelImpl: Channel {
     page: PubNubHashedPage? = nil,
     filter: String? = nil,
     sort: [PubNub.MembershipSortField] = [],
-    completion: ((Swift.Result<(receipts: [String: Timetoken], page: PubNubHashedPage?), Error>) -> Void)? = nil
+    completion: ((Swift.Result<(receipts: [ReadReceipt], page: PubNubHashedPage?), Error>) -> Void)? = nil
   ) {
     target.fetchReadReceipts(
       limit: limit,

--- a/Sources/Entities/ChannelImpl.swift
+++ b/Sources/Entities/ChannelImpl.swift
@@ -265,6 +265,20 @@ extension ChannelImpl: Channel {
     )
   }
 
+  public func hasMember(userId: String, completion: ((Swift.Result<Bool, Error>) -> Void)? = nil) {
+    target.hasMember(
+      userId: userId,
+      completion: completion
+    )
+  }
+
+  public func getMember(userId: String, completion: ((Swift.Result<MembershipImpl?, Error>) -> Void)? = nil) {
+    target.getMember(
+      userId: userId,
+      completion: completion
+    )
+  }
+
   public func connect(callback: @escaping (MessageImpl) -> Void) -> AutoCloseable {
     target.connect(callback: callback)
   }

--- a/Sources/Entities/ChannelImpl.swift
+++ b/Sources/Entities/ChannelImpl.swift
@@ -354,7 +354,7 @@ extension ChannelImpl: Channel {
     )
   }
 
-  public func streamReadReceipts(callback: @escaping (([ReadReceipt]) -> Void)) -> AutoCloseable {
+  public func streamReadReceipts(callback: @escaping ((ReadReceipt) -> Void)) -> AutoCloseable {
     target.streamReadReceipts(
       callback: callback
     )

--- a/Sources/Entities/Membership+AsyncAwait.swift
+++ b/Sources/Entities/Membership+AsyncAwait.swift
@@ -34,6 +34,8 @@ public extension Membership {
 
   /// Setting the last read message for users lets you implement the Read Receipts feature and monitor which channel member read which message.
   ///
+  /// This method emits a read receipt event on the channel, unless ``ChatConfiguration/emitReadReceiptEvents`` is set to `false` for the channel's type.
+  ///
   /// - Parameter message: Last read message on a given channel with the timestamp that gets added to the user-channel membership as the `lastReadMessageTimetoken` property
   /// - Returns: An updated ``Membership`` object
   func setLastReadMessage(message: ChatType.ChatMessageType) async throws -> ChatType.ChatMembershipType {
@@ -67,6 +69,8 @@ public extension Membership {
   }
 
   /// Setting the last read message timetoken for users lets you implement the Read Receipts feature and monitor which channel member read which message.
+  ///
+  /// This method emits a read receipt event on the channel, unless ``ChatConfiguration/emitReadReceiptEvents`` is set to `false` for the channel's type.
   ///
   /// - Parameter timetoken: Timetoken of the last read message on a given channel that gets added to the user-channel membership as the `lastReadMessageTimetoken` property
   /// - Returns: An updated ``Membership`` object

--- a/Sources/Entities/Membership.swift
+++ b/Sources/Entities/Membership.swift
@@ -52,6 +52,8 @@ public protocol Membership: CustomStringConvertible {
 
   /// Setting the last read message for users lets you implement the Read Receipts feature and monitor which channel member read which message.
   ///
+  /// This method emits a read receipt event on the channel, unless ``ChatConfiguration/emitReadReceiptEvents`` is set to `false` for the channel's type.
+  ///
   /// - Parameters:
   ///   - message: Last read message on a given channel with the timestamp that gets added to the user-channel membership as the `lastReadMessageTimetoken` property
   ///   - completion: The async `Result` of the method call
@@ -75,6 +77,8 @@ public protocol Membership: CustomStringConvertible {
   )
 
   /// Setting the last read message timetoken for users lets you implement the Read Receipts feature and monitor which channel member read which message.
+  ///
+  /// This method emits a read receipt event on the channel, unless ``ChatConfiguration/emitReadReceiptEvents`` is set to `false` for the channel's type.
   ///
   /// - Parameters:
   ///   - timetoken: Timetoken of the last read message on a given channel that gets added to the user-channel membership as the `lastReadMessageTimetoken` property

--- a/Sources/Entities/Message.swift
+++ b/Sources/Entities/Message.swift
@@ -27,6 +27,7 @@ public protocol Message: CustomStringConvertible {
   /// Unique ID of the user who sent the message
   var userId: String { get }
   /// Any actions associated with the message, such as reactions, replies, or other interactive elements
+  @available(*, deprecated, message: "Use `Message.reactions` instead for accessing message reactions")
   var actions: [String: [String: [Action]]]? { get }
   /// Extra information added to the message giving additional context
   var meta: [String: JSONCodable]? { get }
@@ -57,7 +58,7 @@ public protocol Message: CustomStringConvertible {
   /// List of attached files to the given ``Message`` with their names, types, and sources
   var files: [File] { get }
   /// List of reactions attached to the given ``Message``
-  var reactions: [String: [Action]] { get }
+  var reactions: [MessageReaction] { get }
   /// Error associated with the message, if any
   var error: Error? { get }
 

--- a/Sources/Entities/MessageImpl.swift
+++ b/Sources/Entities/MessageImpl.swift
@@ -77,7 +77,7 @@ extension MessageImpl: Message {
   public var hasThread: Bool { target.hasThread }
   public var type: String { target.type }
   public var files: [File] { target.files }
-  public var reactions: [String: [Action]] { target.reactions }
+  public var reactions: [MessageReaction] { target.reactions }
   public var textLinks: [TextLink]? { target.textLinks }
   public var error: Error? { target.error }
 

--- a/Sources/Entities/ThreadChannelImpl.swift
+++ b/Sources/Entities/ThreadChannelImpl.swift
@@ -297,6 +297,20 @@ extension ThreadChannelImpl: ThreadChannel {
     )
   }
 
+  public func hasMember(userId: String, completion: ((Swift.Result<Bool, Error>) -> Void)? = nil) {
+    target.hasMember(
+      userId: userId,
+      completion: completion
+    )
+  }
+
+  public func getMember(userId: String, completion: ((Swift.Result<MembershipImpl?, Error>) -> Void)? = nil) {
+    target.getMember(
+      userId: userId,
+      completion: completion
+    )
+  }
+
   public func connect(callback: @escaping (MessageImpl) -> Void) -> AutoCloseable {
     target.connect(
       callback: callback

--- a/Sources/Entities/ThreadChannelImpl.swift
+++ b/Sources/Entities/ThreadChannelImpl.swift
@@ -391,7 +391,7 @@ extension ThreadChannelImpl: ThreadChannel {
     )
   }
 
-  public func streamReadReceipts(callback: @escaping (([ReadReceipt]) -> Void)) -> AutoCloseable {
+  public func streamReadReceipts(callback: @escaping ((ReadReceipt) -> Void)) -> AutoCloseable {
     target.streamReadReceipts(
       callback: callback
     )

--- a/Sources/Entities/ThreadChannelImpl.swift
+++ b/Sources/Entities/ThreadChannelImpl.swift
@@ -391,7 +391,7 @@ extension ThreadChannelImpl: ThreadChannel {
     )
   }
 
-  public func streamReadReceipts(callback: @escaping (([String: Timetoken]) -> Void)) -> AutoCloseable {
+  public func streamReadReceipts(callback: @escaping (([ReadReceipt]) -> Void)) -> AutoCloseable {
     target.streamReadReceipts(
       callback: callback
     )
@@ -402,7 +402,7 @@ extension ThreadChannelImpl: ThreadChannel {
     page: PubNubHashedPage? = nil,
     filter: String? = nil,
     sort: [PubNub.MembershipSortField] = [],
-    completion: ((Swift.Result<(receipts: [String: Timetoken], page: PubNubHashedPage?), Error>) -> Void)? = nil
+    completion: ((Swift.Result<(receipts: [ReadReceipt], page: PubNubHashedPage?), Error>) -> Void)? = nil
   ) {
     target.fetchReadReceipts(
       limit: limit,

--- a/Sources/Entities/ThreadChannelImpl.swift
+++ b/Sources/Entities/ThreadChannelImpl.swift
@@ -391,9 +391,25 @@ extension ThreadChannelImpl: ThreadChannel {
     )
   }
 
-  public func streamReadReceipts(callback: @escaping (([Timetoken: [String]]) -> Void)) -> AutoCloseable {
+  public func streamReadReceipts(callback: @escaping (([String: Timetoken]) -> Void)) -> AutoCloseable {
     target.streamReadReceipts(
       callback: callback
+    )
+  }
+
+  public func fetchReadReceipts(
+    limit: Int? = nil,
+    page: PubNubHashedPage? = nil,
+    filter: String? = nil,
+    sort: [PubNub.MembershipSortField] = [],
+    completion: ((Swift.Result<(receipts: [String: Timetoken], page: PubNubHashedPage?), Error>) -> Void)? = nil
+  ) {
+    target.fetchReadReceipts(
+      limit: limit,
+      page: page,
+      filter: filter,
+      sort: sort,
+      completion: completion
     )
   }
 

--- a/Sources/Entities/ThreadMessageImpl.swift
+++ b/Sources/Entities/ThreadMessageImpl.swift
@@ -85,7 +85,7 @@ extension ThreadMessageImpl: ThreadMessage {
   public var hasThread: Bool { target.hasThread }
   public var type: String { target.type }
   public var files: [File] { target.files }
-  public var reactions: [String: [Action]] { target.reactions }
+  public var reactions: [MessageReaction] { target.reactions }
   public var textLinks: [TextLink]? { target.textLinks }
   public var parentChannelId: String { target.message.parentChannelId }
   public var error: Error? { target.message.error }

--- a/Sources/Entities/User+AsyncAwait.swift
+++ b/Sources/Entities/User+AsyncAwait.swift
@@ -179,6 +179,40 @@ public extension User {
     }
   }
 
+  /// Checks if the user is a member of a specific channel.
+  ///
+  /// - Parameter channelId: Unique identifier of the channel to check
+  /// - Returns: A `Bool` value indicating whether the user is a member of the specified channel
+  func isMemberOf(channelId: String) async throws -> Bool {
+    try await withCheckedThrowingContinuation { continuation in
+      isMemberOf(channelId: channelId) {
+        switch $0 {
+        case let .success(isMember):
+          continuation.resume(returning: isMember)
+        case let .failure(error):
+          continuation.resume(throwing: error)
+        }
+      }
+    }
+  }
+
+  /// Retrieves the user's membership for a specific channel.
+  ///
+  /// - Parameter channelId: Unique identifier of the channel
+  /// - Returns: The user's ``Membership`` for the specified channel, or `nil` if not a member
+  func getMembership(channelId: String) async throws -> ChatType.ChatMembershipType? {
+    try await withCheckedThrowingContinuation { continuation in
+      getMembership(channelId: channelId) {
+        switch $0 {
+        case let .success(membership):
+          continuation.resume(returning: membership)
+        case let .failure(error):
+          continuation.resume(throwing: error)
+        }
+      }
+    }
+  }
+
   /// Receives updates on a single User object.
   ///
   /// - Returns: An asynchronous stream that produces updates when the current ``User`` is edited or `nil` if the user was removed.

--- a/Sources/Entities/User.swift
+++ b/Sources/Entities/User.swift
@@ -152,6 +152,30 @@ public protocol User: CustomStringConvertible {
     completion: ((Swift.Result<(memberships: [ChatType.ChatMembershipType], page: PubNubHashedPage?), Error>) -> Void)?
   )
 
+  /// Checks if the user is a member of a specific channel.
+  ///
+  /// - Parameters:
+  ///   - channelId: Unique identifier of the channel to check
+  ///   - completion: The async `Result` of the method call
+  ///     - **Success**: A `Bool` value indicating whether the user is a member of the specified channel
+  ///     - **Failure**: An `Error` describing the failure
+  func isMemberOf(
+    channelId: String,
+    completion: ((Swift.Result<Bool, Error>) -> Void)?
+  )
+
+  /// Retrieves the user's membership for a specific channel.
+  ///
+  /// - Parameters:
+  ///   - channelId: Unique identifier of the channel
+  ///   - completion: The async `Result` of the method call
+  ///     - **Success**: The user's ``Membership`` for the specified channel, or `nil` if not a member
+  ///     - **Failure**: An `Error` describing the failure
+  func getMembership(
+    channelId: String,
+    completion: ((Swift.Result<ChatType.ChatMembershipType?, Error>) -> Void)?
+  )
+
   /// Receives updates on a single User object.
   ///
   /// - Important: Keep a strong reference to the returned ``AutoCloseable`` object as long as you want to receive updates. If ``AutoCloseable`` is deallocated,

--- a/Sources/Entities/UserImpl.swift
+++ b/Sources/Entities/UserImpl.swift
@@ -244,6 +244,42 @@ extension UserImpl: User {
     }
   }
 
+  public func isMemberOf(
+    channelId: String,
+    completion: ((Swift.Result<Bool, Error>) -> Void)? = nil
+  ) {
+    user.isMemberOf(
+      channelId: channelId
+    ).async(caller: self) { (result: FutureResult<UserImpl, Bool>) in
+      switch result.result {
+      case let .success(isMember):
+        completion?(.success(isMember))
+      case let .failure(error):
+        completion?(.failure(error))
+      }
+    }
+  }
+
+  public func getMembership(
+    channelId: String,
+    completion: ((Swift.Result<MembershipImpl?, Error>) -> Void)? = nil
+  ) {
+    user.getMembership(
+      channelId: channelId
+    ).async(caller: self) { (result: FutureResult<UserImpl, PubNubChat.Membership?>) in
+      switch result.result {
+      case let .success(membership):
+        if let membership {
+          completion?(.success(MembershipImpl(membership: membership, chat: result.caller.chat)))
+        } else {
+          completion?(.success(nil))
+        }
+      case let .failure(error):
+        completion?(.failure(error))
+      }
+    }
+  }
+
   public func streamUpdates(callback: @escaping ((UserImpl?) -> Void)) -> AutoCloseable {
     AutoCloseableImpl(
       user.streamUpdates { [weak self] in

--- a/Sources/Extensions/Dictionary.swift
+++ b/Sources/Extensions/Dictionary.swift
@@ -109,3 +109,14 @@ extension [PubNubSwiftChatSDK.ChannelType: Int64] {
     )
   }
 }
+
+extension [PubNubSwiftChatSDK.ChannelType: Bool] {
+  func transform() -> [PubNubChat.ChannelType: KotlinBoolean] {
+    ChatConfigurationKt.EmitReadReceiptEvents(
+      direct: self[.direct] ?? false,
+      group: self[.group] ?? false,
+      public: self[.public] ?? false,
+      unknown: self[.unknown] ?? false
+    )
+  }
+}

--- a/Sources/Extensions/PubNubChat+Transform.swift
+++ b/Sources/Extensions/PubNubChat+Transform.swift
@@ -79,3 +79,18 @@ extension [PubNubChat.MessageReaction] {
     map { $0.transform() }
   }
 }
+
+extension PubNubChat.ReadReceipt {
+  func transform() -> ReadReceipt {
+    ReadReceipt(
+      userId: userId,
+      lastReadTimetoken: Timetoken(lastReadTimetoken)
+    )
+  }
+}
+
+extension [PubNubChat.ReadReceipt] {
+  func transform() -> [ReadReceipt] {
+    map { $0.transform() }
+  }
+}

--- a/Sources/Extensions/PubNubChat+Transform.swift
+++ b/Sources/Extensions/PubNubChat+Transform.swift
@@ -63,3 +63,19 @@ extension PubNubChat.EventContent.TextMessageContent {
     )
   }
 }
+
+extension PubNubChat.MessageReaction {
+  func transform() -> MessageReaction {
+    MessageReaction(
+      value: value,
+      isMine: isMine,
+      userIds: userIds
+    )
+  }
+}
+
+extension [PubNubChat.MessageReaction] {
+  func transform() -> [MessageReaction] {
+    map { $0.transform() }
+  }
+}

--- a/Sources/Models/MessageReaction.swift
+++ b/Sources/Models/MessageReaction.swift
@@ -1,0 +1,30 @@
+//
+//  MessageReaction.swift
+//
+//  Copyright (c) PubNub Inc.
+//  All rights reserved.
+//
+//  This source code is licensed under the license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+
+/// Represents a reaction attached to a message.
+public struct MessageReaction {
+  /// The emoji or reaction string (e.g., "👍", "❤️", "😂")
+  public let value: String
+  /// Whether the current user added this reaction
+  public let isMine: Bool
+  /// List of all user IDs who added this reaction
+  public let userIds: [String]
+
+  /// The number of users who added this reaction
+  public var count: Int { userIds.count }
+
+  init(value: String, isMine: Bool, userIds: [String]) {
+    self.value = value
+    self.isMine = isMine
+    self.userIds = userIds
+  }
+}

--- a/Sources/Models/MessageReaction.swift
+++ b/Sources/Models/MessageReaction.swift
@@ -21,10 +21,4 @@ public struct MessageReaction {
 
   /// The number of users who added this reaction
   public var count: Int { userIds.count }
-
-  init(value: String, isMine: Bool, userIds: [String]) {
-    self.value = value
-    self.isMine = isMine
-    self.userIds = userIds
-  }
 }

--- a/Sources/Models/ReadReceipt.swift
+++ b/Sources/Models/ReadReceipt.swift
@@ -1,0 +1,20 @@
+//
+//  ReadReceipt.swift
+//
+//  Copyright (c) PubNub Inc.
+//  All rights reserved.
+//
+//  This source code is licensed under the license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import PubNubSDK
+
+/// Represents a read receipt for a single user on a channel, indicating how far they have read.
+public struct ReadReceipt {
+  /// The user ID who read the messages
+  public let userId: String
+  /// The timetoken of the last message the user has read
+  public let lastReadTimetoken: Timetoken
+}

--- a/Tests/AsyncAwait/ChannelAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/ChannelAsyncIntegrationTests.swift
@@ -522,11 +522,11 @@ class ChannelAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
   }
 
   func testChannelAsync_FetchReadReceipts() async throws {
-    let anotherUser = try await chat.createUser(
-      user: UserImpl(chat: chat, id: randomString())
-    )
+    let anotherUser = try await chat.createUser(user: UserImpl(chat: chat, id: randomString()))
     let membership = try await channel.invite(user: chat.currentUser)
+
     try await Task.sleep(nanoseconds: 1_000_000_000)
+
     let anotherMembership = try await channel.invite(user: anotherUser)
 
     let timetoken = try XCTUnwrap(membership.lastReadMessageTimetoken)
@@ -534,10 +534,14 @@ class ChannelAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
     let currentUserId = chat.currentUser.id
     let anotherUserId = anotherUser.id
 
-    let (receipts, _) = try await channel.fetchReadReceipts()
+    let response = try await channel.fetchReadReceipts()
+    let readReceipt = response.receipts.first { $0.userId == chat.currentUser.id }
+    let secondReadReceipt = response.receipts.first { $0.userId == anotherUserId }
 
-    XCTAssertEqual(receipts[currentUserId], timetoken)
-    XCTAssertEqual(receipts[anotherUserId], secondTimetoken)
+    XCTAssertEqual(readReceipt?.userId, currentUserId)
+    XCTAssertEqual(readReceipt?.lastReadTimetoken, timetoken)
+    XCTAssertEqual(secondReadReceipt?.userId, anotherUserId)
+    XCTAssertEqual(readReceipt?.lastReadTimetoken, secondTimetoken)
 
     addTeardownBlock { [unowned self] in
       _ = try? await chat.deleteUser(id: anotherUserId)

--- a/Tests/AsyncAwait/ChannelAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/ChannelAsyncIntegrationTests.swift
@@ -316,6 +316,56 @@ class ChannelAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
     }
   }
 
+  func testChannelAsync_HasMember() async throws {
+    let someUser = try await chat.createUser(id: randomString())
+    let membership = try await channel.invite(user: someUser)
+    let hasMember = try await channel.hasMember(userId: someUser.id)
+    
+    XCTAssertTrue(hasMember)
+
+    addTeardownBlock { [unowned self] in
+      _ = try? await chat.deleteUser(id: someUser.id)
+      _ = try? await membership.channel.leave()
+    }
+  }
+
+  func testChannelAsync_HasMember_NotMember() async throws {
+    let someUser = try await chat.createUser(id: randomString())
+    let hasMember = try await channel.hasMember(userId: someUser.id)
+    
+    XCTAssertFalse(hasMember)
+
+    addTeardownBlock { [unowned self] in
+      _ = try? await chat.deleteUser(id: someUser.id)
+    }
+  }
+
+  func testChannelAsync_GetMember() async throws {
+    let someUser = try await chat.createUser(id: randomString())
+    let membership = try await channel.invite(user: someUser)
+    let retrievedMembership = try await channel.getMember(userId: someUser.id)
+
+    XCTAssertNotNil(retrievedMembership)
+    XCTAssertEqual(retrievedMembership?.user.id, someUser.id)
+    XCTAssertEqual(retrievedMembership?.channel.id, channel.id)
+
+    addTeardownBlock { [unowned self] in
+      _ = try? await chat.deleteUser(id: someUser.id)
+      _ = try? await membership.channel.leave()
+    }
+  }
+
+  func testChannelAsync_GetMember_NotMember() async throws {
+    let someUser = try await chat.createUser(user: UserImpl(chat: chat, id: randomString()))
+    let membership = try await channel.getMember(userId: someUser.id)
+
+    XCTAssertNil(membership)
+
+    addTeardownBlock { [unowned self] in
+      _ = try? await chat.deleteUser(id: someUser.id)
+    }
+  }
+
   func testChannelAsync_Connect() async throws {
     let expectation = XCTestExpectation(description: "Connect")
     expectation.assertForOverFulfill = true

--- a/Tests/AsyncAwait/ChannelAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/ChannelAsyncIntegrationTests.swift
@@ -507,10 +507,8 @@ class ChannelAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
 
     let task = Task {
       for await readReceipt in channel.streamReadReceipts() {
-        XCTAssertEqual(readReceipt[timetoken]?.count, 1)
-        XCTAssertEqual(readReceipt[timetoken]?.first, currentUserId)
-        XCTAssertEqual(readReceipt[secondTimetoken]?.count, 1)
-        XCTAssertEqual(readReceipt[secondTimetoken]?.first, anotherUserId)
+        XCTAssertEqual(readReceipt[currentUserId], timetoken)
+        XCTAssertEqual(readReceipt[anotherUserId], secondTimetoken)
         expectation.fulfill()
       }
     }
@@ -519,6 +517,29 @@ class ChannelAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
 
     addTeardownBlock { [unowned self] in
       task.cancel()
+      _ = try? await chat.deleteUser(id: anotherUserId)
+    }
+  }
+
+  func testChannelAsync_FetchReadReceipts() async throws {
+    let anotherUser = try await chat.createUser(
+      user: UserImpl(chat: chat, id: randomString())
+    )
+    let membership = try await channel.invite(user: chat.currentUser)
+    try await Task.sleep(nanoseconds: 1_000_000_000)
+    let anotherMembership = try await channel.invite(user: anotherUser)
+
+    let timetoken = try XCTUnwrap(membership.lastReadMessageTimetoken)
+    let secondTimetoken = try XCTUnwrap(anotherMembership.lastReadMessageTimetoken)
+    let currentUserId = chat.currentUser.id
+    let anotherUserId = anotherUser.id
+
+    let (receipts, _) = try await channel.fetchReadReceipts()
+
+    XCTAssertEqual(receipts[currentUserId], timetoken)
+    XCTAssertEqual(receipts[anotherUserId], secondTimetoken)
+
+    addTeardownBlock { [unowned self] in
       _ = try? await chat.deleteUser(id: anotherUserId)
     }
   }

--- a/Tests/AsyncAwait/ChannelAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/ChannelAsyncIntegrationTests.swift
@@ -320,7 +320,7 @@ class ChannelAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
     let someUser = try await chat.createUser(id: randomString())
     let membership = try await channel.invite(user: someUser)
     let hasMember = try await channel.hasMember(userId: someUser.id)
-    
+
     XCTAssertTrue(hasMember)
 
     addTeardownBlock { [unowned self] in
@@ -332,7 +332,7 @@ class ChannelAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
   func testChannelAsync_HasMember_NotMember() async throws {
     let someUser = try await chat.createUser(id: randomString())
     let hasMember = try await channel.hasMember(userId: someUser.id)
-    
+
     XCTAssertFalse(hasMember)
 
     addTeardownBlock { [unowned self] in

--- a/Tests/AsyncAwait/ChannelAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/ChannelAsyncIntegrationTests.swift
@@ -490,34 +490,28 @@ class ChannelAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
 
   func testChannelAsync_StreamReadReceipts() async throws {
     let expectation = expectation(description: "StreamReadReceipts")
-    expectation.assertForOverFulfill = true
     expectation.expectedFulfillmentCount = 1
+    expectation.assertForOverFulfill = true
 
-    let anotherUser = try await chat.createUser(user: UserImpl(chat: chat, id: randomString()))
-    try await Task.sleep(nanoseconds: 3_000_000_000)
-
-    let membership = try await channel.invite(user: chat.currentUser)
-    try await Task.sleep(nanoseconds: 1_000_000_000)
-    let anotherMembership = try await channel.invite(user: anotherUser)
-
-    let timetoken = try XCTUnwrap(membership.lastReadMessageTimetoken)
-    let secondTimetoken = try XCTUnwrap(anotherMembership.lastReadMessageTimetoken)
+    let joinResult = try await channel.join()
+    let membership = joinResult.membership
     let currentUserId = chat.currentUser.id
-    let anotherUserId = anotherUser.id
+    let messageTimetoken = try await channel.sendText(text: "Read receipt test")
 
     let task = Task {
       for await readReceipt in channel.streamReadReceipts() {
-        XCTAssertEqual(readReceipt[currentUserId], timetoken)
-        XCTAssertEqual(readReceipt[anotherUserId], secondTimetoken)
+        XCTAssertEqual(readReceipt.userId, currentUserId)
+        XCTAssertEqual(readReceipt.lastReadTimetoken, messageTimetoken)
         expectation.fulfill()
       }
     }
 
+    _ = try await membership.setLastReadMessageTimetoken(messageTimetoken)
+
     await fulfillment(of: [expectation], timeout: 6)
 
-    addTeardownBlock { [unowned self] in
+    addTeardownBlock {
       task.cancel()
-      _ = try? await chat.deleteUser(id: anotherUserId)
     }
   }
 

--- a/Tests/AsyncAwait/MessageAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/MessageAsyncIntegrationTests.swift
@@ -176,10 +176,12 @@ class MessageAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
     try await Task.sleep(nanoseconds: 3_000_000_000)
 
     let updatedMessage = try await testMessage.toggleReaction(reaction: ":+1")
-    let reaction = try XCTUnwrap(updatedMessage.reactions[":+1"]?.first)
-    let userId = reaction.uuid
+    let reaction = try XCTUnwrap(updatedMessage.reactions.first)
 
-    XCTAssertEqual(userId, chat.currentUser.id)
+    XCTAssertEqual(reaction.value, ":+1")
+    XCTAssertTrue(reaction.isMine)
+    XCTAssertEqual(reaction.count, 1)
+    XCTAssertTrue(reaction.userIds.contains(chat.currentUser.id))
   }
 
   func testAsyncMessage_Restore() async throws {

--- a/Tests/AsyncAwait/ThreadMessageAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/ThreadMessageAsyncIntegrationTests.swift
@@ -144,13 +144,12 @@ class ThreadMessageaAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
 
   func testThreadMessageAsync_ToggleReaction() async throws {
     let updateMessage = try await threadMessage.toggleReaction(reaction: ":+1")
-    let reaction = try XCTUnwrap(updateMessage.reactions[":+1"]?.first)
-    let userId = reaction.uuid
+    let reaction = try XCTUnwrap(updateMessage.reactions.first)
 
-    XCTAssertEqual(
-      userId,
-      chat.currentUser.id
-    )
+    XCTAssertEqual(reaction.value, ":+1")
+    XCTAssertTrue(reaction.isMine)
+    XCTAssertEqual(reaction.count, 1)
+    XCTAssertTrue(reaction.userIds.contains(chat.currentUser.id))
   }
 
   func testThreadMessageAsync_StreamUpdates() async throws {

--- a/Tests/AsyncAwait/UserAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/UserAsyncIntegrationTests.swift
@@ -201,7 +201,7 @@ class UserAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
     let channel = try await chat.createChannel(id: randomString())
     let membership = try await channel.invite(user: chat.currentUser)
     let isMember = try await chat.currentUser.isMemberOf(channelId: channel.id)
-    
+
     XCTAssertTrue(isMember)
 
     addTeardownBlock { [unowned self] in
@@ -213,7 +213,7 @@ class UserAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
   func testUserAsync_IsMemberOf_NotMember() async throws {
     let channel = try await chat.createChannel(id: randomString())
     let isMember = try await chat.currentUser.isMemberOf(channelId: channel.id)
-    
+
     XCTAssertFalse(isMember)
 
     addTeardownBlock { [unowned self] in
@@ -239,7 +239,7 @@ class UserAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
   func testUserAsync_GetMembership_NotMember() async throws {
     let channel = try await chat.createChannel(id: randomString())
     let membership = try await chat.currentUser.getMembership(channelId: channel.id)
-    
+
     XCTAssertNil(membership)
 
     addTeardownBlock { [unowned self] in

--- a/Tests/AsyncAwait/UserAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/UserAsyncIntegrationTests.swift
@@ -197,6 +197,57 @@ class UserAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
     }
   }
 
+  func testUserAsync_IsMemberOf() async throws {
+    let channel = try await chat.createChannel(id: randomString())
+    let membership = try await channel.invite(user: chat.currentUser)
+    let isMember = try await chat.currentUser.isMemberOf(channelId: channel.id)
+    
+    XCTAssertTrue(isMember)
+
+    addTeardownBlock { [unowned self] in
+      _ = try? await chat.deleteChannel(id: channel.id)
+      _ = try? await membership.channel.leave()
+    }
+  }
+
+  func testUserAsync_IsMemberOf_NotMember() async throws {
+    let channel = try await chat.createChannel(id: randomString())
+    let isMember = try await chat.currentUser.isMemberOf(channelId: channel.id)
+    
+    XCTAssertFalse(isMember)
+
+    addTeardownBlock { [unowned self] in
+      _ = try? await chat.deleteChannel(id: channel.id)
+    }
+  }
+
+  func testUserAsync_GetMembership() async throws {
+    let channel = try await chat.createChannel(id: randomString())
+    let membership = try await channel.invite(user: chat.currentUser)
+    let retrievedMembership = try await chat.currentUser.getMembership(channelId: channel.id)
+
+    XCTAssertNotNil(retrievedMembership)
+    XCTAssertEqual(retrievedMembership?.user.id, chat.currentUser.id)
+    XCTAssertEqual(retrievedMembership?.channel.id, channel.id)
+
+    addTeardownBlock { [unowned self] in
+      _ = try? await chat.deleteChannel(id: channel.id)
+      _ = try? await membership.channel.leave()
+    }
+  }
+
+  func testUserAsync_GetMembership_NotMember() async throws {
+    let channel = try await chat.createChannel(id: randomString())
+    let membership = try await chat.currentUser.getMembership(channelId: channel.id)
+    
+    XCTAssertNil(membership)
+
+    addTeardownBlock { [unowned self] in
+      _ = try? await chat.deleteChannel(id: channel.id)
+      _ = try? await membership?.channel.leave()
+    }
+  }
+
   func testUserAsync_StreamUpdates() async throws {
     let expectation = expectation(description: "StreamUpdates")
     expectation.assertForOverFulfill = true

--- a/Tests/ChannelIntegrationTests.swift
+++ b/Tests/ChannelIntegrationTests.swift
@@ -110,7 +110,6 @@ class ChannelIntegrationTests: BaseClosureIntegrationTestCase {
       )
     }
 
-    XCTAssertFalse(retrievedChannel?.active ?? true)
     XCTAssertEqual(retrievedChannel?.id, someChannel.id)
 
     addTeardownBlock { [unowned self] in

--- a/Tests/ChannelIntegrationTests.swift
+++ b/Tests/ChannelIntegrationTests.swift
@@ -743,49 +743,35 @@ class ChannelIntegrationTests: BaseClosureIntegrationTestCase {
     expectation.assertForOverFulfill = true
     expectation.expectedFulfillmentCount = 1
 
-    let anotherUser = try awaitResultValue {
-      chat.createUser(
-        user: UserImpl(chat: chat, id: randomString()),
-        completion: $0
-      )
-    }
-    let membership = try awaitResultValue(delay: 3) {
-      channel.invite(
-        user: chat.currentUser,
-        completion: $0
-      )
-    }
-    let anotherMembership = try awaitResultValue(delay: 1) {
-      channel.invite(
-        user: anotherUser,
-        completion: $0
-      )
-    }
-
-    let timetoken = try XCTUnwrap(membership.lastReadMessageTimetoken)
-    let secondTimetoken = try XCTUnwrap(anotherMembership.lastReadMessageTimetoken)
+    let joinResult = try awaitResultValue { channel.join(completion: $0) }
+    let membership = joinResult.membership
     let currentUserId = chat.currentUser.id
-    let anotherUserId = anotherUser.id
 
-    let closeable = channel.streamReadReceipts {
-      XCTAssertEqual($0[currentUserId], timetoken)
-      XCTAssertEqual($0[anotherUserId], secondTimetoken)
+    let messageTimetoken = try awaitResultValue {
+      channel.sendText(
+        text: "Read receipt test",
+        completion: $0
+      )
+    }
+
+    let closeable = channel.streamReadReceipts { readReceipt in
+      XCTAssertEqual(readReceipt.userId, currentUserId)
+      XCTAssertEqual(readReceipt.lastReadTimetoken, messageTimetoken)
       expectation.fulfill()
     }
 
-    wait(
-      for: [expectation],
-      timeout: 6
-    )
+    _ = try awaitResultValue(delay: 1) {
+      membership.setLastReadMessageTimetoken(
+        messageTimetoken,
+        completion: $0
+      )
+    }
 
-    addTeardownBlock { [unowned self] in
+    wait(for: [expectation], timeout: 6)
+
+    addTeardownBlock {
       closeable.close()
-      try awaitResult {
-        chat.deleteUser(
-          id: anotherUserId,
-          completion: $0
-        )
-      }
+      joinResult.disconnect?.close()
     }
   }
 

--- a/Tests/ChannelIntegrationTests.swift
+++ b/Tests/ChannelIntegrationTests.swift
@@ -768,10 +768,8 @@ class ChannelIntegrationTests: BaseClosureIntegrationTestCase {
     let anotherUserId = anotherUser.id
 
     let closeable = channel.streamReadReceipts {
-      XCTAssertEqual($0[timetoken]?.count, 1)
-      XCTAssertEqual($0[timetoken]?.first, currentUserId)
-      XCTAssertEqual($0[secondTimetoken]?.count, 1)
-      XCTAssertEqual($0[secondTimetoken]?.first, anotherUserId)
+      XCTAssertEqual($0[currentUserId], timetoken)
+      XCTAssertEqual($0[anotherUserId], secondTimetoken)
       expectation.fulfill()
     }
 

--- a/Tests/MessageIntegrationTests.swift
+++ b/Tests/MessageIntegrationTests.swift
@@ -359,10 +359,12 @@ final class MessageIntegrationTests: BaseClosureIntegrationTestCase {
       )
     }
 
-    let reaction = try XCTUnwrap(result.reactions[":+1"]?.first)
-    let userId = reaction.uuid
+    let reaction = try XCTUnwrap(result.reactions.first)
 
-    XCTAssertEqual(userId, chat.currentUser.id)
+    XCTAssertEqual(reaction.value, ":+1")
+    XCTAssertTrue(reaction.isMine)
+    XCTAssertEqual(reaction.count, 1)
+    XCTAssertTrue(reaction.userIds.contains(chat.currentUser.id))
   }
 
   func testMessage_StreamUpdates() throws {

--- a/Tests/ThreadMessageIntegrationTests.swift
+++ b/Tests/ThreadMessageIntegrationTests.swift
@@ -228,13 +228,12 @@ class ThreadMessageIntegrationTests: BaseClosureIntegrationTestCase {
       )
     }
 
-    let reaction = try XCTUnwrap(result.reactions[":+1"]?.first)
-    let userId = reaction.uuid
+    let reaction = try XCTUnwrap(result.reactions.first)
 
-    XCTAssertEqual(
-      userId,
-      chat.currentUser.id
-    )
+    XCTAssertEqual(reaction.value, ":+1")
+    XCTAssertTrue(reaction.isMine)
+    XCTAssertEqual(reaction.count, 1)
+    XCTAssertTrue(reaction.userIds.contains(chat.currentUser.id))
   }
 
   func testThreadMessage_StreamUpdates() throws {


### PR DESCRIPTION
refactor: Introduce MessageReaction type for clearer and more intuitive access to reactions
feat: Introduce membership-oriented methods directly on Channel and User entities
refactor: Improve the `streamReadReceipts` method and introduce `fetchReadReceipts`