### PR TITLE
Add Membership status/type, Channel.getInvitees(), rename createThreadWithResult, and update DocC

### DIFF
--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/Channel.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/Channel.md
@@ -4,18 +4,30 @@
 
 ### Receiving Updates
 
+- ``stream``
 - ``streamUpdates()``
 - ``streamUpdates(callback:)``
 - ``streamUpdatesOn(channels:)``
 - ``streamUpdatesOn(channels:callback:)``
 - ``streamReadReceipts()``
 - ``streamReadReceipts(callback:)``
-- ``fetchReadReceipts(limit:page:filter:sort:)``
-- ``fetchReadReceipts(limit:page:filter:sort:completion:)``
 - ``streamMessageReports()``
 - ``streamMessageReports(callback:)``
 - ``streamPresence()``
 - ``streamPresence(callback:)``
+- ``onUpdated(callback:)``
+- ``onDeleted(callback:)``
+- ``onTypingChanged(callback:)``
+- ``onMessageReceived(callback:)``
+- ``onReadReceiptReceived(callback:)``
+- ``onPresenceChanged(callback:)``
+- ``onMessageReported(callback:)``
+- ``onCustomEvent(messageType:callback:)``
+
+### Read Receipts
+
+- ``fetchReadReceipts(limit:page:filter:sort:)``
+- ``fetchReadReceipts(limit:page:filter:sort:completion:)``
 
 ### Update and Delete a Channel
 
@@ -39,8 +51,8 @@
 - ``whoIsPresent(limit:offset:completion:)``
 - ``isPresent(userId:)``
 - ``isPresent(userId:completion:)``
-- ``join(custom:)``
-- ``join(custom:callback:completion:)``
+- ``join(custom:status:type:)``
+- ``join(custom:status:type:completion:)``
 - ``leave()``
 - ``leave(completion:)``
 - ``streamPresence()``
@@ -54,6 +66,8 @@
 - ``inviteMultiple(users:completion:)``
 - ``getMembers(limit:page:filter:sort:)``
 - ``getMembers(limit:page:filter:sort:completion:)``
+- ``getInvitees(limit:page:filter:sort:)``
+- ``getInvitees(limit:page:filter:sort:completion:)``
 - ``hasMember(userId:)``
 - ``hasMember(userId:completion:)``
 - ``getMember(userId:)``

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ChannelImpl.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ChannelImpl.md
@@ -4,18 +4,30 @@
 
 ### Receiving Updates
 
+- ``stream``
 - ``streamUpdates()``
 - ``streamUpdates(callback:)``
 - ``streamUpdatesOn(channels:)``
 - ``streamUpdatesOn(channels:callback:)``
 - ``streamReadReceipts()``
 - ``streamReadReceipts(callback:)``
-- ``fetchReadReceipts(limit:page:filter:sort:)``
-- ``fetchReadReceipts(limit:page:filter:sort:completion:)``
 - ``streamMessageReports()``
 - ``streamMessageReports(callback:)``
 - ``streamPresence()``
 - ``streamPresence(callback:)``
+- ``onUpdated(callback:)``
+- ``onDeleted(callback:)``
+- ``onTypingChanged(callback:)``
+- ``onMessageReceived(callback:)``
+- ``onReadReceiptReceived(callback:)``
+- ``onPresenceChanged(callback:)``
+- ``onMessageReported(callback:)``
+- ``onCustomEvent(messageType:callback:)``
+
+### Read Receipts
+
+- ``fetchReadReceipts(limit:page:filter:sort:)``
+- ``fetchReadReceipts(limit:page:filter:sort:completion:)``
 
 ### Update and Delete a Channel
 
@@ -39,8 +51,8 @@
 - ``whoIsPresent(limit:offset:completion:)``
 - ``isPresent(userId:)``
 - ``isPresent(userId:completion:)``
-- ``join(custom:)``
-- ``join(custom:callback:completion:)``
+- ``join(custom:status:type:)``
+- ``join(custom:status:type:completion:)``
 - ``leave()``
 - ``leave(completion:)``
 - ``streamPresence()``
@@ -54,6 +66,8 @@
 - ``inviteMultiple(users:completion:)``
 - ``getMembers(limit:page:filter:sort:)``
 - ``getMembers(limit:page:filter:sort:completion:)``
+- ``getInvitees(limit:page:filter:sort:)``
+- ``getInvitees(limit:page:filter:sort:completion:)``
 - ``hasMember(userId:)``
 - ``hasMember(userId:completion:)``
 - ``getMember(userId:)``

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/Chat.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/Chat.md
@@ -28,8 +28,8 @@
 - ``updateChannel(id:name:custom:description:status:type:completion:)``
 - ``deleteChannel(id:)``
 - ``deleteChannel(id:completion:)``
