### PR TITLE
Chat SDK changes

### DIFF
--- a/PubNubSwiftChatSDK.xcodeproj/project.pbxproj
+++ b/PubNubSwiftChatSDK.xcodeproj/project.pbxproj
@@ -119,12 +119,13 @@
 		3DB73A7B2C57EA29007FE249 /* ChatImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DB73A7A2C57EA29007FE249 /* ChatImpl.swift */; };
 		3DB73A7D2C57EA94007FE249 /* Timetoken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DB73A7C2C57EA94007FE249 /* Timetoken.swift */; };
 		3DB73A7F2C58CCAE007FE249 /* GetCurrentUserMentionsResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DB73A7E2C58CCAE007FE249 /* GetCurrentUserMentionsResult.swift */; };
-		3DBEDAFC2F59A47300D7BB8F /* PubNubChat in Frameworks */ = {isa = PBXBuildFile; productRef = 3DBEDAFB2F59A47300D7BB8F /* PubNubChat */; };
+		3DCA168C2F631E6100DE8045 /* PubNubChat in Frameworks */ = {isa = PBXBuildFile; productRef = 3DCA168B2F631E6100DE8045 /* PubNubChat */; };
 		3DCF7DFC2CD0FFCC00889326 /* PubNubSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 3DCF7DFB2CD0FFCC00889326 /* PubNubSDK */; };
 		AA00000000000000000001B1 /* ChannelStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000000000001A1 /* ChannelStream.swift */; };
 		AA00000000000000000002B2 /* UserStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000000000002A2 /* UserStream.swift */; };
 		AA00000000000000000003B3 /* MessageStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000000000003A3 /* MessageStream.swift */; };
 		AA00000000000000000004B4 /* MembershipStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000000000004A4 /* MembershipStream.swift */; };
+		AA00000000000000000005B5 /* ChannelGroupStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000000000005A5 /* ChannelGroupStream.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -274,6 +275,7 @@
 		AA00000000000000000002A2 /* UserStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserStream.swift; sourceTree = "<group>"; };
 		AA00000000000000000003A3 /* MessageStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageStream.swift; sourceTree = "<group>"; };
 		AA00000000000000000004A4 /* MembershipStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MembershipStream.swift; sourceTree = "<group>"; };
+		AA00000000000000000005A5 /* ChannelGroupStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelGroupStream.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -289,7 +291,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3DBEDAFC2F59A47300D7BB8F /* PubNubChat in Frameworks */,
+				3DCA168C2F631E6100DE8045 /* PubNubChat in Frameworks */,
 				3DCF7DFC2CD0FFCC00889326 /* PubNubSDK in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -502,6 +504,7 @@
 				3DB5A3162E2F848A001741C8 /* ChannelGroup.swift */,
 				3DB5A3182E2F900B001741C8 /* ChannelGroupImpl.swift */,
 				3DB5A31F2E30D771001741C8 /* ChannelGroup+AsyncAwait.swift */,
+				AA00000000000000000005A5 /* ChannelGroupStream.swift */,
 			);
 			path = Entities;
 			sourceTree = "<group>";
@@ -587,7 +590,7 @@
 			name = PubNubSwiftChatSDK;
 			packageProductDependencies = (
 				3DCF7DFB2CD0FFCC00889326 /* PubNubSDK */,
-				3DBEDAFB2F59A47300D7BB8F /* PubNubChat */,
+				3DCA168B2F631E6100DE8045 /* PubNubChat */,
 			);
 			productName = PubNubChatSDK;
 			productReference = 3DB73A072C4FE13C007FE249 /* PubNubSwiftChatSDK.framework */;
@@ -644,7 +647,7 @@
 			mainGroup = 3DB739FD2C4FE13B007FE249;
 			packageReferences = (
 				3DCF7DFA2CD0FFCC00889326 /* XCRemoteSwiftPackageReference "swift" */,
-				3DBEDAFA2F59A47300D7BB8F /* XCRemoteSwiftPackageReference "kmp-chat" */,
+				3DCA168A2F631E6100DE8045 /* XCRemoteSwiftPackageReference "kmp-chat" */,
 			);
 			productRefGroup = 3DB73A082C4FE13C007FE249 /* Products */;
 			projectDirPath = "";
@@ -790,6 +793,7 @@
 				3DB73A512C539421007FE249 /* InputFile.swift in Sources */,
 				3D842D242C9DC0AA005C0B55 /* ErrorConstants.swift in Sources */,
 				AA00000000000000000001B1 /* ChannelStream.swift in Sources */,
+				AA00000000000000000005B5 /* ChannelGroupStream.swift in Sources */,
 				AA00000000000000000002B2 /* UserStream.swift in Sources */,
 				AA00000000000000000003B3 /* MessageStream.swift in Sources */,
 				AA00000000000000000004B4 /* MembershipStream.swift in Sources */,
@@ -1172,7 +1176,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		3DBEDAFA2F59A47300D7BB8F /* XCRemoteSwiftPackageReference "kmp-chat" */ = {
+		3DCA168A2F631E6100DE8045 /* XCRemoteSwiftPackageReference "kmp-chat" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/pubnub/kmp-chat";
 			requirement = {
@@ -1191,9 +1195,9 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		3DBEDAFB2F59A47300D7BB8F /* PubNubChat */ = {
+		3DCA168B2F631E6100DE8045 /* PubNubChat */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 3DBEDAFA2F59A47300D7BB8F /* XCRemoteSwiftPackageReference "kmp-chat" */;
+			package = 3DCA168A2F631E6100DE8045 /* XCRemoteSwiftPackageReference "kmp-chat" */;
 			productName = PubNubChat;
 		};
 		3DCF7DFB2CD0FFCC00889326 /* PubNubSDK */ = {

--- a/PubNubSwiftChatSDK.xcodeproj/project.pbxproj
+++ b/PubNubSwiftChatSDK.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		3D64DC732F58A58C004AC52B /* Mention.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D64DC722F58A58C004AC52B /* Mention.swift */; };
 		3D64DC742F58A58C004AC52B /* Invite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D64DC712F58A58C004AC52B /* Invite.swift */; };
 		3D64DC762F58A803004AC52B /* Report.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D64DC752F58A803004AC52B /* Report.swift */; };
+		3D64DC772F58A803004AC52B /* CustomEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D64DC782F58A803004AC52B /* CustomEvent.swift */; };
 		3D7062C62D2D4A4F000729E1 /* ChatAsyncIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D7062C52D2D4A4F000729E1 /* ChatAsyncIntegrationTests.swift */; };
 		3D7062C82D2D82A5000729E1 /* User+AsyncAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D7062C72D2D82A5000729E1 /* User+AsyncAwait.swift */; };
 		3D7062CB2D2D8C27000729E1 /* UserAsyncIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D7062C92D2D8BD9000729E1 /* UserAsyncIntegrationTests.swift */; };
@@ -198,6 +199,7 @@
 		3D64DC712F58A58C004AC52B /* Invite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Invite.swift; sourceTree = "<group>"; };
 		3D64DC722F58A58C004AC52B /* Mention.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mention.swift; sourceTree = "<group>"; };
 		3D64DC752F58A803004AC52B /* Report.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Report.swift; sourceTree = "<group>"; };
+		3D64DC782F58A803004AC52B /* CustomEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomEvent.swift; sourceTree = "<group>"; };
 		3D7062C52D2D4A4F000729E1 /* ChatAsyncIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAsyncIntegrationTests.swift; sourceTree = "<group>"; };
 		3D7062C72D2D82A5000729E1 /* User+AsyncAwait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "User+AsyncAwait.swift"; sourceTree = "<group>"; };
 		3D7062C92D2D8BD9000729E1 /* UserAsyncIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAsyncIntegrationTests.swift; sourceTree = "<group>"; };
@@ -510,6 +512,7 @@
 				3D64DC712F58A58C004AC52B /* Invite.swift */,
 				3D64DC722F58A58C004AC52B /* Mention.swift */,
 				3D64DC752F58A803004AC52B /* Report.swift */,