-- ``whoIsPresent(channelId:)``
-- ``whoIsPresent(channelId:completion:)``
+- ``whoIsPresent(channelId:limit:offset:)``
+- ``whoIsPresent(channelId:limit:offset:completion:)``
 - ``getPushChannels()``
 - ``getPushChannels(completion:)``
 - ``registerPushChannels(channels:)``

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ChatImpl.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ChatImpl.md
@@ -29,8 +29,8 @@
 - ``updateChannel(id:name:custom:description:status:type:completion:)``
 - ``deleteChannel(id:)``
 - ``deleteChannel(id:completion:)``
-- ``whoIsPresent(channelId:)``
-- ``whoIsPresent(channelId:completion:)``
+- ``whoIsPresent(channelId:limit:offset:)``
+- ``whoIsPresent(channelId:limit:offset:completion:)``
 - ``getPushChannels()``
 - ``getPushChannels(completion:)``
 - ``registerPushChannels(channels:)``

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/Membership.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/Membership.md
@@ -4,10 +4,13 @@
 
 ### Receiving Updates
 
+- ``stream``
 - ``streamUpdates()``
 - ``streamUpdates(callback:)``
 - ``streamUpdatesOn(memberships:)``
 - ``streamUpdatesOn(memberships:callback:)``
+- ``onUpdated(callback:)``
+- ``onDeleted(callback:)``
 
 ### Read Receipts
 
@@ -20,10 +23,11 @@
 
 ### Updating Membership
 
-- ``update(custom:)``
-- ``update(custom:completion:)``
+- ``update(custom:status:type:)``
+- ``update(custom:status:type:completion:)``
 
 ### Deleting Membership
 
 - ``delete()``
 - ``delete(completion:)``
+

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/MembershipImpl.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/MembershipImpl.md
@@ -4,10 +4,13 @@
 
 ### Receiving Updates
 
+- ``stream``
 - ``streamUpdates()``
 - ``streamUpdates(callback:)``
 - ``streamUpdatesOn(memberships:)``
 - ``streamUpdatesOn(memberships:callback:)``
+- ``onUpdated(callback:)``
+- ``onDeleted(callback:)``
 
 ### Read Receipts
 
@@ -20,10 +23,11 @@
 
 ### Updating Membership
 
-- ``update(custom:)``
-- ``update(custom:completion:)``
+- ``update(custom:status:type:)``
+- ``update(custom:status:type:completion:)``
 
 ### Deleting Membership
 
 - ``delete()``
 - ``delete(completion:)``
+

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/Message.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/Message.md
@@ -46,8 +46,8 @@
 
 - ``getThread()``
 - ``getThread(completion:)``
-- ``createThread()``
-- ``createThread(completion:)``
+- ``createThread(text:params:)``
+- ``createThread(text:params:completion:)``
 - ``removeThread()``
 - ``removeThread(completion:)``
 

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/Message.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/Message.md
@@ -14,10 +14,12 @@
 
 ### Receiving Updates
 
+- ``stream``
 - ``streamUpdates()``
 - ``streamUpdates(completion:)``
 - ``streamUpdatesOn(messages:)``
 - ``streamUpdatesOn(messages:callback:)``
+- ``onUpdated(callback:)``
 
 ### Reactions
 
@@ -63,3 +65,4 @@
 
 - ``report(reason:)``
 - ``report(reason:completion:)``
+

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/MessageImpl.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/MessageImpl.md
@@ -46,8 +46,8 @@
 
 - ``getThread()``
 - ``getThread(completion:)``
-- ``createThread()``
-- ``createThread(completion:)``
+- ``createThread(text:params:)``
+- ``createThread(text:params:completion:)``
 - ``removeThread()``
 - ``removeThread(completion:)``
 

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/MessageImpl.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/MessageImpl.md
@@ -14,10 +14,12 @@
 
 ### Receiving Updates
 
+- ``stream``
 - ``streamUpdates()``
 - ``streamUpdates(completion:)``
 - ``streamUpdatesOn(messages:)``
 - ``streamUpdatesOn(messages:callback:)``
+- ``onUpdated(callback:)``
 
 ### Reactions
 
@@ -63,3 +65,4 @@
 
 - ``report(reason:)``
 - ``report(reason:completion:)``
+

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ThreadChannel.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ThreadChannel.md
@@ -8,3 +8,14 @@
 - ``pinMessageToParentChannel(message:completion:)``
 - ``unpinMessageFromParentChannel()``
 - ``unpinMessageFromParentChannel(completion:)``