+				3D64DC782F58A803004AC52B /* CustomEvent.swift */,
 				3D2CA23B2C5B9E51008D2284 /* Action.swift */,
 				3DB2A8BA2C8099F300167058 /* EventContent.swift */,
 				3DB2A8BC2C809A1400167058 /* ChatError.swift */,
@@ -757,6 +760,7 @@
 				3DB49E212C761BD1006356ED /* AutoCloseable.swift in Sources */,
 				3DB73A532C53A20C007FE249 /* MessageImpl.swift in Sources */,
 				3D64DC762F58A803004AC52B /* Report.swift in Sources */,
+				3D64DC772F58A803004AC52B /* CustomEvent.swift in Sources */,
 				3D1CE5232D79DED800617200 /* String+Helpers.swift in Sources */,
 				3DB73A672C57A8C5007FE249 /* CreateGroupConversationResult.swift in Sources */,
 				3DB2A8B52C807E2A00167058 /* MembershipImpl.swift in Sources */,

--- a/Sources/Entities/BaseChannel.swift
+++ b/Sources/Entities/BaseChannel.swift
@@ -728,6 +728,47 @@ final class BaseChannel<C: PubNubChat.Channel_, M: PubNubChat.Message>: Channel 
     )
   }
 
+  func emitCustomEvent(
+    payload: [String: JSONCodable],
+    messageType: String?,
+    storeInHistory: Bool,
+    completion: ((Swift.Result<Timetoken, Error>) -> Void)?
+  ) {
+    channel.emitCustomEvent(
+      payload: payload,
+      messageType: messageType,
+      storeInHistory: storeInHistory
+    ).async(caller: self) { (result: FutureResult<BaseChannel, PubNubChat.PNPublishResult>) in
+      switch result.result {
+      case let .success(response):
+        completion?(.success(Timetoken(response.timetoken)))
+      case let .failure(error):
+        completion?(.failure(error))
+      }
+    }
+  }
+
+  func onCustomEvent(
+    messageType: String?,
+    callback: @escaping (CustomEvent) -> Void
+  ) -> AutoCloseable {
+    AutoCloseableImpl(
+      channel.onCustomEvent(messageType: messageType) { [weak self] in
+        if self != nil {
+          callback(
+            CustomEvent(
+              timetoken: Timetoken($0.timetoken),
+              userId: $0.userId,
+              type: $0.type,
+              payload: ($0.payload as? [String: Any])?.compactMapValues { AnyJSON($0) } ?? [:]
+            )
+          )
+        }
+      },
+      owner: self
+    )
+  }
+
   func createMessageDraft(
     userSuggestionSource: UserSuggestionSource,
     isTypingIndicatorTriggered: Bool,

--- a/Sources/Entities/BaseChannel.swift
+++ b/Sources/Entities/BaseChannel.swift
@@ -348,20 +348,18 @@ final class BaseChannel<C: PubNubChat.Channel_, M: PubNubChat.Message>: Channel 
 
   func join(
     custom: [String: JSONCodableScalar]?,
-    callback: ((ChatType.ChatMessageType) -> Void)?,
-    completion: ((Swift.Result<(membership: MembershipImpl, disconnect: AutoCloseable?), Error>) -> Void)?
+    status: String?,
+    type: String?,
+    completion: ((Swift.Result<ChatType.ChatMembershipType, Error>) -> Void)?
   ) {
-    channel.join(custom: custom?.asCustomObject(), callback: { [weak self] in
-      if let self = self {
-        callback?(MessageImpl(message: $0, chat: self.chat))
-      }
-    }).async(caller: self) { (result: FutureResult<BaseChannel, PubNubChat.JoinResult>) in
+    channel.join(
+      status: status,
+      type: type,
+      custom: custom?.asCustomObject()
+    ).async(caller: self) { (result: FutureResult<BaseChannel, PubNubChat.Membership>) in
       switch result.result {
-      case let .success(joinRes):
-        completion?(.success((
-          membership: MembershipImpl(membership: joinRes.membership, chat: result.caller.chat),
-          disconnect: AutoCloseableImpl(joinRes.disconnect, owner: result.caller)
-        )))
+      case let .success(membership):
+        completion?(.success(MembershipImpl(membership: membership, chat: result.caller.chat)))
       case let .failure(error):
         completion?(.failure(error))
       }

--- a/Sources/Entities/Channel+AsyncAwait.swift
+++ b/Sources/Entities/Channel+AsyncAwait.swift
@@ -379,33 +379,24 @@ public extension Channel {
     }
   }
 
-  /// Connects a user to the ``Channel`` and sets membership - this way, the chat user can both watch the channel's content and be its full-fledged member.
+  /// Sets the caller's membership on this channel.
   ///
   /// - Parameters:
   ///   - custom: Any custom properties or metadata associated with the channel-user membership in the form of key-value pairs
-  /// - Returns: A `Tuple` containing the user's membership in the channel, and an asynchronous stream that produces a new value every time a new message is published on the current channel
+  ///   - status: Optional membership status value
+  ///   - type: Optional membership type value
+  /// - Returns: The caller's membership in the channel
   @discardableResult
   func join(
-    custom: [String: JSONCodableScalar]? = nil
-  ) async throws -> (
-    membership: ChatType.ChatMembershipType,
-    messagesStream: AsyncStream<ChatType.ChatMessageType>
-  ) {
-    let messagesStream = AsyncStream { continuation in
-      let autoCloseable = connect {
-        continuation.yield($0)
-      }
-      continuation.onTermination = { _ in
-        autoCloseable.close()
-      }
-    }
-
+    custom: [String: JSONCodableScalar]? = nil,
+    status: String? = nil,
+    type: String? = nil
+  ) async throws -> ChatType.ChatMembershipType {
     return try await withCheckedThrowingContinuation { continuation in
-      join(custom: custom, callback: nil) {
+      join(custom: custom, status: status, type: type) {
         switch $0 {
-        case let .success(joinResult):
-          joinResult.disconnect?.close()
-          continuation.resume(returning: (membership: joinResult.membership, messagesStream: messagesStream))
+        case let .success(membership):
+          continuation.resume(returning: membership)
         case let .failure(error):
           continuation.resume(throwing: error)
         }

--- a/Sources/Entities/Channel+AsyncAwait.swift
+++ b/Sources/Entities/Channel+AsyncAwait.swift
@@ -675,6 +675,35 @@ public extension Channel {
     }
   }
 
+  /// Emits a custom event on this channel.
+  ///
+  /// - Parameters:
+  ///   - payload: Arbitrary key-value payload to publish
+  ///   - messageType: Optional custom message type used for filtering
+  ///   - storeInHistory: If true, event is stored in Message Persistence (if enabled)
+  /// - Returns: The timetoken of the emitted event
+  @discardableResult
+  func emitCustomEvent(
+    payload: [String: JSONCodable],
+    messageType: String? = nil,
+    storeInHistory: Bool = true
+  ) async throws -> Timetoken {
+    try await withCheckedThrowingContinuation { continuation in
+      emitCustomEvent(
+        payload: payload,
+        messageType: messageType,
+        storeInHistory: storeInHistory
+      ) {
+        switch $0 {
+        case let .success(timetoken):
+          continuation.resume(returning: timetoken)
+        case let .failure(error):
+          continuation.resume(throwing: error)
+        }
+      }
+    }
+  }
+
   /// As an admin of your chat app, monitor all events emitted when someone reports an offensive message.
   @available(*, deprecated, message: "Use `stream.reports()` instead")
   func streamMessageReports() -> AsyncStream<EventWrapper<EventContent.Report>> {

--- a/Sources/Entities/Channel.swift
+++ b/Sources/Entities/Channel.swift
@@ -340,6 +340,36 @@ public protocol Channel: CustomStringConvertible {
     callback: @escaping (MessageType) -> Void
   ) -> AutoCloseable
 
+  /// Emits a custom event on this channel.
+  ///
+  /// - Parameters:
+  ///   - payload: Arbitrary key-value payload to publish
+  ///   - messageType: Optional custom message type used for filtering
+  ///   - storeInHistory: If true, event is stored in Message Persistence (if enabled)
+  ///   - completion: The async `Result` of the method call
+  ///     - **Success**: The timetoken of the emitted event
+  ///     - **Failure**: An `Error` describing the failure
+  func emitCustomEvent(
+    payload: [String: JSONCodable],
+    messageType: String?,
+    storeInHistory: Bool,
+    completion: ((Swift.Result<Timetoken, Error>) -> Void)?
+  )
+
+  /// Listens for custom events on this channel.
+  ///
+  /// - Important: Keep a strong reference to the returned ``AutoCloseable`` object as long as you want to receive updates. If ``AutoCloseable`` is deallocated,
+  /// the stream will be canceled, and no further items will be produced. You can also stop receiving updates manually by calling ``AutoCloseable/close()``.
+  ///
+  /// - Parameters:
+  ///   - messageType: Optional custom message type filter. If nil, all custom message types are accepted
+  ///   - callback: A closure invoked for each matching custom event
+  /// - Returns: An ``AutoCloseable`` that stops listening when closed
+  func onCustomEvent(
+    messageType: String?,
+    callback: @escaping (CustomEvent) -> Void
+  ) -> AutoCloseable
+
   /// Sets the caller's membership on this channel.
   ///
   /// - Parameters:

--- a/Sources/Entities/Channel.swift
+++ b/Sources/Entities/Channel.swift
@@ -340,18 +340,21 @@ public protocol Channel: CustomStringConvertible {
     callback: @escaping (MessageType) -> Void
   ) -> AutoCloseable
 
-  /// Connects a user to the ``Channel`` and sets membership - this way, the chat user can both watch the channel's ontent and be its full-fledged member.
+  /// Sets the caller's membership on this channel.
   ///
   /// - Parameters:
   ///   - custom: Any custom properties or metadata associated with the channel-user membership in the form of key-value pairs
-  ///   - callback: Defines the custom behavior to be executed whenever a message is received on the [Channel]
+  ///   - status: Optional membership status value
+  ///   - type: Optional membership type value
   ///   - completion: The async `Result` of the method call
   ///     - **Success**: A `Tuple` containing the user's ``Membership`` in the channel, and ``AutoCloseable`` that  lets you stop listening to new channel messages while remaining a channel membership
   ///     - **Failure**: An `Error` describing the failure
+  /// - Returns: The caller's membership in the channel
   func join(
     custom: [String: JSONCodableScalar]?,
-    callback: ((ChatType.ChatMessageType) -> Void)?,
-    completion: ((Swift.Result<(membership: ChatType.ChatMembershipType, disconnect: AutoCloseable?), Error>) -> Void)?
+    status: String?,
+    type: String?,
+    completion: ((Swift.Result<ChatType.ChatMembershipType, Error>) -> Void)?
   )
 
   /// Remove user's channel membership.

--- a/Sources/Entities/ChannelGroup+AsyncAwait.swift
+++ b/Sources/Entities/ChannelGroup+AsyncAwait.swift
@@ -15,6 +15,11 @@ import PubNubSDK
 /// Extension providing `async-await` support for ``ChannelGroup``.
 ///
 public extension ChannelGroup {
+  /// Namespace for `AsyncStream`-based streaming methods.
+  var stream: ChannelGroupStream<Self> {
+    ChannelGroupStream(channelGroup: self)
+  }
+
   /// Returns a paginated list of all existing channels in a given ``ChannelGroup``.
   ///
   /// - Parameters:
@@ -140,11 +145,10 @@ public extension ChannelGroup {
   }
 
   /// Enables real-time tracking of users connecting to or disconnecting from the given ``ChannelGroup``.
-  ///
-  /// - Returns: An asynchronous stream that produces a dictionary of channel identifiers and their present user identifiers
+  @available(*, deprecated, message: "Use `stream.presenceChanges()` instead")
   func streamPresence() -> AsyncStream<[String: [String]]> {
     AsyncStream { continuation in
-      let autoCloseable = streamPresence {
+      let autoCloseable = onPresenceChanged {
         continuation.yield($0)
       }
       continuation.onTermination = { _ in
@@ -154,11 +158,10 @@ public extension ChannelGroup {
   }
 
   /// Watch the ``ChannelGroup`` content.
-  ///
-  /// - Returns: An asynchronous stream that produces new messages from any channel in the group
+  @available(*, deprecated, message: "Use `stream.messages()` instead")
   func connect() -> AsyncStream<ChatType.ChatMessageType> {
     AsyncStream { continuation in
-      let autoCloseable = connect {
+      let autoCloseable = onMessageReceived {
         continuation.yield($0)
       }
       continuation.onTermination = { _ in

--- a/Sources/Entities/ChannelGroup.swift
+++ b/Sources/Entities/ChannelGroup.swift
@@ -98,11 +98,31 @@ public protocol ChannelGroup {
   ///
   /// - Parameter callback: A closure that will be called with a dictionary of channel identifiers and their present user identifiers
   /// - Returns: ``AutoCloseable`` interface you can call to stop listening for present users by invoking the ``AutoCloseable/close()`` method.
+  @available(*, deprecated, message: "Use `onPresenceChanged(callback:)` instead")
   func streamPresence(callback: @escaping ([String: [String]]) -> Void) -> AutoCloseable
+
+  /// Emits presence data whenever the presence state changes on any channel within this channel group.
+  ///
+  /// - Important: Keep a strong reference to the returned ``AutoCloseable`` object as long as you want to receive updates. If ``AutoCloseable`` is deallocated,
+  /// the stream will be canceled, and no further items will be produced. You can also stop receiving updates manually by calling ``AutoCloseable/close()``.
+  ///
+  /// - Parameter callback: A closure invoked with a dictionary of channel identifiers and their present user identifiers
+  /// - Returns: An ``AutoCloseable`` that stops listening when closed
+  func onPresenceChanged(callback: @escaping ([String: [String]]) -> Void) -> AutoCloseable
 
   /// Watch the ``ChannelGroup`` content.
   ///
   /// - Parameter callback: Custom behavior whenever a message is received
   /// - Returns: ``AutoCloseable`` interface you can call to stop listening for new messages by invoking the ``AutoCloseable/close()`` method.
+  @available(*, deprecated, message: "Use `onMessageReceived(callback:)` instead")
   func connect(callback: @escaping (ChatType.ChatMessageType) -> Void) -> AutoCloseable
+
+  /// Emits the received message whenever a new message is published on any channel within this channel group.
+  ///
+  /// - Important: Keep a strong reference to the returned ``AutoCloseable`` object as long as you want to receive updates. If ``AutoCloseable`` is deallocated,
+  /// the stream will be canceled, and no further items will be produced. You can also stop receiving updates manually by calling ``AutoCloseable/close()``.
+  ///
+  /// - Parameter callback: A closure invoked with the received message
+  /// - Returns: An ``AutoCloseable`` that stops listening when closed
+  func onMessageReceived(callback: @escaping (ChatType.ChatMessageType) -> Void) -> AutoCloseable
 }

--- a/Sources/Entities/ChannelGroupImpl.swift
+++ b/Sources/Entities/ChannelGroupImpl.swift
@@ -129,6 +129,10 @@ public class ChannelGroupImpl: ChannelGroup {
   }
 
   public func streamPresence(callback: @escaping ([String: [String]]) -> Void) -> AutoCloseable {
+    onPresenceChanged(callback: callback)
+  }
+
+  public func onPresenceChanged(callback: @escaping ([String: [String]]) -> Void) -> AutoCloseable {
     AutoCloseableImpl(
       channelGroup.streamPresence { [weak self] in
         if let userIds = $0 as? [String: [String]], self != nil {
@@ -140,6 +144,10 @@ public class ChannelGroupImpl: ChannelGroup {
   }
 
   public func connect(callback: @escaping (MessageImpl) -> Void) -> AutoCloseable {
+    onMessageReceived(callback: callback)
+  }
+
+  public func onMessageReceived(callback: @escaping (MessageImpl) -> Void) -> AutoCloseable {
     AutoCloseableImpl(
       channelGroup.connect { [weak self] in
         if let self = self {

--- a/Sources/Entities/ChannelGroupStream.swift
+++ b/Sources/Entities/ChannelGroupStream.swift
@@ -1,0 +1,48 @@
+//
+//  ChannelGroupStream.swift
+//
+//  Copyright (c) PubNub Inc.
+//  All rights reserved.
+//
+//  This source code is licensed under the license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+
+/// Namespace providing `AsyncStream`-based streaming methods for a ``ChannelGroup``.
+public struct ChannelGroupStream<C: ChannelGroup> {
+  let channelGroup: C
+
+  /// Emits the received message whenever a new message is published on any channel within this channel group.
+  ///
+  /// Async equivalent of ``ChannelGroup/onMessageReceived(callback:)``.
+  ///
+  /// - Returns: An `AsyncStream` of messages
+  public func messages() -> AsyncStream<C.ChatType.ChatMessageType> {
+    AsyncStream { continuation in
+      let autoCloseable = channelGroup.onMessageReceived {
+        continuation.yield($0)
+      }
+      continuation.onTermination = { _ in
+        autoCloseable.close()
+      }
+    }
+  }
+
+  /// Emits presence data whenever the presence state changes on any channel within this channel group.
+  ///
+  /// Async equivalent of ``ChannelGroup/onPresenceChanged(callback:)``.
+  ///
+  /// - Returns: An `AsyncStream` of dictionaries mapping channel identifiers to present user identifiers
+  public func presenceChanges() -> AsyncStream<[String: [String]]> {
+    AsyncStream { continuation in
+      let autoCloseable = channelGroup.onPresenceChanged {
+        continuation.yield($0)
+      }
+      continuation.onTermination = { _ in
+        autoCloseable.close()
+      }
+    }
+  }
+}

--- a/Sources/Entities/ChannelImpl.swift
+++ b/Sources/Entities/ChannelImpl.swift
@@ -478,6 +478,30 @@ extension ChannelImpl: Channel {
     target.onMessageReported(callback: callback)
   }
 
+  public func emitCustomEvent(
+    payload: [String: JSONCodable],
+    messageType: String? = nil,
+    storeInHistory: Bool = true,
+    completion: ((Swift.Result<Timetoken, Error>) -> Void)? = nil
+  ) {
+    target.emitCustomEvent(
+      payload: payload,
+      messageType: messageType,
+      storeInHistory: storeInHistory,
+      completion: completion
+    )
+  }
+
+  public func onCustomEvent(
+    messageType: String? = nil,
+    callback: @escaping (CustomEvent) -> Void
+  ) -> AutoCloseable {
+    target.onCustomEvent(
+      messageType: messageType,
+      callback: callback
+    )
+  }
+
   public func createMessageDraft(
     userSuggestionSource: UserSuggestionSource = .channel,
     isTypingIndicatorTriggered: Bool = true,

--- a/Sources/Entities/ChannelImpl.swift
+++ b/Sources/Entities/ChannelImpl.swift
@@ -81,7 +81,7 @@ extension ChannelImpl: Channel {
       return AutoCloseableImpl.empty()
     }
     return AutoCloseableImpl(
-      PubNubChat.ThreadChannelCompanion.shared.streamUpdatesOn(channels: channels.map(\.target.channel)) { [chat = firstChat] in
+      PubNubChat.BaseChannelCompanion.shared.streamUpdatesOn(channels: channels.map(\.target.channel)) { [chat = firstChat] in
         callback(($0 as? [PubNubChat.Channel_] ?? []).map {
           ChannelImpl(channel: $0, chat: chat)
         })

--- a/Sources/Entities/ChannelImpl.swift
+++ b/Sources/Entities/ChannelImpl.swift
@@ -441,25 +441,19 @@ extension ChannelImpl: Channel {
   }
 
   public func onMessageReceived(callback: @escaping (MessageImpl) -> Void) -> AutoCloseable {
-    AutoCloseableImpl(
-      target.channel.onMessageReceived { [weak self] in
-        if let self = self, let message = $0 as? PubNubChat.Message {
-          callback(MessageImpl(message: message, chat: self.chat))
-        }
-      },
-      owner: self
-    )
+    target.onMessageReceived { [weak self] in
+      if let self = self {
+        callback(MessageImpl(message: $0.message, chat: self.chat))
+      }
+    }
   }
 
   public func onUpdated(callback: @escaping (ChannelImpl) -> Void) -> AutoCloseable {
-    AutoCloseableImpl(
-      target.channel.onUpdated { [weak self] in
-        if let self = self {
-          callback(ChannelImpl(channel: $0, chat: self.chat))
-        }
-      },
-      owner: self
-    )
+    target.onUpdated { [weak self] in
+      if let self = self {
+        callback(ChannelImpl(channel: $0.channel, chat: self.chat))
+      }
+    }
   }
 
   public func onDeleted(callback: @escaping () -> Void) -> AutoCloseable {

--- a/Sources/Entities/ChannelImpl.swift
+++ b/Sources/Entities/ChannelImpl.swift
@@ -285,12 +285,14 @@ extension ChannelImpl: Channel {
 
   public func join(
     custom: [String: JSONCodableScalar]? = nil,
-    callback: ((MessageImpl) -> Void)? = nil,
-    completion: ((Swift.Result<(membership: MembershipImpl, disconnect: AutoCloseable?), Error>) -> Void)? = nil
+    status: String? = nil,
+    type: String? = nil,
+    completion: ((Swift.Result<MembershipImpl, any Error>) -> Void)? = nil
   ) {
     target.join(
       custom: custom,
-      callback: callback,
+      status: status,
+      type: type,
       completion: completion
     )
   }

--- a/Sources/Entities/ChannelStream.swift
+++ b/Sources/Entities/ChannelStream.swift
@@ -111,6 +111,23 @@ public struct ChannelStream<C: Channel> {
     }
   }
 
+  /// Emits custom events published on this channel.
+  ///
+  /// Async equivalent of ``Channel/onCustomEvent(messageType:callback:)``.
+  ///
+  /// - Parameter messageType: Optional custom message type filter
+  /// - Returns: An `AsyncStream` of ``CustomEvent`` values
+  public func customEvents(messageType: String? = nil) -> AsyncStream<CustomEvent> {
+    AsyncStream { continuation in
+      let autoCloseable = channel.onCustomEvent(messageType: messageType) {
+        continuation.yield($0)
+      }
+      continuation.onTermination = { _ in
+        autoCloseable.close()
+      }
+    }
+  }
+
   /// Emits a report whenever a message in this channel is reported by a user.
   ///
   /// Async equivalent of ``Channel/onMessageReported(callback:)``.

--- a/Sources/Entities/MessageImpl.swift
+++ b/Sources/Entities/MessageImpl.swift
@@ -218,8 +218,8 @@ extension MessageImpl: Message {
 
   public func onUpdated(callback: @escaping (MessageImpl) -> Void) -> AutoCloseable {
     target.onUpdated { [weak self] in
-      if let message = $0 as? PubNubChat.Message, let self = self {
-        callback(MessageImpl(message: message, chat: self.chat))
+      if let self = self {
+        callback(MessageImpl(message: $0.message, chat: self.chat))
       }
     }
   }

--- a/Sources/Entities/MessageImpl.swift
+++ b/Sources/Entities/MessageImpl.swift
@@ -217,14 +217,11 @@ extension MessageImpl: Message {
   }
 
   public func onUpdated(callback: @escaping (MessageImpl) -> Void) -> AutoCloseable {
-    AutoCloseableImpl(
-      target.message.onUpdated { [weak self] in
-        if let message = $0 as? PubNubChat.Message, let self = self {
-          callback(MessageImpl(message: message, chat: self.chat))
-        }
-      },
-      owner: self
-    )
+    target.onUpdated { [weak self] in
+      if let message = $0 as? PubNubChat.Message, let self = self {
+        callback(MessageImpl(message: message, chat: self.chat))
+      }
+    }
   }
 
   public func restore(completion: ((Swift.Result<MessageImpl, Error>) -> Void)? = nil) {

--- a/Sources/Entities/ThreadChannelImpl.swift
+++ b/Sources/Entities/ThreadChannelImpl.swift
@@ -341,12 +341,14 @@ extension ThreadChannelImpl: ThreadChannel {
 
   public func join(
     custom: [String: JSONCodableScalar]? = nil,
-    callback: ((MessageImpl) -> Void)? = nil,
-    completion: ((Swift.Result<(membership: MembershipImpl, disconnect: AutoCloseable?), Error>) -> Void)? = nil
+    status: String? = nil,
+    type: String? = nil,
+    completion: ((Swift.Result<MembershipImpl, any Error>) -> Void)? = nil
   ) {
     target.join(
       custom: custom,
-      callback: callback,
+      status: status,
+      type: type,
       completion: completion
     )
   }

--- a/Sources/Entities/ThreadChannelImpl.swift
+++ b/Sources/Entities/ThreadChannelImpl.swift
@@ -515,6 +515,30 @@ extension ThreadChannelImpl: ThreadChannel {
     target.onMessageReported(callback: callback)
   }
 
+  public func emitCustomEvent(
+    payload: [String: JSONCodable],
+    messageType: String? = nil,
+    storeInHistory: Bool = true,
+    completion: ((Swift.Result<Timetoken, Error>) -> Void)? = nil
+  ) {
+    target.emitCustomEvent(
+      payload: payload,
+      messageType: messageType,
+      storeInHistory: storeInHistory,
+      completion: completion
+    )
+  }
+
+  public func onCustomEvent(
+    messageType: String? = nil,
+    callback: @escaping (CustomEvent) -> Void
+  ) -> AutoCloseable {
+    target.onCustomEvent(
+      messageType: messageType,
+      callback: callback
+    )
+  }
+
   public func createMessageDraft(
     userSuggestionSource: UserSuggestionSource = .channel,
     isTypingIndicatorTriggered: Bool = true,

--- a/Sources/Entities/UserImpl.swift
+++ b/Sources/Entities/UserImpl.swift
@@ -224,7 +224,7 @@ extension UserImpl: User {
       limit: limit?.asKotlinInt,
       page: page?.transform(),
       filter: filter,
-      sort: sort.compactMap { $0.transform }
+      sort: sort.compactMap { $0.transform() }
     ).async(caller: self) { (result: FutureResult<UserImpl, MembershipsResponse>) in
       switch result.result {
       case let .success(response):

--- a/Sources/Models/CustomEvent.swift
+++ b/Sources/Models/CustomEvent.swift
@@ -1,0 +1,24 @@
+//
+//  CustomEvent.swift
+//
+//  Copyright (c) PubNub Inc.
+//  All rights reserved.
+//
+//  This source code is licensed under the license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import PubNubSDK
+
+/// Represents a custom event received on a channel.
+public struct CustomEvent {
+  /// The timetoken indicating when the event was published
+  public let timetoken: Timetoken
+  /// The ID of the user who emitted the event
+  public let userId: String
+  /// The custom message type used to categorize the event
+  public let type: String?
+  /// The custom event payload data
+  public let payload: [String: JSONCodable]
+}

--- a/Tests/AsyncAwait/ChannelAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/ChannelAsyncIntegrationTests.swift
@@ -382,16 +382,10 @@ class ChannelAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
   }
 
   func testChannelAsync_Join() async throws {
-    let expectation = XCTestExpectation(description: "Connect")
-    expectation.assertForOverFulfill = true
-    expectation.expectedFulfillmentCount = 1
-
     let membership = try await channel.join()
 
     XCTAssertEqual(membership.channel.id, channel.id)
     XCTAssertEqual(membership.user.id, chat.currentUser.id)
-
-    await fulfillment(of: [expectation], timeout: 5)
   }
 
   func testChannelAsync_Leave() async throws {
@@ -829,6 +823,9 @@ class ChannelAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
 
     channel.chat.pubNub.subscribe(to: [channel.id])
 
+    // Allow time for the subscription to register, ensuring the user appears as present on the channel
+    try await Task.sleep(nanoseconds: 4_000_000_000)
+
     let presenceTask = Task {
       for await userIdentifiers in channel.stream.presenceChanges() where !userIdentifiers.isEmpty {
         XCTAssertEqual(userIdentifiers.count, 1)
@@ -837,7 +834,7 @@ class ChannelAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
       }
     }
 
-    await fulfillment(of: [expectation], timeout: 5)
+    await fulfillment(of: [expectation], timeout: 6)
 
     addTeardownBlock {
       presenceTask.cancel()

--- a/Tests/AsyncAwait/ChannelAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/ChannelAsyncIntegrationTests.swift
@@ -692,6 +692,51 @@ class ChannelAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
     }
   }
 
+  func testChannelAsync_Stream_CustomEvents() async throws {
+    let expectation = expectation(description: "Stream_CustomEvents")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    let task = Task {
+      for await event in channel.stream.customEvents() {
+        XCTAssertEqual(event.userId, chat.currentUser.id)
+        expectation.fulfill()
+      }
+    }
+
+    try await Task.sleep(nanoseconds: 2_000_000_000)
+    try await channel.emitCustomEvent(payload: ["key": "value"])
+
+    await fulfillment(of: [expectation], timeout: 10)
+    addTeardownBlock { task.cancel() }
+  }
+
+  func testChannelAsync_Stream_CustomEvents_WithMessageTypeFilter() async throws {
+    let expectation = expectation(description: "Stream_CustomEvents_Filtered")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    let task = Task {
+      for await event in channel.stream.customEvents(messageType: "myType") {
+        XCTAssertEqual(event.type, "myType")
+        XCTAssertEqual(event.userId, chat.currentUser.id)
+        expectation.fulfill()
+      }
+    }
+
+    try await Task.sleep(nanoseconds: 2_000_000_000)
+
+    // Emit with a different type first - should not trigger
+    try await channel.emitCustomEvent(payload: ["key": "other"], messageType: "otherType")
+    try await Task.sleep(nanoseconds: 1_000_000_000)
+
+    // Emit with the matching type - should trigger
+    try await channel.emitCustomEvent(payload: ["key": "value"], messageType: "myType")
+
+    await fulfillment(of: [expectation], timeout: 10)
+    addTeardownBlock { task.cancel() }
+  }
+
   // MARK: - Stream Namespace Tests
 
   func testChannelAsync_Stream_TypingChanges() async throws {

--- a/Tests/AsyncAwait/ChannelAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/ChannelAsyncIntegrationTests.swift
@@ -115,24 +115,20 @@ class ChannelAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
   }
 
   func testChannelAsync_WhoIsPresent() async throws {
-    // Keeps a strong reference to the returned AsyncStream to prevent it from being deallocated. If this object is not retained,
-    // the AsyncStream will be deallocated, which would cause the behavior being tested to fail.
-    let joinResult = try await channel.join()
-    debugPrint(joinResult)
+    channel.chat.pubNub.subscribe(to: [channel.id])
 
+    // Allow time for the subscription to register, ensuring the user appears as present on the channel
     try await Task.sleep(nanoseconds: 4_000_000_000)
-    let whoIsPresent = try await channel.whoIsPresent()
 
+    let whoIsPresent = try await channel.whoIsPresent()
     XCTAssertEqual(whoIsPresent.count, 1)
     XCTAssertEqual(whoIsPresent.first, chat.currentUser.id)
   }
 
   func testChannelAsync_WhoIsPresentWithLimitAndOffset() async throws {
-    // Keeps a strong reference to the returned AsyncStream to prevent it from being deallocated. If this object is not retained,
-    // the AsyncStream will be deallocated, which would cause the behavior being tested to fail.
-    let joinResult = try await channel.join()
-    debugPrint(joinResult)
+    channel.chat.pubNub.subscribe(to: [channel.id])
 
+    // Allow time for the subscription to register, ensuring the user appears as present on the channel
     try await Task.sleep(nanoseconds: 4_000_000_000)
 
     let whoIsPresentWithLimit = try await channel.whoIsPresent(limit: 10)
@@ -148,12 +144,11 @@ class ChannelAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
   }
 
   func testChannelAsync_IsPresent() async throws {
-    // Keeps a strong reference to the returned AsyncStream to prevent it from being deallocated. If this object is not retained,
-    // the AsyncStream will be deallocated, which would cause the behavior being tested to fail.
-    let joinResult = try await channel.join()
-    debugPrint(joinResult)
+    channel.chat.pubNub.subscribe(to: [channel.id])
 
+    // Allow time for the subscription to register, ensuring the user appears as present on the channel
     try await Task.sleep(nanoseconds: 4_000_000_000)
+
     let isPresent = try await channel.isPresent(userId: chat.currentUser.id)
     XCTAssertTrue(isPresent)
   }
@@ -391,24 +386,12 @@ class ChannelAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
     expectation.assertForOverFulfill = true
     expectation.expectedFulfillmentCount = 1
 
-    let joinResult = try await channel.join()
+    let membership = try await channel.join()
 
-    XCTAssertEqual(joinResult.membership.channel.id, channel.id)
-    XCTAssertEqual(joinResult.membership.user.id, chat.currentUser.id)
+    XCTAssertEqual(membership.channel.id, channel.id)
+    XCTAssertEqual(membership.user.id, chat.currentUser.id)
 
-    let task = Task {
-      for await message in joinResult.messagesStream {
-        XCTAssertEqual(message.text, "This is a text")
-        XCTAssertEqual(message.channelId, channel.id)
-        expectation.fulfill()
-      }
-    }
-
-    try await Task.sleep(nanoseconds: 2_000_000_000)
-    try await channel.sendText(text: "This is a text")
-
-    await fulfillment(of: [expectation], timeout: 7)
-    addTeardownBlock { task.cancel() }
+    await fulfillment(of: [expectation], timeout: 5)
   }
 
   func testChannelAsync_Leave() async throws {
@@ -637,11 +620,7 @@ class ChannelAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
     expectation.assertForOverFulfill = true
     expectation.expectedFulfillmentCount = 1
 
-    let task = Task {
-      for await message in channel.connect() {
-        debugPrint("Did receive message: \(message)")
-      }
-    }
+    channel.chat.pubNub.subscribe(to: [channel.id])
 
     let presenceStreamTask = Task {
       for await userIdentifiers in channel.streamPresence() where !userIdentifiers.isEmpty {
@@ -655,7 +634,6 @@ class ChannelAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
 
     addTeardownBlock {
       presenceStreamTask.cancel()
-      task.cancel()
     }
   }
 
@@ -804,11 +782,7 @@ class ChannelAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
     expectation.assertForOverFulfill = true
     expectation.expectedFulfillmentCount = 1
 
-    let connectTask = Task {
-      for await message in channel.connect() {
-        debugPrint("Did receive message: \(message)")
-      }
-    }
+    channel.chat.pubNub.subscribe(to: [channel.id])
 
     let presenceTask = Task {
       for await userIdentifiers in channel.stream.presenceChanges() where !userIdentifiers.isEmpty {
@@ -822,7 +796,6 @@ class ChannelAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
 
     addTeardownBlock {
       presenceTask.cancel()
-      connectTask.cancel()
     }
   }
 

--- a/Tests/AsyncAwait/ChannelAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/ChannelAsyncIntegrationTests.swift
@@ -523,7 +523,7 @@ class ChannelAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
     XCTAssertEqual(readReceipt?.userId, currentUserId)
     XCTAssertEqual(readReceipt?.lastReadTimetoken, timetoken)
     XCTAssertEqual(secondReadReceipt?.userId, anotherUserId)
-    XCTAssertEqual(readReceipt?.lastReadTimetoken, secondTimetoken)
+    XCTAssertEqual(secondReadReceipt?.lastReadTimetoken, secondTimetoken)
 
     addTeardownBlock { [unowned self] in
       _ = try? await chat.deleteUser(id: anotherUserId)

--- a/Tests/AsyncAwait/ChannelGroupAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/ChannelGroupAsyncIntegrationTests.swift
@@ -69,23 +69,18 @@ class ChannelGroupAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
   func testChannelGroup_WhoIsPresent() async throws {
     try await channelGroup.add(channels: [channel, secondChannel])
 
-    let connectStream = channelGroup.connect()
-    let connectTask = Task {
-      for await message in connectStream {
-        debugPrint("Did receive message: \(message)")
-      }
-    }
+    channelGroup.chat.pubNub.subscribe(
+      to: [randomString()],
+      and: [channelGroup.id]
+    )
 
-    try await Task.sleep(nanoseconds: 3_000_000_000)
+    // Allow time for the subscription to register, ensuring the user appears as present on the channel group
+    try await Task.sleep(nanoseconds: 4_000_000_000)
+
     let whoIsPresentValue = try await channelGroup.whoIsPresent()
-
     XCTAssertEqual(whoIsPresentValue.count, 2)
     XCTAssertEqual(whoIsPresentValue[channel.id], [chat.currentUser.id])
     XCTAssertEqual(whoIsPresentValue[secondChannel.id], [chat.currentUser.id])
-
-    addTeardownBlock {
-      connectTask.cancel()
-    }
   }
 
   func testChannelGroup_StreamPresence() async throws {

--- a/Tests/AsyncAwait/ChannelGroupAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/ChannelGroupAsyncIntegrationTests.swift
@@ -141,4 +141,61 @@ class ChannelGroupAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
 
     await fulfillment(of: [expectation], timeout: 6)
   }
+
+  func testChannelGroup_Stream_PresenceChanges() async throws {
+    let expectation = expectation(description: "Stream_PresenceChanges")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    try await channelGroup.add(channels: [channel, secondChannel])
+
+    channelGroup.chat.pubNub.subscribe(
+      to: [randomString()],
+      and: [channelGroup.id]
+    )
+
+    // Allow time for the subscription to register, ensuring the user appears as present on the channel group
+    try await Task.sleep(nanoseconds: 4_000_000_000)
+
+    let presenceTask = Task { [unowned self] in
+      for await presenceData in channelGroup.stream.presenceChanges() where presenceData.count == 2 {
+        XCTAssertEqual(presenceData[channel.id], [chat.currentUser.id])
+        XCTAssertEqual(presenceData[secondChannel.id], [chat.currentUser.id])
+        expectation.fulfill()
+        break
+      }
+    }
+
+    addTeardownBlock {
+      presenceTask.cancel()
+    }
+
+    await fulfillment(of: [expectation], timeout: 7)
+  }
+
+  func testChannelGroup_Stream_Messages() async throws {
+    let expectation = XCTestExpectation(description: "Stream_Messages")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    try await channelGroup.add(channels: [channel, secondChannel])
+
+    let task = Task { [unowned self] in
+      for await message in channelGroup.stream.messages() {
+        XCTAssertEqual(message.text, "This is a text")
+        XCTAssertEqual(message.channelId, channel.id)
+        expectation.fulfill()
+        break
+      }
+    }
+
+    addTeardownBlock {
+      task.cancel()
+    }
+
+    try await Task.sleep(nanoseconds: 4_000_000_000)
+    try await channel.sendText(text: "This is a text")
+
+    await fulfillment(of: [expectation], timeout: 6)
+  }
 }

--- a/Tests/AsyncAwait/ChatAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/ChatAsyncIntegrationTests.swift
@@ -129,12 +129,11 @@ class ChatAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
     let channelId = randomString()
     let channel = try await chat.createChannel(id: channelId, name: channelId)
 
-    // Keeps a strong reference to the returned AsyncStream to prevent it from being deallocated. If this object is not retained,
-    // the AsyncStream will be deallocated, which would cause the behavior being tested to fail.
-    let connectResult = channel.connect()
-    debugPrint(connectResult)
+    channel.chat.pubNub.subscribe(to: [channelId])
 
+    // Allow time for the subscription to register, ensuring the user appears as present on the channel
     try await Task.sleep(nanoseconds: 5_000_000_000)
+
     let channelIdentifiers = try await chat.wherePresent(userId: chat.currentUser.id)
     let expectedChannelIdentifiers = [channelId]
 
@@ -149,14 +148,9 @@ class ChatAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
     let channelId = randomString()
     let channel = try await chat.createChannel(id: channelId, name: channelId)
 
-    // Keeps a strong reference to the returned AsyncStream to prevent it from being deallocated. If this object is not retained,
-    // the AsyncStream will be deallocated, which would cause the behavior being tested to fail.
-    let connectResult = channel.connect()
-    let joinResult = try await channel.join()
+    channel.chat.pubNub.subscribe(to: [channelId])
 
-    debugPrint(connectResult)
-    debugPrint(joinResult)
-
+    // Allow time for the subscription to register, ensuring the user appears as present on the channel
     try await Task.sleep(nanoseconds: 3_000_000_000)
 
     let isPresent = try await chat.isPresent(userId: chat.currentUser.id, channelId: channelId)
@@ -290,11 +284,9 @@ class ChatAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
       name: "ChannelName"
     )
 
-    // Keeps a strong reference to the returned AsyncStream to prevent it from being deallocated. If this object is not retained,
-    // the AsyncStream will be deallocated, which would cause the behavior being tested to fail.
-    let joinValue = try await channel.join()
-    debugPrint(joinValue)
+    channel.chat.pubNub.subscribe(to: [channel.id])
 
+    // Allow time for the subscription to register, ensuring the user appears as present on the channel
     try await Task.sleep(nanoseconds: 4_000_000_000)
 
     let whoIsPresentValue = try await chat.whoIsPresent(channelId: channel.id)

--- a/Tests/AsyncAwait/UserAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/UserAsyncIntegrationTests.swift
@@ -115,12 +115,11 @@ class UserAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
     let channelId = randomString()
     let createdChannel = try await chat.createChannel(id: channelId, name: channelId)
 
-    // Keeps a strong reference to the returned AsyncStream to prevent it from being deallocated. If this object is not retained,
-    // the AsyncStream will be deallocated, which would cause the behavior being tested to fail.
-    let connectResult = createdChannel.connect()
-    debugPrint(connectResult)
+    createdChannel.chat.pubNub.subscribe(to: [channelId])
 
+    // Allow time for the subscription to register, ensuring the user appears as present on the channel
     try await Task.sleep(nanoseconds: 4_000_000_000)
+
     let isPresent = try await chat.currentUser.isPresentOn(channelId: createdChannel.id)
     XCTAssertTrue(isPresent)
 
@@ -163,11 +162,9 @@ class UserAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
     let channelId = randomString()
     let channel = try await chat.createChannel(id: channelId, name: channelId)
 
-    // Keeps a strong reference to the returned AsyncStream to prevent it from being deallocated. If this object is not retained,
-    // the AsyncStream will be deallocated, which would cause the behavior being tested to fail.
-    let connectResult = channel.connect()
-    debugPrint(connectResult)
+    channel.chat.pubNub.subscribe(to: [channelId])
 
+    // Allow time for the subscription to register, ensuring the user appears as present on the channel
     try await Task.sleep(nanoseconds: 5_000_000_000)
 
     let channelIdentifiers = try await chat.currentUser.wherePresent()

--- a/Tests/ChannelGroupIntegrationTests.swift
+++ b/Tests/ChannelGroupIntegrationTests.swift
@@ -238,4 +238,77 @@ final class ChannelGroupIntegrationTests: BaseClosureIntegrationTestCase {
       closeable.close()
     }
   }
+
+  func testChannelGroup_OnPresenceChanged() throws {
+    let expectation = expectation(description: "OnPresenceChanged")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    try awaitResultValue {
+      channelGroup.add(
+        channels: [channel, secondChannel],
+        completion: $0
+      )
+    }
+
+    let presenceCloseable = channelGroup.onPresenceChanged { [unowned self] in
+      if $0.count == 2 {
+        XCTAssertEqual($0[channel.id], [chat.currentUser.id])
+        XCTAssertEqual($0[secondChannel.id], [chat.currentUser.id])
+        expectation.fulfill()
+      }
+    }
+
+    // Allow time for the subscription to register, ensuring the user appears as present on the channel group
+    DispatchQueue.global().asyncAfter(deadline: .now() + 2) { [weak self] in
+      self?.channel.chat.pubNub.subscribe(
+        to: [self?.randomString() ?? ""],
+        and: [self?.channelGroup.id ?? ""]
+      )
+    }
+
+    wait(
+      for: [expectation],
+      timeout: 7
+    )
+
+    addTeardownBlock {
+      presenceCloseable.close()
+    }
+  }
+
+  func testChannelGroup_OnMessageReceived() throws {
+    let expectation = XCTestExpectation(description: "OnMessageReceived")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    try awaitResultValue {
+      channelGroup.add(
+        channels: [channel, secondChannel],
+        completion: $0
+      )
+    }
+
+    let closeable = channelGroup.onMessageReceived { [unowned self] in
+      XCTAssertEqual($0.text, "This is a text")
+      XCTAssertEqual($0.channelId, channel.id)
+      expectation.fulfill()
+    }
+
+    try awaitResultValue(delay: 4) {
+      channel.sendText(
+        text: "This is a text",
+        completion: $0
+      )
+    }
+
+    wait(
+      for: [expectation],
+      timeout: 6
+    )
+
+    addTeardownBlock {
+      closeable.close()
+    }
+  }
 }

--- a/Tests/ChannelIntegrationTests.swift
+++ b/Tests/ChannelIntegrationTests.swift
@@ -887,11 +887,14 @@ class ChannelIntegrationTests: BaseClosureIntegrationTestCase {
       }
     }
 
-    channel.chat.pubNub.subscribe(to: [channel.id])
+    // Allow time for the subscription to register, ensuring the user appears as present on the channel
+    DispatchQueue.global().asyncAfter(deadline: .now() + 2) { [weak self] in
+      self?.channel.chat.pubNub.subscribe(to: [self?.channel.id ?? ""])
+    }
 
     wait(
       for: [expectation],
-      timeout: 5
+      timeout: 6
     )
     addTeardownBlock {
       presenceCloseable.close()
@@ -1116,7 +1119,10 @@ class ChannelIntegrationTests: BaseClosureIntegrationTestCase {
       }
     }
 
-    channel.chat.pubNub.subscribe(to: [channel.id])
+    // Allow time for the subscription to register, ensuring the user appears as present on the channel
+    DispatchQueue.global().asyncAfter(deadline: .now() + 2) { [weak self] in
+      self?.channel.chat.pubNub.subscribe(to: [self?.channel.id ?? ""])
+    }
 
     wait(
       for: [expectation],

--- a/Tests/ChannelIntegrationTests.swift
+++ b/Tests/ChannelIntegrationTests.swift
@@ -201,11 +201,7 @@ class ChannelIntegrationTests: BaseClosureIntegrationTestCase {
   }
 
   func testChannel_WhoIsPresent() throws {
-    let joinValue = try awaitResultValue {
-      channel.join(
-        completion: $0
-      )
-    }
+    channel.chat.pubNub.subscribe(to: [channel.id])
 
     let whoIsPresentValue = try awaitResultValue(delay: 4) {
       channel.whoIsPresent(
@@ -215,18 +211,10 @@ class ChannelIntegrationTests: BaseClosureIntegrationTestCase {
 
     XCTAssertEqual(whoIsPresentValue.count, 1)
     XCTAssertEqual(whoIsPresentValue.first, chat.currentUser.id)
-
-    addTeardownBlock {
-      joinValue.disconnect?.close()
-    }
   }
 
   func testChannel_IsPresent() throws {
-    let joinValue = try awaitResultValue {
-      channel.join(
-        completion: $0
-      )
-    }
+    channel.chat.pubNub.subscribe(to: [channel.id])
 
     XCTAssertTrue(try awaitResultValue(delay: 3) {
       channel.isPresent(
@@ -234,10 +222,6 @@ class ChannelIntegrationTests: BaseClosureIntegrationTestCase {
         completion: $0
       )
     })
-
-    addTeardownBlock {
-      joinValue.disconnect?.close()
-    }
   }
 
   func testChannel_GetHistory() throws {
@@ -559,42 +543,18 @@ class ChannelIntegrationTests: BaseClosureIntegrationTestCase {
   }
 
   func testChannel_Join() throws {
-    let expectation = XCTestExpectation(description: "Connect")
-    expectation.assertForOverFulfill = true
-    expectation.expectedFulfillmentCount = 1
-
-    let joinValue = try awaitResultValue { [unowned self] in
+    let membership = try awaitResultValue {
       channel.join(
-        callback: {
-          XCTAssertEqual($0.text, "This is a text")
-          XCTAssertEqual($0.channelId, self.channel.id)
-          expectation.fulfill()
-        },
         completion: $0
       )
     }
 
-    XCTAssertEqual(joinValue.membership.channel.id, channel.id)
-    XCTAssertEqual(joinValue.membership.user.id, chat.currentUser.id)
-
-    try awaitResultValue(delay: 3) {
-      channel.sendText(
-        text: "This is a text",
-        completion: $0
-      )
-    }
-
-    wait(
-      for: [expectation],
-      timeout: 7
-    )
-    addTeardownBlock {
-      joinValue.disconnect?.close()
-    }
+    XCTAssertEqual(membership.channel.id, channel.id)
+    XCTAssertEqual(membership.user.id, chat.currentUser.id)
   }
 
   func testChannel_Leave() throws {
-    let joinValue = try awaitResultValue {
+    try awaitResultValue {
       channel.join(
         completion: $0
       )
@@ -611,10 +571,6 @@ class ChannelIntegrationTests: BaseClosureIntegrationTestCase {
         )
       }.memberships.isEmpty
     )
-
-    addTeardownBlock {
-      joinValue.disconnect?.close()
-    }
   }
 
   func testChannel_PinMessageGetPinnedMessage() throws {
@@ -923,10 +879,6 @@ class ChannelIntegrationTests: BaseClosureIntegrationTestCase {
     expectation.assertForOverFulfill = true
     expectation.expectedFulfillmentCount = 1
 
-    let connectCloseable = channel.connect(callback: {
-      debugPrint("Did receive message: \($0)")
-    })
-
     let presenceCloseable = channel.streamPresence { [unowned self] in
       if !$0.isEmpty {
         XCTAssertEqual($0.count, 1)
@@ -935,13 +887,14 @@ class ChannelIntegrationTests: BaseClosureIntegrationTestCase {
       }
     }
 
+    channel.chat.pubNub.subscribe(to: [channel.id])
+
     wait(
       for: [expectation],
       timeout: 5
     )
     addTeardownBlock {
       presenceCloseable.close()
-      connectCloseable.close()
     }
   }
 
@@ -1163,9 +1116,7 @@ class ChannelIntegrationTests: BaseClosureIntegrationTestCase {
       }
     }
 
-    let connectCloseable = channel.connect(callback: {
-      debugPrint("Did receive message: \($0)")
-    })
+    channel.chat.pubNub.subscribe(to: [channel.id])
 
     wait(
       for: [expectation],
@@ -1173,7 +1124,6 @@ class ChannelIntegrationTests: BaseClosureIntegrationTestCase {
     )
     addTeardownBlock {
       presenceCloseable.close()
-      connectCloseable.close()
     }
   }
 

--- a/Tests/ChannelIntegrationTests.swift
+++ b/Tests/ChannelIntegrationTests.swift
@@ -1127,6 +1127,71 @@ class ChannelIntegrationTests: BaseClosureIntegrationTestCase {
     }
   }
 
+  func testChannel_OnCustomEvent() throws {
+    let expectation = expectation(description: "OnCustomEvent")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    let closeable = channel.onCustomEvent { [unowned self] event in
+      XCTAssertEqual(event.userId, chat.currentUser.id)
+      XCTAssertEqual(event.payload["key"]?.stringOptional, "value")
+      expectation.fulfill()
+    }
+
+    try awaitResultValue(delay: 2) {
+      channel.emitCustomEvent(
+        payload: ["key": "value"],
+        completion: $0
+      )
+    }
+
+    wait(
+      for: [expectation],
+      timeout: 10
+    )
+    addTeardownBlock {
+      closeable.close()
+    }
+  }
+
+  func testChannel_OnCustomEvent_WithMessageTypeFilter() throws {
+    let expectation = expectation(description: "OnCustomEvent_Filtered")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    let closeable = channel.onCustomEvent(messageType: "myType") { [unowned self] event in
+      XCTAssertEqual(event.payload["key"]?.stringOptional, "value")
+      XCTAssertEqual(event.userId, chat.currentUser.id)
+      expectation.fulfill()
+    }
+
+    // Emit with a different type first - should not trigger
+    try awaitResultValue(delay: 2) {
+      channel.emitCustomEvent(
+        payload: ["key": "other"],
+        messageType: "otherType",
+        completion: $0
+      )
+    }
+
+    // Emit with the matching type - should trigger
+    try awaitResultValue(delay: 1) {
+      channel.emitCustomEvent(
+        payload: ["key": "value"],
+        messageType: "myType",
+        completion: $0
+      )
+    }
+
+    wait(
+      for: [expectation],
+      timeout: 10
+    )
+    addTeardownBlock {
+      closeable.close()
+    }
+  }
+
   func testChannel_OnReadReceiptReceived() throws {
     let expectation = expectation(description: "OnReadReceiptReceived")
     expectation.assertForOverFulfill = true

--- a/Tests/ChatIntegrationTests.swift
+++ b/Tests/ChatIntegrationTests.swift
@@ -269,15 +269,10 @@ class ChatIntegrationTests: BaseClosureIntegrationTestCase {
   func testChat_IsPresent() throws {
     let channelId = randomString()
     let channel = try awaitResultValue { chat.createChannel(id: channelId, name: channelId, completion: $0) }
-    let closeable = channel.connect(callback: { _ in })
 
-    let joinValue = try awaitResultValue {
-      channel.join(
-        completion: $0
-      )
-    }
+    channel.chat.pubNub.subscribe(to: [channelId])
 
-    XCTAssertTrue(try awaitResultValue(delay: 3) {
+    XCTAssertTrue(try awaitResultValue(delay: 4) {
       chat.isPresent(
         userId: chat.currentUser.id,
         channelId: channelId,
@@ -286,9 +281,6 @@ class ChatIntegrationTests: BaseClosureIntegrationTestCase {
     })
 
     addTeardownBlock { [unowned self] in
-      joinValue.disconnect?.close()
-      closeable.close()
-
       try awaitResult {
         chat.deleteChannel(
           id: channelId,
@@ -551,11 +543,9 @@ class ChatIntegrationTests: BaseClosureIntegrationTestCase {
         completion: $0
       )
     }
-    let joinValue = try awaitResultValue {
-      channel.join(
-        completion: $0
-      )
-    }
+
+    channel.chat.pubNub.subscribe(to: [channel.id])
+
     let whoIsPresentValue = try awaitResultValue(delay: 4) {
       chat.whoIsPresent(
         channelId: channel.id,
@@ -567,7 +557,6 @@ class ChatIntegrationTests: BaseClosureIntegrationTestCase {
     XCTAssertEqual(whoIsPresentValue.first, chat.currentUser.id)
 
     addTeardownBlock { [unowned self] in
-      joinValue.disconnect?.close()
       try awaitResult {
         chat.deleteChannel(
           id: channel.id,


### PR DESCRIPTION
- Add `emitCustomEvent()`, `onCustomEvent()`, and `stream.customEvents()` to Channel
- Simplify `join()` to accept `status`/`type` params and return `Membership` directly
- Update presence tests to use `pubNub.subscribe()` instead of `join`/`connect`
- Entity-first streaming API for `ChannelGroup`