+
+### Receiving Updates
+
+- ``onUpdated(callback:)``
+- ``onDeleted(callback:)``
+- ``onTypingChanged(callback:)``
+- ``onMessageReceived(callback:)``
+- ``onReadReceiptReceived(callback:)``
+- ``onPresenceChanged(callback:)``
+- ``onMessageReported(callback:)``
+- ``onCustomEvent(messageType:callback:)``

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ThreadChannelImpl.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ThreadChannelImpl.md
@@ -8,3 +8,14 @@
 - ``pinMessageToParentChannel(message:completion:)``
 - ``unpinMessageFromParentChannel()``
 - ``unpinMessageFromParentChannel(completion:)``
+
+### Receiving Updates
+
+- ``onUpdated(callback:)``
+- ``onDeleted(callback:)``
+- ``onTypingChanged(callback:)``
+- ``onMessageReceived(callback:)``
+- ``onReadReceiptReceived(callback:)``
+- ``onPresenceChanged(callback:)``
+- ``onMessageReported(callback:)``
+- ``onCustomEvent(messageType:callback:)``

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ThreadMessage.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ThreadMessage.md
@@ -8,3 +8,7 @@
 - ``pinToParentChannel(completion:)``
 - ``unpinFromParentChannel()``
 - ``unpinFromParentChannel(completion:)``
+
+### Receiving Updates
+
+- ``onUpdated(callback:)``

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ThreadMessageImpl.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ThreadMessageImpl.md
@@ -8,3 +8,7 @@
 - ``pinToParentChannel(completion:)``
 - ``unpinFromParentChannel()``
 - ``unpinFromParentChannel(completion:)``
+
+### Receiving Updates
+
+- ``onUpdated(callback:)``

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/User.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/User.md
@@ -4,10 +4,16 @@
 
 ### Receiving Updates
 
+- ``stream``
 - ``streamUpdates()``
 - ``streamUpdates(callback:)``
 - ``streamUpdatesOn(users:)``
 - ``streamUpdatesOn(users:callback:)``
+- ``onUpdated(callback:)``
+- ``onDeleted(callback:)``
+- ``onMentioned(callback:)``
+- ``onInvited(callback:)``
+- ``onRestrictionChanged(callback:)``
 
 ### Update and Delete a User
 
@@ -33,3 +39,4 @@
 - ``isMemberOf(channelId:completion:)``
 - ``getMembership(channelId:)``
 - ``getMembership(channelId:completion:)``
+

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/UserImpl.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/UserImpl.md
@@ -4,10 +4,16 @@
 
 ### Receiving Updates
 
+- ``stream``
 - ``streamUpdates()``
 - ``streamUpdates(callback:)``
 - ``streamUpdatesOn(users:)``
 - ``streamUpdatesOn(users:callback:)``
+- ``onUpdated(callback:)``
+- ``onDeleted(callback:)``
+- ``onMentioned(callback:)``
+- ``onInvited(callback:)``
+- ``onRestrictionChanged(callback:)``
 
 ### Update and Delete a User
 
@@ -33,3 +39,4 @@
 - ``isMemberOf(channelId:completion:)``
 - ``getMembership(channelId:)``
 - ``getMembership(channelId:completion:)``
+

--- a/Sources/Chat/Chat.swift
+++ b/Sources/Chat/Chat.swift
@@ -516,10 +516,10 @@ public protocol Chat: AnyObject {
   /// Returns a reference to a ``ChannelGroup`` with the specified id.
   ///
   /// This does **not** create a group on the server. If the group exists, the reference points to it. If the group does not exist, it serves as a handle to create
-  /// and modify it via channel changes. For example, ``ChannelGroup/add(channels:completion:)``, ``ChannelGroup/addChannelIdentifiers(ids:completion:)``
+  /// and modify it via channel changes. For example, ``ChannelGroup/add(channels:completion:)``, ``ChannelGroup/addChannelIdentifiers(_:completion:)``
   ///
   /// - Parameter id: The ID of the ``ChannelGroup`` to get
-  /// - Returns: A ``ChatChannelGroupType`` instance
+  /// - Returns: A ``ChannelGroup`` instance
   func getChannelGroup(id: String) -> ChatChannelGroupType
 
   /// Removes a channel group with the specified id.
@@ -538,17 +538,9 @@ public protocol Chat: AnyObject {
   func addConnectionStatusListener(_ listener: @escaping (ConnectionStatus) -> Void) -> AutoCloseable
 
   /// Reconnects the client to the PubNub system.
-  ///
-  /// - Parameter completion: The async `Result` of the method call
-  ///     - **Success**: A `Void` indicating a success
-  ///     - **Failure**: An `Error` describing the failure
   func reconnectSubscriptions()
 
   /// Disconnects the client from the PubNub system.
-  ///
-  /// - Parameter completion: The async `Result` of the method call
-  ///     - **Success**: A `Void` indicating a success
-  ///     - **Failure**: An `Error` describing the failure
   func disconnectSubscriptions()
 
   // swiftlint:disable:next file_length

--- a/Sources/Entities/BaseChannel.swift
+++ b/Sources/Entities/BaseChannel.swift
@@ -587,6 +587,39 @@ final class BaseChannel<C: PubNubChat.Channel_, M: PubNubChat.Message>: Channel 
     )
   }
 
+  func getInvitees(
+    limit: Int?,
+    page: PubNubHashedPage?,
+    filter: String?,
+    sort: [PubNub.MembershipSortField],
+    completion: ((Swift.Result<(memberships: [ChatType.ChatMembershipType], page: PubNubHashedPage?), Error>) -> Void)?
+  ) {
+    channel.getInvitees(
+      limit: limit?.asKotlinInt,
+      page: page?.transform(),
+      filter: filter,
+      sort: sort.compactMap { $0.transform() }
+    ).async(caller: self) { (result: FutureResult<BaseChannel, PubNubChat.MembersResponse>) in
+      switch result.result {
+      case let .success(response):
+        completion?(.success(
+          (
+            memberships: response.members.map {
+              MembershipImpl(membership: $0, chat: result.caller.chat)
+            },
+            page: PubNubHashedPageBase(
+              start: response.next?.pageHash,
+              end: response.prev?.pageHash,
+              totalCount: Int(response.total)
+            )
+          )
+        ))
+      case let .failure(error):
+        completion?(.failure(error))
+      }
+    }
+  }
+
   func getUserSuggestions(
     text: String,
     limit: Int,

--- a/Sources/Entities/BaseMessage.swift
+++ b/Sources/Entities/BaseMessage.swift
@@ -204,7 +204,7 @@ extension BaseMessage: Message {
     }
   }
 
-  func createThreadWithResult(
+  func createThread(
     text: String,
     params: SendTextParams,
     completion: ((Swift.Result<CreateThreadResult<ThreadChannelImpl, MessageImpl>, Error>) -> Void)?

--- a/Sources/Entities/Channel+AsyncAwait.swift
+++ b/Sources/Entities/Channel+AsyncAwait.swift
@@ -650,6 +650,32 @@ public extension Channel {
     }
   }
 
+  /// Returns the list of all invited members of the channel.
+  ///
+  /// - Parameters:
+  ///   - limit: Number of objects to return in response
+  ///   - page: Object used for pagination to define which previous or next result page you want to fetch
+  ///   - filter: Expression used to filter the results. Returns only these members whose properties satisfy the given expression
+  ///   - sort: A collection to specify the sort order
+  /// - Returns: A `Tuple` containing an array of the invitees of the channel, and the next pagination `PubNubHashedPage` (if one exists)
+  func getInvitees(
+    limit: Int? = nil,
+    page: PubNubHashedPage? = nil,
+    filter: String? = nil,
+    sort: [PubNub.MembershipSortField] = []
+  ) async throws -> (memberships: [ChatType.ChatMembershipType], page: PubNubHashedPage?) {
+    try await withCheckedThrowingContinuation { continuation in
+      getInvitees(limit: limit, page: page, filter: filter, sort: sort) {
+        switch $0 {
+        case let .success(getInviteesResult):
+          continuation.resume(returning: getInviteesResult)
+        case let .failure(error):
+          continuation.resume(throwing: error)
+        }
+      }
+    }
+  }
+
   /// Fetches all suggested users that match the provided 3-letter string from ``Channel``.
   ///
   /// - Parameters:

--- a/Sources/Entities/Channel.swift
+++ b/Sources/Entities/Channel.swift
@@ -339,7 +339,7 @@ public protocol Channel: CustomStringConvertible {
 
   /// Emits the received message whenever a new message is published on this channel.
   ///
-  /// For a ``ThreadChannel``, this returns thread messages (``ChatType/ChatThreadMessageType``).
+  /// For a ``ThreadChannel``, this returns thread messages (``ThreadMessage``).
   ///
   /// - Parameter callback: A closure invoked with the received message
   /// - Returns: An ``AutoCloseable`` that stops listening when closed
@@ -386,7 +386,6 @@ public protocol Channel: CustomStringConvertible {
   ///   - completion: The async `Result` of the method call
   ///     - **Success**: A `Tuple` containing the user's ``Membership`` in the channel, and ``AutoCloseable`` that  lets you stop listening to new channel messages while remaining a channel membership
   ///     - **Failure**: An `Error` describing the failure
-  /// - Returns: The caller's membership in the channel
   func join(
     custom: [String: JSONCodableScalar]?,
     status: String?,
@@ -583,6 +582,24 @@ public protocol Channel: CustomStringConvertible {
   func onPresenceChanged(
     callback: @escaping (Set<String>) -> Void
   ) -> AutoCloseable
+
+  /// Returns the list of all invited members of the channel.
+  ///
+  /// - Parameters:
+  ///   - limit: Number of objects to return in response
+  ///   - page: Object used for pagination to define which previous or next result page you want to fetch
+  ///   - filter: Expression used to filter the results. Returns only these members whose properties satisfy the given expression
+  ///   - sort: A collection to specify the sort order
+  ///   - completion: The async `Result` of the method call
+  ///     - **Success**: A `Tuple` containing an array of the invitees of the channel, and the next pagination `PubNubHashedPage` (if one exists)
+  ///     - **Failure**: An `Error` describing the failure
+  func getInvitees(
+    limit: Int?,
+    page: PubNubHashedPage?,
+    filter: String?,
+    sort: [PubNub.MembershipSortField],
+    completion: ((Swift.Result<(memberships: [ChatType.ChatMembershipType], page: PubNubHashedPage?), Error>) -> Void)?
+  )
 
   /// Fetches all suggested users that match the provided 3-letter string from ``Channel``.
   ///

--- a/Sources/Entities/ChannelImpl.swift
+++ b/Sources/Entities/ChannelImpl.swift
@@ -429,6 +429,22 @@ extension ChannelImpl: Channel {
     )
   }
 
+  public func getInvitees(
+    limit: Int? = nil,
+    page: PubNubHashedPage? = nil,
+    filter: String? = nil,
+    sort: [PubNub.MembershipSortField] = [],
+    completion: ((Swift.Result<(memberships: [MembershipImpl], page: PubNubHashedPage?), Error>) -> Void)? = nil
+  ) {
+    target.getInvitees(
+      limit: limit,
+      page: page,
+      filter: filter,
+      sort: sort,
+      completion: completion
+    )
+  }
+
   public func getUserSuggestions(
     text: String,
     limit: Int = 10,

--- a/Sources/Entities/Membership+AsyncAwait.swift
+++ b/Sources/Entities/Membership+AsyncAwait.swift
@@ -59,11 +59,18 @@ public extension Membership {
 
   /// Updates the channel membership information for a given user.
   ///
-  /// - Parameter custom: Any custom properties or metadata associated with the channel-user membership in a form of key-value pairs
+  /// - Parameters:
+  ///   - custom: Any custom properties or metadata associated with the channel-user membership in a form of key-value pairs
+  ///   - status: Optional membership status value
+  ///   - type: Optional membership type value
   /// - Returns: An updated ``Membership`` object
-  func update(custom: [String: JSONCodableScalar]) async throws -> ChatType.ChatMembershipType {
+  func update(
+    custom: [String: JSONCodableScalar],
+    status: String? = nil,
+    type: String? = nil
+  ) async throws -> ChatType.ChatMembershipType {
     try await withCheckedThrowingContinuation { continuation in
-      update(custom: custom) {
+      update(custom: custom, status: status, type: type) {
         switch $0 {
         case let .success(membership):
           continuation.resume(returning: membership)

--- a/Sources/Entities/Membership.swift
+++ b/Sources/Entities/Membership.swift
@@ -68,11 +68,15 @@ public protocol Membership: CustomStringConvertible {
   ///
   /// - Parameters:
   ///   - custom: Any custom properties or metadata associated with the channel-user membership in a form of key-value pairs
+  ///   - status: Optional membership status value
+  ///   - type: Optional membership type value
   ///   - completion: The async `Result` of the method call
   ///     - **Success**: An updated ``Membership`` object
   ///     - **Failure**: An `Error` describing the failure
   func update(
     custom: [String: JSONCodableScalar],
+    status: String?,
+    type: String?,
     completion: ((Swift.Result<ChatType.ChatMembershipType, Error>) -> Void)?
   )
 

--- a/Sources/Entities/MembershipImpl.swift
+++ b/Sources/Entities/MembershipImpl.swift
@@ -102,9 +102,13 @@ extension MembershipImpl: Membership {
 
   public func update(
     custom: [String: JSONCodableScalar],
+    status: String? = nil,
+    type: String? = nil,
     completion: ((Swift.Result<MembershipImpl, Error>) -> Void)? = nil
   ) {
     membership.update(
+      status: status,
+      type: type,
       custom: custom
     ).async(caller: self) { (result: FutureResult<MembershipImpl, PubNubChat.Membership>) in
       switch result.result {

--- a/Sources/Entities/Message+AsyncAwait.swift
+++ b/Sources/Entities/Message+AsyncAwait.swift
@@ -150,7 +150,7 @@ public extension Message {
   /// Create a thread (channel) for a selected message.
   ///
   /// - Returns: A ``ThreadChannel`` object which can be used for sending and reading messages from the newly created message thread
-  @available(*, deprecated, message: "Use `createThreadWithResult(text:params:)` instead")
+  @available(*, deprecated, message: "Use `createThread(text:params:)` instead")
   func createThread() async throws -> ChatType.ChatThreadChannelType {
     try await withCheckedThrowingContinuation { continuation in
       createThread {
@@ -177,7 +177,7 @@ public extension Message {
   ///   - usersToMention: A collection of user ids to automatically notify with a mention after this message is sent
   ///   - customPushData: Additional key-value pairs that will be added to the FCM and/or APNS push messages for the message itself and any user mentions
   /// - Returns: A ``ThreadChannel`` object which can be used for sending and reading messages from the newly created message thread
-  @available(*, deprecated, message: "Use `createThreadWithResult(text:params:)` instead")
+  @available(*, deprecated, message: "Use `createThread(text:params:)` instead")
   func createThread(
     text: String,
     meta: [String: JSONCodable]? = nil,
@@ -217,12 +217,12 @@ public extension Message {
   ///   - text: Text of the first reply to send in the thread
   ///   - params: Additional parameters for sending text, encapsulated in a ``SendTextParams`` object
   /// - Returns: A ``CreateThreadResult`` containing the thread channel and updated parent message
-  func createThreadWithResult(
+  func createThread(
     text: String,
     params: SendTextParams = SendTextParams()
   ) async throws -> CreateThreadResult<ChatType.ChatThreadChannelType, ChatType.ChatMessageType> {
     try await withCheckedThrowingContinuation { continuation in
-      createThreadWithResult(
+      createThread(
         text: text,
         params: params
       ) {

--- a/Sources/Entities/Message.swift
+++ b/Sources/Entities/Message.swift
@@ -162,7 +162,7 @@ public protocol Message: CustomStringConvertible {
   ///   - completion: The async `Result` of the method call
   ///     - **Success**:  Returns a ``ThreadChannel`` object which can be used for sending and reading messages from the newly created message thread
   ///     - **Failure**: An `Error` describing the failure
-  @available(*, deprecated, message: "Use `createThreadWithResult(text:params:completion:)` instead")
+  @available(*, deprecated, message: "Use `createThread(text:params:completion:)` instead")
   func createThread(
     completion: ((Swift.Result<ChatType.ChatThreadChannelType, Error>) -> Void)?
   )
@@ -182,7 +182,7 @@ public protocol Message: CustomStringConvertible {
   ///   - completion: The async `Result` of the method call
   ///     - **Success**:  Returns a ``ThreadChannel`` object which can be used for sending and reading messages from the newly created message thread
   ///     - **Failure**: An `Error` describing the failure
-  @available(*, deprecated, message: "Use `createThreadWithResult(text:params:completion:)` instead")
+  @available(*, deprecated, message: "Use `createThread(text:params:completion:)` instead")
   func createThread(
     text: String,
     meta: [String: JSONCodable]?,
@@ -204,7 +204,7 @@ public protocol Message: CustomStringConvertible {
   ///   - completion: The async `Result` of the method call
   ///     - **Success**: A ``CreateThreadResult`` containing the thread channel and updated parent message
   ///     - **Failure**: An `Error` describing the failure
-  func createThreadWithResult(
+  func createThread(
     text: String,
     params: SendTextParams,
     completion: ((Swift.Result<CreateThreadResult<ChatType.ChatThreadChannelType, ChatType.ChatMessageType>, Error>) -> Void)?

--- a/Sources/Entities/MessageImpl.swift
+++ b/Sources/Entities/MessageImpl.swift
@@ -192,12 +192,12 @@ extension MessageImpl: Message {
     )
   }
 
-  public func createThreadWithResult(
+  public func createThread(
     text: String,
     params: SendTextParams = SendTextParams(),
     completion: ((Swift.Result<CreateThreadResult<ThreadChannelImpl, MessageImpl>, Error>) -> Void)? = nil
   ) {
-    target.createThreadWithResult(
+    target.createThread(
       text: text,
       params: params,
       completion: completion

--- a/Sources/Entities/ThreadChannelImpl.swift
+++ b/Sources/Entities/ThreadChannelImpl.swift
@@ -489,6 +489,22 @@ extension ThreadChannelImpl: ThreadChannel {
     )
   }
 
+  public func getInvitees(
+    limit: Int? = nil,
+    page: PubNubHashedPage? = nil,
+    filter: String? = nil,
+    sort: [PubNub.MembershipSortField] = [],
+    completion: ((Swift.Result<(memberships: [MembershipImpl], page: PubNubHashedPage?), Error>) -> Void)? = nil
+  ) {
+    target.getInvitees(
+      limit: limit,
+      page: page,
+      filter: filter,
+      sort: sort,
+      completion: completion
+    )
+  }
+
   public func getUserSuggestions(
     text: String,
     limit: Int = 10,

--- a/Sources/Entities/ThreadMessageImpl.swift
+++ b/Sources/Entities/ThreadMessageImpl.swift
@@ -238,12 +238,12 @@ extension ThreadMessageImpl: ThreadMessage {
     )
   }
 
-  public func createThreadWithResult(
+  public func createThread(
     text: String,
     params: SendTextParams = SendTextParams(),
     completion: ((Swift.Result<CreateThreadResult<ThreadChannelImpl, MessageImpl>, Error>) -> Void)? = nil
   ) {
-    target.createThreadWithResult(
+    target.createThread(
       text: text,
       params: params,
       completion: completion

--- a/Tests/AsyncAwait/ChannelAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/ChannelAsyncIntegrationTests.swift
@@ -880,6 +880,32 @@ class ChannelAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
     }
   }
 
+  func testChannelAsync_GetInvitees() async throws {
+    let someUser = try await chat.createUser(user: UserImpl(chat: chat, id: randomString()))
+    try await channel.inviteMultiple(users: [chat.currentUser, someUser])
+
+    let invitees = try await channel.getInvitees().memberships
+
+    let firstMatch = try XCTUnwrap(
+      invitees.first {
+        $0.user.id == chat.currentUser.id && $0.channel.id == channel.id
+      }
+    )
+    let secondMatch = try XCTUnwrap(
+      invitees.first {
+        $0.user.id == someUser.id && $0.channel.id == channel.id
+      }
+    )
+
+    XCTAssertEqual(invitees.count, 2)
+    XCTAssertNotNil(firstMatch)
+    XCTAssertNotNil(secondMatch)
+
+    addTeardownBlock { [unowned self] in
+      _ = try? await chat.deleteUser(id: someUser.id)
+    }
+  }
+
   func testChannelAsync_SendTextWithParams() async throws {
     let params = SendTextParams(
       meta: ["x": 42, "y": "hello"],

--- a/Tests/AsyncAwait/ChannelAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/ChannelAsyncIntegrationTests.swift
@@ -372,6 +372,7 @@ class ChannelAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
 
     XCTAssertEqual(membership.channel.id, channel.id)
     XCTAssertEqual(membership.user.id, chat.currentUser.id)
+    XCTAssertEqual(membership.status, "")
   }
 
   func testChannelAsync_Leave() async throws {

--- a/Tests/AsyncAwait/MembershipAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/MembershipAsyncIntegrationTests.swift
@@ -45,12 +45,18 @@ class MembershipAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
 
   func testMembershipAsync_Update() async throws {
     let newCustom: [String: JSONCodableScalar] = ["a": 1, "b": "Lorem ipsum", "c": 3.557]
-    let updatedMembership = try await membership.update(custom: newCustom)
+    let updatedMembership = try await membership.update(
+      custom: newCustom,
+      status: "active",
+      type: "premium"
+    )
 
     XCTAssertEqual(
       newCustom.mapValues { $0.scalarValue },
       updatedMembership.custom?.mapValues { $0.scalarValue }
     )
+    XCTAssertEqual(updatedMembership.status, "active")
+    XCTAssertEqual(updatedMembership.type, "premium")
   }
 
   func testMembershipAsync_SetLastReadMessageTimetoken() async throws {

--- a/Tests/AsyncAwait/MessageAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/MessageAsyncIntegrationTests.swift
@@ -129,7 +129,7 @@ class MessageAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
   }
 
   func testAsyncMessage_CreateThreadWithParameters() async throws {
-    let threadChannel = try await testMessage.createThread(text: "This is reply in a thread")
+    let threadChannel = try await testMessage.createThread(text: "This is reply in a thread").threadChannel
     XCTAssertEqual(threadChannel.parentMessage.timetoken, testMessage.timetoken)
     XCTAssertEqual(threadChannel.parentChannelId, testMessage.channelId)
 
@@ -147,12 +147,12 @@ class MessageAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
     }
   }
 
-  func testAsyncMessage_CreateThreadWithResult() async throws {
+  func testAsyncMessage_CreateThread_WithResult() async throws {
     let params = SendTextParams(
       meta: ["key": "value"],
       shouldStore: true
     )
-    let result = try await testMessage.createThreadWithResult(
+    let result = try await testMessage.createThread(
       text: "Thread reply with params",
       params: params
     )

--- a/Tests/ChannelIntegrationTests.swift
+++ b/Tests/ChannelIntegrationTests.swift
@@ -517,6 +517,7 @@ class ChannelIntegrationTests: BaseClosureIntegrationTestCase {
 
     XCTAssertEqual(membership.channel.id, channel.id)
     XCTAssertEqual(membership.user.id, chat.currentUser.id)
+    XCTAssertEqual(membership.status, "")
   }
 
   func testChannel_Leave() throws {

--- a/Tests/ChannelIntegrationTests.swift
+++ b/Tests/ChannelIntegrationTests.swift
@@ -1201,6 +1201,56 @@ class ChannelIntegrationTests: BaseClosureIntegrationTestCase {
     }
   }
 
+  func testChannel_GetInvitees() throws {
+    let someUser = UserImpl(
+      chat: chat,
+      id: randomString()
+    )
+
+    try awaitResultValue {
+      chat.createUser(
+        user: someUser,
+        completion: $0
+      )
+    }
+
+    try awaitResultValue {
+      channel.inviteMultiple(
+        users: [chat.currentUser, someUser],
+        completion: $0
+      )
+    }
+
+    let invitees = try XCTUnwrap(
+      awaitResultValue {
+        channel.getInvitees(
+          completion: $0
+        )
+      }.memberships
+    )
+
+    let firstMatch = try XCTUnwrap(
+      invitees.first {
+        $0.user.id == chat.currentUser.id && $0.channel.id == channel.id
+      }
+    )
+    let secondMatch = try XCTUnwrap(
+      invitees.first {
+        $0.user.id == someUser.id && $0.channel.id == channel.id
+      }
+    )
+
+    XCTAssertEqual(invitees.count, 2)
+    XCTAssertNotNil(firstMatch)
+    XCTAssertNotNil(secondMatch)
+
+    addTeardownBlock { [unowned self] in
+      try awaitResult {
+        chat.deleteUser(id: someUser.id, completion: $0)
+      }
+    }
+  }
+
   func testChannel_SendTextWithParams() throws {
     let params = SendTextParams(
       meta: ["x": 42, "y": "hello"],

--- a/Tests/MembershipIntegrationTests.swift
+++ b/Tests/MembershipIntegrationTests.swift
@@ -73,6 +73,8 @@ final class MembershipTests: BaseClosureIntegrationTestCase {
     let newValue = try awaitResultValue {
       membership.update(
         custom: newCustom,
+        status: "active",
+        type: "premium",
         completion: $0
       )
     }
@@ -80,6 +82,8 @@ final class MembershipTests: BaseClosureIntegrationTestCase {
       newCustom.mapValues { $0.scalarValue },
       newValue.custom?.mapValues { $0.scalarValue }
     )
+    XCTAssertEqual(newValue.status, "active")
+    XCTAssertEqual(newValue.type, "premium")
   }
 
   func testMembership_SetLastReadMessageTimetoken() throws {

--- a/Tests/MessageIntegrationTests.swift
+++ b/Tests/MessageIntegrationTests.swift
@@ -274,7 +274,7 @@ final class MessageIntegrationTests: BaseClosureIntegrationTestCase {
         text: "This is reply in a thread",
         completion: $0
       )
-    }
+    }.threadChannel
 
     let threadChannelHistory = try awaitResultValue(delay: 4) {
       threadChannel.getHistory(
@@ -300,14 +300,14 @@ final class MessageIntegrationTests: BaseClosureIntegrationTestCase {
     }
   }
 
-  func testMessage_CreateThreadWithResult() throws {
+  func testMessage_CreateThread_WithResult() throws {
     let params = SendTextParams(
       meta: ["key": "value"],
       shouldStore: true
     )
 
     let result = try awaitResultValue {
-      testMessage.createThreadWithResult(
+      testMessage.createThread(
         text: "Thread reply with params",
         params: params,
         completion: $0


### PR DESCRIPTION
- Add `status` and `type` parameters to `Membership.update()`
- Add `getInvitees()` method to Channel protocol
- Rename `createThreadWithResult(text:params:)` to `createThread(text:params:)` and update deprecation messages on older overloads
- Update all DocC documentation