### PR TITLE
Chat SDK 1.0.0

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,61 @@
 name: swift-chat-sdk
 scm: github.com/pubnub/swift-chat-sdk
-version: 0.34.0
+version: 1.0.0
 schema: 1
 changelog:
+  - date: 2026-04-01
+    version: 1.0.0
+    changes:
+      - type: feature
+        text: "All entities now expose `onXxx(callback:)` closure-based methods and a `stream` property with `AsyncStream`-based equivalents, replacing the previous `connect()`/`streamUpdates()` pattern."
+      - type: feature
+        text: "Added `Channel.onMessageReceived()` and `Channel.onTypingChanged()`, replacing deprecated `connect()` and `getTyping()`."
+      - type: feature
+        text: "Added `Channel.sendText(text:params:completion:)` with new `SendTextParams` struct. Previous multi-param `sendText()` overload is deprecated."
+      - type: feature
+        text: "Added `Channel.emitCustomEvent()` and `Channel.onCustomEvent()` for publishing and listening to custom events with message type filtering."
+      - type: feature
+        text: "Added `Channel.getInvitees()` to return channel members with pending (invited) status."
+      - type: feature
+        text: "Added `Channel.hasMember()` and `Channel.getMember()` membership-oriented convenience methods."
+      - type: feature
+        text: "Added `ChannelGroup.onMessageReceived()` and `ChannelGroup.onPresenceChanged()`, replacing deprecated `connect()` and `streamPresence()`."
+      - type: feature
+        text: "Added `User.onUpdated()`, `User.onDeleted()`, `User.onMentioned()`, `User.onInvited()`, `User.onRestrictionChanged()`, replacing deprecated `streamUpdates()`."
+      - type: feature
+        text: "Added `User.isMemberOf()` and `User.getMembership()` membership-oriented convenience methods."
+      - type: feature
+        text: "Added `Membership.onUpdated()` and `Membership.onDeleted()`, replacing deprecated `streamUpdates()`."
+      - type: feature
+        text: "`Membership.update()` now accepts optional `status` and `type` parameters alongside `custom`."
+      - type: feature
+        text: "Added `Membership.delete()` for deleting a membership relationship."
+      - type: feature
+        text: "Added `Message.onUpdated()`, replacing deprecated `streamUpdates()` for listening to message edits and reaction changes."
+      - type: feature
+        text: "Added `Message.createThread(text:params:completion:)` returning `CreateThreadResult` with thread channel and updated parent message."
+      - type: feature
+        text: "`ThreadChannelImpl` returns typed `ThreadChannelImpl` and `ThreadMessageImpl` from `update()`, `getMessage()`, `getPinnedMessage()`, `getHistory()` instead of base types."
+      - type: feature
+        text: "Added `ThreadChannelImpl.onMessageReceived()` and `ThreadChannelImpl.onUpdated()`, returning typed `ThreadMessageImpl` and `ThreadChannelImpl` instead of base types."
+      - type: feature
+        text: "`ThreadMessageImpl` returns typed `ThreadMessageImpl` from `editText()`, `toggleReaction()`, `restore()` instead of base types."
+      - type: feature
+        text: "Added `ThreadMessageImpl.onUpdated()`, returning typed `ThreadMessageImpl` for thread message updates."
+      - type: feature
+        text: "Added `ChatConfiguration.emitReadReceiptEvents` as `[ChannelType: Bool]` for per-channel-type control over read receipt event emission. Defaults to `true` except for `.public` channels."
+      - type: improvement
+        text: "BREAKING CHANGES: `Channel.join()` now only creates membership without subscribing or setting `lastReadMessageTimetoken`. Previous `join()` signature removed along with `JoinResult` type."
+      - type: improvement
+        text: "BREAKING CHANGES: `Message.reactions` changed from `[String: [Action]]` to `[MessageReaction]` with `isMine`, `userIds`, `count` per reaction."
+      - type: improvement
+        text: "BREAKING CHANGES: `Message.removeThread()` completion now returns `Void` instead of a tuple of remove result and optional channel."
+      - type: improvement
+        text: "BREAKING CHANGES: `Channel.delete()` and `Chat.deleteChannel()` now permanently delete. The `soft` parameter is removed."
+      - type: improvement
+        text: "BREAKING CHANGES: `User.delete()` and `Chat.deleteUser()` now permanently delete. The `soft` parameter is removed."
+      - type: improvement
+        text: "`Chat.emitEvent()` and `Chat.listenForEvents()` deprecated. Replaced by entity-level methods like `Channel.emitCustomEvent()` and `User.onMentioned()`."
   - date: 2026-01-26
     version: 0.34.0
     changes:
@@ -207,7 +260,7 @@ sdks:
           - distribution-type: source
             distribution-repository: GitHub release
             package-name: PubNubSwiftChatSDK
-            location: https://github.com/pubnub/swift-chat-sdk/archive/refs/tags/0.34.0.zip
+            location: https://github.com/pubnub/swift-chat-sdk/archive/refs/tags/1.0.0.zip
             supported-platforms:
               supported-operating-systems:
                 iOS:

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(url: "https://github.com/pubnub/kmp-chat", exact: "0.16.2-swift"),
+    .package(url: "https://github.com/pubnub/kmp-chat", exact: "1.0.0-swift"),
     .package(url: "https://github.com/pubnub/swift", exact: "10.1.2")
   ],
   targets: [

--- a/PubNubSwiftChatSDK.xcodeproj/project.pbxproj
+++ b/PubNubSwiftChatSDK.xcodeproj/project.pbxproj
@@ -119,13 +119,15 @@
 		3DB73A7B2C57EA29007FE249 /* ChatImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DB73A7A2C57EA29007FE249 /* ChatImpl.swift */; };
 		3DB73A7D2C57EA94007FE249 /* Timetoken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DB73A7C2C57EA94007FE249 /* Timetoken.swift */; };
 		3DB73A7F2C58CCAE007FE249 /* GetCurrentUserMentionsResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DB73A7E2C58CCAE007FE249 /* GetCurrentUserMentionsResult.swift */; };
-		3DCA168C2F631E6100DE8045 /* PubNubChat in Frameworks */ = {isa = PBXBuildFile; productRef = 3DCA168B2F631E6100DE8045 /* PubNubChat */; };
 		3DCF7DFC2CD0FFCC00889326 /* PubNubSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 3DCF7DFB2CD0FFCC00889326 /* PubNubSDK */; };
+		3DD00C7D2F684E07002FD5F4 /* PubNubChat in Frameworks */ = {isa = PBXBuildFile; productRef = 3DD00C7C2F684E07002FD5F4 /* PubNubChat */; };
 		AA00000000000000000001B1 /* ChannelStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000000000001A1 /* ChannelStream.swift */; };
 		AA00000000000000000002B2 /* UserStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000000000002A2 /* UserStream.swift */; };
 		AA00000000000000000003B3 /* MessageStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000000000003A3 /* MessageStream.swift */; };
 		AA00000000000000000004B4 /* MembershipStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000000000004A4 /* MembershipStream.swift */; };
 		AA00000000000000000005B5 /* ChannelGroupStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000000000005A5 /* ChannelGroupStream.swift */; };
+		AA0001022C000001007FE249 /* SendTextParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001012C000001007FE249 /* SendTextParams.swift */; };
+		AA0001042C000002007FE249 /* CreateThreadResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001032C000002007FE249 /* CreateThreadResult.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -276,6 +278,8 @@
 		AA00000000000000000003A3 /* MessageStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageStream.swift; sourceTree = "<group>"; };
 		AA00000000000000000004A4 /* MembershipStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MembershipStream.swift; sourceTree = "<group>"; };
 		AA00000000000000000005A5 /* ChannelGroupStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelGroupStream.swift; sourceTree = "<group>"; };
+		AA0001012C000001007FE249 /* SendTextParams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendTextParams.swift; sourceTree = "<group>"; };
+		AA0001032C000002007FE249 /* CreateThreadResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateThreadResult.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -291,7 +295,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3DCA168C2F631E6100DE8045 /* PubNubChat in Frameworks */,
+				3DD00C7D2F684E07002FD5F4 /* PubNubChat in Frameworks */,
 				3DCF7DFC2CD0FFCC00889326 /* PubNubSDK in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -528,6 +532,8 @@
 				3DB73A582C53BF18007FE249 /* GetFileItem.swift */,
 				3DB73A642C57A782007FE249 /* CreateDirectConversationResult.swift */,
 				3DB73A662C57A8C5007FE249 /* CreateGroupConversationResult.swift */,
+				AA0001012C000001007FE249 /* SendTextParams.swift */,
+				AA0001032C000002007FE249 /* CreateThreadResult.swift */,
 				3DB73A6A2C57B9D8007FE249 /* GetUnreadMessagesCount.swift */,
 				3DB73A702C57C034007FE249 /* Event.swift */,
 				3DB73A7E2C58CCAE007FE249 /* GetCurrentUserMentionsResult.swift */,
@@ -590,7 +596,7 @@
 			name = PubNubSwiftChatSDK;
 			packageProductDependencies = (
 				3DCF7DFB2CD0FFCC00889326 /* PubNubSDK */,
-				3DCA168B2F631E6100DE8045 /* PubNubChat */,
+				3DD00C7C2F684E07002FD5F4 /* PubNubChat */,
 			);
 			productName = PubNubChatSDK;
 			productReference = 3DB73A072C4FE13C007FE249 /* PubNubSwiftChatSDK.framework */;
@@ -647,7 +653,7 @@
 			mainGroup = 3DB739FD2C4FE13B007FE249;
 			packageReferences = (
 				3DCF7DFA2CD0FFCC00889326 /* XCRemoteSwiftPackageReference "swift" */,
-				3DCA168A2F631E6100DE8045 /* XCRemoteSwiftPackageReference "kmp-chat" */,
+				3DD00C7B2F684E07002FD5F4 /* XCRemoteSwiftPackageReference "kmp-chat" */,
 			);
 			productRefGroup = 3DB73A082C4FE13C007FE249 /* Products */;
 			projectDirPath = "";
@@ -766,6 +772,8 @@
 				3D64DC772F58A803004AC52B /* CustomEvent.swift in Sources */,
 				3D1CE5232D79DED800617200 /* String+Helpers.swift in Sources */,
 				3DB73A672C57A8C5007FE249 /* CreateGroupConversationResult.swift in Sources */,
+				AA0001022C000001007FE249 /* SendTextParams.swift in Sources */,
+				AA0001042C000002007FE249 /* CreateThreadResult.swift in Sources */,
 				3DB2A8B52C807E2A00167058 /* MembershipImpl.swift in Sources */,
 				3D0F90D32D48DB4700986686 /* MutedUsersManagerInterface.swift in Sources */,
 				3DB2A8B92C80993B00167058 /* ChannelType.swift in Sources */,
@@ -1176,14 +1184,6 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		3DCA168A2F631E6100DE8045 /* XCRemoteSwiftPackageReference "kmp-chat" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/pubnub/kmp-chat";
-			requirement = {
-				kind = exactVersion;
-				version = "0.16.2-swift";
-			};
-		};
 		3DCF7DFA2CD0FFCC00889326 /* XCRemoteSwiftPackageReference "swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/pubnub/swift";
@@ -1192,18 +1192,26 @@
 				version = 10.1.2;
 			};
 		};
+		3DD00C7B2F684E07002FD5F4 /* XCRemoteSwiftPackageReference "kmp-chat" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/pubnub/kmp-chat";
+			requirement = {
+				kind = exactVersion;
+				version = "0.16.2-swift";
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		3DCA168B2F631E6100DE8045 /* PubNubChat */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 3DCA168A2F631E6100DE8045 /* XCRemoteSwiftPackageReference "kmp-chat" */;
-			productName = PubNubChat;
-		};
 		3DCF7DFB2CD0FFCC00889326 /* PubNubSDK */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 3DCF7DFA2CD0FFCC00889326 /* XCRemoteSwiftPackageReference "swift" */;
 			productName = PubNubSDK;
+		};
+		3DD00C7C2F684E07002FD5F4 /* PubNubChat */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3DD00C7B2F684E07002FD5F4 /* XCRemoteSwiftPackageReference "kmp-chat" */;
+			productName = PubNubChat;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/PubNubSwiftChatSDK.xcodeproj/project.pbxproj
+++ b/PubNubSwiftChatSDK.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		3D0F90D52D48DEC700986686 /* MutedUsersManagerInterface+AsyncAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D0F90D42D48DEC700986686 /* MutedUsersManagerInterface+AsyncAwait.swift */; };
 		3D1CE5232D79DED800617200 /* String+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1CE5222D79DED800617200 /* String+Helpers.swift */; };
 		3D1E67D72E3CBC84001454C1 /* ConnectionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1E67D62E3CBC84001454C1 /* ConnectionStatus.swift */; };
+		3D1E67D92E3CBCA0001454C1 /* MessageReaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1E67D82E3CBCA0001454C1 /* MessageReaction.swift */; };
+		3D1E67DA2E3CBCB0001454C1 /* ReadReceipt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1E67DB2E3CBCB0001454C1 /* ReadReceipt.swift */; };
 		3D27B8D02D2D9A61003AD459 /* ThreadChannelAsyncIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D27B8CF2D2D9A61003AD459 /* ThreadChannelAsyncIntegrationTests.swift */; };
 		3D27B8D22D2D9BBB003AD459 /* ThreadChannel+AsyncAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D27B8D12D2D9BBB003AD459 /* ThreadChannel+AsyncAwait.swift */; };
 		3D27B8D42D2EAEA6003AD459 /* MessageDraftAsyncIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D27B8D32D2EAEA5003AD459 /* MessageDraftAsyncIntegrationTests.swift */; };
@@ -155,6 +157,8 @@
 		3D0F90D42D48DEC700986686 /* MutedUsersManagerInterface+AsyncAwait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MutedUsersManagerInterface+AsyncAwait.swift"; sourceTree = "<group>"; };
 		3D1CE5222D79DED800617200 /* String+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Helpers.swift"; sourceTree = "<group>"; };
 		3D1E67D62E3CBC84001454C1 /* ConnectionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionStatus.swift; sourceTree = "<group>"; };
+		3D1E67D82E3CBCA0001454C1 /* MessageReaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageReaction.swift; sourceTree = "<group>"; };
+		3D1E67DB2E3CBCB0001454C1 /* ReadReceipt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadReceipt.swift; sourceTree = "<group>"; };
 		3D27B8CF2D2D9A61003AD459 /* ThreadChannelAsyncIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadChannelAsyncIntegrationTests.swift; sourceTree = "<group>"; };
 		3D27B8D12D2D9BBB003AD459 /* ThreadChannel+AsyncAwait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ThreadChannel+AsyncAwait.swift"; sourceTree = "<group>"; };
 		3D27B8D32D2EAEA5003AD459 /* MessageDraftAsyncIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageDraftAsyncIntegrationTests.swift; sourceTree = "<group>"; };
@@ -505,6 +509,8 @@
 				3DB2A8B82C80993B00167058 /* ChannelType.swift */,
 				3DB2A8BE2C809B1F00167058 /* EmitEventMethod.swift */,
 				3D1E67D62E3CBC84001454C1 /* ConnectionStatus.swift */,
+				3D1E67D82E3CBCA0001454C1 /* MessageReaction.swift */,
+				3D1E67DB2E3CBCB0001454C1 /* ReadReceipt.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -699,6 +705,8 @@
 				3D2CA2382C5B9ACA008D2284 /* File.swift in Sources */,
 				3DB5A3192E2F900B001741C8 /* ChannelGroupImpl.swift in Sources */,
 				3D1E67D72E3CBC84001454C1 /* ConnectionStatus.swift in Sources */,
+				3D1E67D92E3CBCA0001454C1 /* MessageReaction.swift in Sources */,
+				3D1E67DA2E3CBCB0001454C1 /* ReadReceipt.swift in Sources */,
 				3DB73A752C57D073007FE249 /* PubNubChat.Event.swift in Sources */,
 				3D2CA2362C5B9320008D2284 /* PubNubChat+Transform.swift in Sources */,
 				3DB73A492C513578007FE249 /* MessageReferencedChannel.swift in Sources */,

--- a/PubNubSwiftChatSDK.xcodeproj/project.pbxproj
+++ b/PubNubSwiftChatSDK.xcodeproj/project.pbxproj
@@ -1028,7 +1028,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 0.34.0;
+				MARKETING_VERSION = 1.0.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS";
@@ -1076,7 +1076,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 0.34.0;
+				MARKETING_VERSION = 1.0.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS";

--- a/PubNubSwiftChatSDK.xcodeproj/project.pbxproj
+++ b/PubNubSwiftChatSDK.xcodeproj/project.pbxproj
@@ -1197,7 +1197,7 @@
 			repositoryURL = "https://github.com/pubnub/kmp-chat";
 			requirement = {
 				kind = exactVersion;
-				version = "0.16.2-swift";
+				version = "1.0.0-swift";
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/PubNubSwiftChatSDK.xcodeproj/project.pbxproj
+++ b/PubNubSwiftChatSDK.xcodeproj/project.pbxproj
@@ -20,7 +20,6 @@
 		3D27B8D22D2D9BBB003AD459 /* ThreadChannel+AsyncAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D27B8D12D2D9BBB003AD459 /* ThreadChannel+AsyncAwait.swift */; };
 		3D27B8D42D2EAEA6003AD459 /* MessageDraftAsyncIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D27B8D32D2EAEA5003AD459 /* MessageDraftAsyncIntegrationTests.swift */; };
 		3D27B8D62D2EAF86003AD459 /* MessageDraft+AsyncAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D27B8D52D2EAF86003AD459 /* MessageDraft+AsyncAwait.swift */; };
-		3D2813212D7B4EF4004623A0 /* PubNubChat in Frameworks */ = {isa = PBXBuildFile; productRef = 3D2813202D7B4EF4004623A0 /* PubNubChat */; };
 		3D2CA2362C5B9320008D2284 /* PubNubChat+Transform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D2CA2352C5B9320008D2284 /* PubNubChat+Transform.swift */; };
 		3D2CA2382C5B9ACA008D2284 /* File.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D2CA2372C5B9ACA008D2284 /* File.swift */; };
 		3D2CA23A2C5B9CF6008D2284 /* Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D2CA2392C5B9CF6008D2284 /* Dictionary.swift */; };
@@ -49,6 +48,9 @@
 		3D46D4682D13287A007D08DB /* IntegrationTestCaseConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D46D42F2D122C8F007D08DB /* IntegrationTestCaseConfiguration.swift */; };
 		3D46D46A2D142035007D08DB /* ThreadMessageAsyncIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D46D4692D142035007D08DB /* ThreadMessageAsyncIntegrationTests.swift */; };
 		3D46D46C2D14BF2D007D08DB /* ChannelAsyncIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D46D46B2D14BF2D007D08DB /* ChannelAsyncIntegrationTests.swift */; };
+		3D64DC732F58A58C004AC52B /* Mention.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D64DC722F58A58C004AC52B /* Mention.swift */; };
+		3D64DC742F58A58C004AC52B /* Invite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D64DC712F58A58C004AC52B /* Invite.swift */; };
+		3D64DC762F58A803004AC52B /* Report.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D64DC752F58A803004AC52B /* Report.swift */; };
 		3D7062C62D2D4A4F000729E1 /* ChatAsyncIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D7062C52D2D4A4F000729E1 /* ChatAsyncIntegrationTests.swift */; };
 		3D7062C82D2D82A5000729E1 /* User+AsyncAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D7062C72D2D82A5000729E1 /* User+AsyncAwait.swift */; };
 		3D7062CB2D2D8C27000729E1 /* UserAsyncIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D7062C92D2D8BD9000729E1 /* UserAsyncIntegrationTests.swift */; };
@@ -116,7 +118,12 @@
 		3DB73A7B2C57EA29007FE249 /* ChatImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DB73A7A2C57EA29007FE249 /* ChatImpl.swift */; };
 		3DB73A7D2C57EA94007FE249 /* Timetoken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DB73A7C2C57EA94007FE249 /* Timetoken.swift */; };
 		3DB73A7F2C58CCAE007FE249 /* GetCurrentUserMentionsResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DB73A7E2C58CCAE007FE249 /* GetCurrentUserMentionsResult.swift */; };
+		3DBEDAFC2F59A47300D7BB8F /* PubNubChat in Frameworks */ = {isa = PBXBuildFile; productRef = 3DBEDAFB2F59A47300D7BB8F /* PubNubChat */; };
 		3DCF7DFC2CD0FFCC00889326 /* PubNubSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 3DCF7DFB2CD0FFCC00889326 /* PubNubSDK */; };
+		AA00000000000000000001B1 /* ChannelStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000000000001A1 /* ChannelStream.swift */; };
+		AA00000000000000000002B2 /* UserStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000000000002A2 /* UserStream.swift */; };
+		AA00000000000000000003B3 /* MessageStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000000000003A3 /* MessageStream.swift */; };
+		AA00000000000000000004B4 /* MembershipStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000000000004A4 /* MembershipStream.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -188,6 +195,9 @@
 		3D46D4662D1320F6007D08DB /* MessageAsyncIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageAsyncIntegrationTests.swift; sourceTree = "<group>"; };
 		3D46D4692D142035007D08DB /* ThreadMessageAsyncIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadMessageAsyncIntegrationTests.swift; sourceTree = "<group>"; };
 		3D46D46B2D14BF2D007D08DB /* ChannelAsyncIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelAsyncIntegrationTests.swift; sourceTree = "<group>"; };
+		3D64DC712F58A58C004AC52B /* Invite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Invite.swift; sourceTree = "<group>"; };
+		3D64DC722F58A58C004AC52B /* Mention.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mention.swift; sourceTree = "<group>"; };
+		3D64DC752F58A803004AC52B /* Report.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Report.swift; sourceTree = "<group>"; };
 		3D7062C52D2D4A4F000729E1 /* ChatAsyncIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAsyncIntegrationTests.swift; sourceTree = "<group>"; };
 		3D7062C72D2D82A5000729E1 /* User+AsyncAwait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "User+AsyncAwait.swift"; sourceTree = "<group>"; };
 		3D7062C92D2D8BD9000729E1 /* UserAsyncIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAsyncIntegrationTests.swift; sourceTree = "<group>"; };
@@ -258,6 +268,10 @@
 		3DB73A7A2C57EA29007FE249 /* ChatImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatImpl.swift; sourceTree = "<group>"; };
 		3DB73A7C2C57EA94007FE249 /* Timetoken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Timetoken.swift; sourceTree = "<group>"; };
 		3DB73A7E2C58CCAE007FE249 /* GetCurrentUserMentionsResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetCurrentUserMentionsResult.swift; sourceTree = "<group>"; };
+		AA00000000000000000001A1 /* ChannelStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelStream.swift; sourceTree = "<group>"; };
+		AA00000000000000000002A2 /* UserStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserStream.swift; sourceTree = "<group>"; };
+		AA00000000000000000003A3 /* MessageStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageStream.swift; sourceTree = "<group>"; };
+		AA00000000000000000004A4 /* MembershipStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MembershipStream.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -273,7 +287,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3D2813212D7B4EF4004623A0 /* PubNubChat in Frameworks */,
+				3DBEDAFC2F59A47300D7BB8F /* PubNubChat in Frameworks */,
 				3DCF7DFC2CD0FFCC00889326 /* PubNubSDK in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -322,15 +336,15 @@
 			isa = PBXGroup;
 			children = (
 				3D46D42A2D11DC8D007D08DB /* BaseAsyncIntegrationTestCase.swift */,
+				3D7062C52D2D4A4F000729E1 /* ChatAsyncIntegrationTests.swift */,
+				3D46D46B2D14BF2D007D08DB /* ChannelAsyncIntegrationTests.swift */,
+				3DB5A31D2E30D6DA001741C8 /* ChannelGroupAsyncIntegrationTests.swift */,
 				3D46D42C2D1213C0007D08DB /* MembershipAsyncIntegrationTests.swift */,
 				3D46D4662D1320F6007D08DB /* MessageAsyncIntegrationTests.swift */,
-				3D46D4692D142035007D08DB /* ThreadMessageAsyncIntegrationTests.swift */,
-				3D46D46B2D14BF2D007D08DB /* ChannelAsyncIntegrationTests.swift */,
-				3D27B8CF2D2D9A61003AD459 /* ThreadChannelAsyncIntegrationTests.swift */,
-				3D7062C52D2D4A4F000729E1 /* ChatAsyncIntegrationTests.swift */,
-				3D7062C92D2D8BD9000729E1 /* UserAsyncIntegrationTests.swift */,
 				3D27B8D32D2EAEA5003AD459 /* MessageDraftAsyncIntegrationTests.swift */,
-				3DB5A31D2E30D6DA001741C8 /* ChannelGroupAsyncIntegrationTests.swift */,
+				3D27B8CF2D2D9A61003AD459 /* ThreadChannelAsyncIntegrationTests.swift */,
+				3D46D4692D142035007D08DB /* ThreadMessageAsyncIntegrationTests.swift */,
+				3D7062C92D2D8BD9000729E1 /* UserAsyncIntegrationTests.swift */,
 			);
 			path = AsyncAwait;
 			sourceTree = "<group>";
@@ -394,15 +408,15 @@
 				3D46D4382D12310F007D08DB /* AsyncAwait */,
 				3D46D4282D11D8D2007D08DB /* BaseIntegrationTestCase.swift */,
 				3DB73A162C4FE13C007FE249 /* BaseClosureIntegrationTestCase.swift */,
-				3DA530C72C882F2500DDE763 /* ChatIntegrationTests.swift */,
 				3DB2A8AE2C7F54A400167058 /* ChannelIntegrationTests.swift */,
+				3DB5A31B2E2F9633001741C8 /* ChannelGroupIntegrationTests.swift */,
+				3DA530C72C882F2500DDE763 /* ChatIntegrationTests.swift */,
 				3DB49E272C777ECD006356ED /* MembershipIntegrationTests.swift */,
 				3DB49E292C788529006356ED /* MessageIntegrationTests.swift */,
-				3DB551DA2C7C983000634BDC /* ThreadMessageIntegrationTests.swift */,
-				3DA530C52C87455200DDE763 /* ThreadChannelIntegrationTests.swift */,
 				3D9A17992CC659E800F3F8AB /* MessageDraftIntegrationTests.swift */,
+				3DA530C52C87455200DDE763 /* ThreadChannelIntegrationTests.swift */,
+				3DB551DA2C7C983000634BDC /* ThreadMessageIntegrationTests.swift */,
 				3DB49E1C2C75F70C006356ED /* UserIntegrationTests.swift */,
-				3DB5A31B2E2F9633001741C8 /* ChannelGroupIntegrationTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -461,23 +475,27 @@
 			children = (
 				3DB73A3B2C50F42B007FE249 /* User.swift */,
 				3D7062C72D2D82A5000729E1 /* User+AsyncAwait.swift */,
+				AA00000000000000000002A2 /* UserStream.swift */,
 				3DB2A8B22C807DDC00167058 /* UserImpl.swift */,
+				3DB73A5A2C53CAB1007FE249 /* BaseChannel.swift */,
 				3DB73A3F2C51051C007FE249 /* Channel.swift */,
 				3D46D4392D1231F1007D08DB /* Channel+AsyncAwait.swift */,
+				AA00000000000000000001A1 /* ChannelStream.swift */,
+				3DB73A6E2C57BB97007FE249 /* ChannelImpl.swift */,
 				3D043A792CA6AAA000F91C05 /* ThreadChannel.swift */,
 				3D27B8D12D2D9BBB003AD459 /* ThreadChannel+AsyncAwait.swift */,
-				3DB73A5A2C53CAB1007FE249 /* BaseChannel.swift */,
-				3DB73A6E2C57BB97007FE249 /* ChannelImpl.swift */,
 				3DB73A5C2C53CC0A007FE249 /* ThreadChannelImpl.swift */,
 				3DB73A3D2C50F5F3007FE249 /* Membership.swift */,
 				3D46D4352D12302E007D08DB /* Membership+AsyncAwait.swift */,
+				AA00000000000000000004A4 /* MembershipStream.swift */,
 				3DB2A8B42C807E2A00167058 /* MembershipImpl.swift */,
+				3DB73A6C2C57BB35007FE249 /* BaseMessage.swift */,
 				3DB73A412C511900007FE249 /* Message.swift */,
 				3D46D43F2D130526007D08DB /* Message+AsyncAwait.swift */,
+				AA00000000000000000003A3 /* MessageStream.swift */,
+				3DB73A522C53A20C007FE249 /* MessageImpl.swift */,
 				3D043A7B2CAAABBD00F91C05 /* ThreadMessage.swift */,
 				3D46D4412D131BBC007D08DB /* ThreadMessage+AsyncAwait.swift */,
-				3DB73A6C2C57BB35007FE249 /* BaseMessage.swift */,
-				3DB73A522C53A20C007FE249 /* MessageImpl.swift */,
 				3DB73A542C53A22F007FE249 /* ThreadMessageImpl.swift */,
 				3DB5A3162E2F848A001741C8 /* ChannelGroup.swift */,
 				3DB5A3182E2F900B001741C8 /* ChannelGroupImpl.swift */,
@@ -489,6 +507,9 @@
 		3DB73A432C511D36007FE249 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				3D64DC712F58A58C004AC52B /* Invite.swift */,
+				3D64DC722F58A58C004AC52B /* Mention.swift */,
+				3D64DC752F58A803004AC52B /* Report.swift */,
 				3D2CA23B2C5B9E51008D2284 /* Action.swift */,
 				3DB2A8BA2C8099F300167058 /* EventContent.swift */,
 				3DB2A8BC2C809A1400167058 /* ChatError.swift */,
@@ -563,7 +584,7 @@
 			name = PubNubSwiftChatSDK;
 			packageProductDependencies = (
 				3DCF7DFB2CD0FFCC00889326 /* PubNubSDK */,
-				3D2813202D7B4EF4004623A0 /* PubNubChat */,
+				3DBEDAFB2F59A47300D7BB8F /* PubNubChat */,
 			);
 			productName = PubNubChatSDK;
 			productReference = 3DB73A072C4FE13C007FE249 /* PubNubSwiftChatSDK.framework */;
@@ -620,7 +641,7 @@
 			mainGroup = 3DB739FD2C4FE13B007FE249;
 			packageReferences = (
 				3DCF7DFA2CD0FFCC00889326 /* XCRemoteSwiftPackageReference "swift" */,
-				3D28131F2D7B4EF4004623A0 /* XCRemoteSwiftPackageReference "kmp-chat" */,
+				3DBEDAFA2F59A47300D7BB8F /* XCRemoteSwiftPackageReference "kmp-chat" */,
 			);
 			productRefGroup = 3DB73A082C4FE13C007FE249 /* Products */;
 			projectDirPath = "";
@@ -686,6 +707,8 @@
 			files = (
 				3DB73A392C5026E5007FE249 /* PubNub.MembershipSortField.swift in Sources */,
 				3DB73A0C2C4FE13C007FE249 /* PubNubSwiftChatSDK.docc in Sources */,
+				3D64DC732F58A58C004AC52B /* Mention.swift in Sources */,
+				3D64DC742F58A58C004AC52B /* Invite.swift in Sources */,
 				3D2CA2402C5BBDB6008D2284 /* PubNubChat.PNPushEnvironment.swift in Sources */,
 				3DB73A4D2C513646007FE249 /* TextLink.swift in Sources */,
 				3DB73A692C57AA1B007FE249 /* PubNubChat.KotlinArray.swift in Sources */,
@@ -733,6 +756,7 @@
 				3DB73A6B2C57B9D8007FE249 /* GetUnreadMessagesCount.swift in Sources */,
 				3DB49E212C761BD1006356ED /* AutoCloseable.swift in Sources */,
 				3DB73A532C53A20C007FE249 /* MessageImpl.swift in Sources */,
+				3D64DC762F58A803004AC52B /* Report.swift in Sources */,
 				3D1CE5232D79DED800617200 /* String+Helpers.swift in Sources */,
 				3DB73A672C57A8C5007FE249 /* CreateGroupConversationResult.swift in Sources */,
 				3DB2A8B52C807E2A00167058 /* MembershipImpl.swift in Sources */,
@@ -761,6 +785,10 @@
 				3D334BD02C8EE9E500F8793C /* PubNub.PushService.swift in Sources */,
 				3DB73A512C539421007FE249 /* InputFile.swift in Sources */,
 				3D842D242C9DC0AA005C0B55 /* ErrorConstants.swift in Sources */,
+				AA00000000000000000001B1 /* ChannelStream.swift in Sources */,
+				AA00000000000000000002B2 /* UserStream.swift in Sources */,
+				AA00000000000000000003B3 /* MessageStream.swift in Sources */,
+				AA00000000000000000004B4 /* MembershipStream.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1140,7 +1168,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		3D28131F2D7B4EF4004623A0 /* XCRemoteSwiftPackageReference "kmp-chat" */ = {
+		3DBEDAFA2F59A47300D7BB8F /* XCRemoteSwiftPackageReference "kmp-chat" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/pubnub/kmp-chat";
 			requirement = {
@@ -1159,9 +1187,9 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		3D2813202D7B4EF4004623A0 /* PubNubChat */ = {
+		3DBEDAFB2F59A47300D7BB8F /* PubNubChat */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 3D28131F2D7B4EF4004623A0 /* XCRemoteSwiftPackageReference "kmp-chat" */;
+			package = 3DBEDAFA2F59A47300D7BB8F /* XCRemoteSwiftPackageReference "kmp-chat" */;
 			productName = PubNubChat;
 		};
 		3DCF7DFB2CD0FFCC00889326 /* PubNubSDK */ = {

--- a/PubNubSwiftChatSDK.xcodeproj/project.pbxproj
+++ b/PubNubSwiftChatSDK.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		3D64DC732F58A58C004AC52B /* Mention.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D64DC722F58A58C004AC52B /* Mention.swift */; };
 		3D64DC742F58A58C004AC52B /* Invite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D64DC712F58A58C004AC52B /* Invite.swift */; };
 		3D64DC762F58A803004AC52B /* Report.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D64DC752F58A803004AC52B /* Report.swift */; };
+		3D64DC772F58A803004AC52B /* CustomEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D64DC782F58A803004AC52B /* CustomEvent.swift */; };
 		3D7062C62D2D4A4F000729E1 /* ChatAsyncIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D7062C52D2D4A4F000729E1 /* ChatAsyncIntegrationTests.swift */; };
 		3D7062C82D2D82A5000729E1 /* User+AsyncAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D7062C72D2D82A5000729E1 /* User+AsyncAwait.swift */; };
 		3D7062CB2D2D8C27000729E1 /* UserAsyncIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D7062C92D2D8BD9000729E1 /* UserAsyncIntegrationTests.swift */; };
@@ -118,12 +119,13 @@
 		3DB73A7B2C57EA29007FE249 /* ChatImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DB73A7A2C57EA29007FE249 /* ChatImpl.swift */; };
 		3DB73A7D2C57EA94007FE249 /* Timetoken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DB73A7C2C57EA94007FE249 /* Timetoken.swift */; };
 		3DB73A7F2C58CCAE007FE249 /* GetCurrentUserMentionsResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DB73A7E2C58CCAE007FE249 /* GetCurrentUserMentionsResult.swift */; };
-		3DBEDAFC2F59A47300D7BB8F /* PubNubChat in Frameworks */ = {isa = PBXBuildFile; productRef = 3DBEDAFB2F59A47300D7BB8F /* PubNubChat */; };
+		3DCA168C2F631E6100DE8045 /* PubNubChat in Frameworks */ = {isa = PBXBuildFile; productRef = 3DCA168B2F631E6100DE8045 /* PubNubChat */; };
 		3DCF7DFC2CD0FFCC00889326 /* PubNubSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 3DCF7DFB2CD0FFCC00889326 /* PubNubSDK */; };
 		AA00000000000000000001B1 /* ChannelStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000000000001A1 /* ChannelStream.swift */; };
 		AA00000000000000000002B2 /* UserStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000000000002A2 /* UserStream.swift */; };
 		AA00000000000000000003B3 /* MessageStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000000000003A3 /* MessageStream.swift */; };
 		AA00000000000000000004B4 /* MembershipStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000000000004A4 /* MembershipStream.swift */; };
+		AA00000000000000000005B5 /* ChannelGroupStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000000000005A5 /* ChannelGroupStream.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -198,6 +200,7 @@
 		3D64DC712F58A58C004AC52B /* Invite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Invite.swift; sourceTree = "<group>"; };
 		3D64DC722F58A58C004AC52B /* Mention.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mention.swift; sourceTree = "<group>"; };
 		3D64DC752F58A803004AC52B /* Report.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Report.swift; sourceTree = "<group>"; };
+		3D64DC782F58A803004AC52B /* CustomEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomEvent.swift; sourceTree = "<group>"; };
 		3D7062C52D2D4A4F000729E1 /* ChatAsyncIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAsyncIntegrationTests.swift; sourceTree = "<group>"; };
 		3D7062C72D2D82A5000729E1 /* User+AsyncAwait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "User+AsyncAwait.swift"; sourceTree = "<group>"; };
 		3D7062C92D2D8BD9000729E1 /* UserAsyncIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAsyncIntegrationTests.swift; sourceTree = "<group>"; };
@@ -272,6 +275,7 @@
 		AA00000000000000000002A2 /* UserStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserStream.swift; sourceTree = "<group>"; };
 		AA00000000000000000003A3 /* MessageStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageStream.swift; sourceTree = "<group>"; };
 		AA00000000000000000004A4 /* MembershipStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MembershipStream.swift; sourceTree = "<group>"; };
+		AA00000000000000000005A5 /* ChannelGroupStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelGroupStream.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -287,7 +291,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3DBEDAFC2F59A47300D7BB8F /* PubNubChat in Frameworks */,
+				3DCA168C2F631E6100DE8045 /* PubNubChat in Frameworks */,
 				3DCF7DFC2CD0FFCC00889326 /* PubNubSDK in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -500,6 +504,7 @@
 				3DB5A3162E2F848A001741C8 /* ChannelGroup.swift */,
 				3DB5A3182E2F900B001741C8 /* ChannelGroupImpl.swift */,
 				3DB5A31F2E30D771001741C8 /* ChannelGroup+AsyncAwait.swift */,
+				AA00000000000000000005A5 /* ChannelGroupStream.swift */,
 			);
 			path = Entities;
 			sourceTree = "<group>";
@@ -510,6 +515,7 @@
 				3D64DC712F58A58C004AC52B /* Invite.swift */,
 				3D64DC722F58A58C004AC52B /* Mention.swift */,
 				3D64DC752F58A803004AC52B /* Report.swift */,
+				3D64DC782F58A803004AC52B /* CustomEvent.swift */,
 				3D2CA23B2C5B9E51008D2284 /* Action.swift */,
 				3DB2A8BA2C8099F300167058 /* EventContent.swift */,
 				3DB2A8BC2C809A1400167058 /* ChatError.swift */,
@@ -584,7 +590,7 @@
 			name = PubNubSwiftChatSDK;
 			packageProductDependencies = (
 				3DCF7DFB2CD0FFCC00889326 /* PubNubSDK */,
-				3DBEDAFB2F59A47300D7BB8F /* PubNubChat */,
+				3DCA168B2F631E6100DE8045 /* PubNubChat */,
 			);
 			productName = PubNubChatSDK;
 			productReference = 3DB73A072C4FE13C007FE249 /* PubNubSwiftChatSDK.framework */;
@@ -641,7 +647,7 @@
 			mainGroup = 3DB739FD2C4FE13B007FE249;
 			packageReferences = (
 				3DCF7DFA2CD0FFCC00889326 /* XCRemoteSwiftPackageReference "swift" */,
-				3DBEDAFA2F59A47300D7BB8F /* XCRemoteSwiftPackageReference "kmp-chat" */,
+				3DCA168A2F631E6100DE8045 /* XCRemoteSwiftPackageReference "kmp-chat" */,
 			);
 			productRefGroup = 3DB73A082C4FE13C007FE249 /* Products */;
 			projectDirPath = "";
@@ -757,6 +763,7 @@
 				3DB49E212C761BD1006356ED /* AutoCloseable.swift in Sources */,
 				3DB73A532C53A20C007FE249 /* MessageImpl.swift in Sources */,
 				3D64DC762F58A803004AC52B /* Report.swift in Sources */,
+				3D64DC772F58A803004AC52B /* CustomEvent.swift in Sources */,
 				3D1CE5232D79DED800617200 /* String+Helpers.swift in Sources */,
 				3DB73A672C57A8C5007FE249 /* CreateGroupConversationResult.swift in Sources */,
 				3DB2A8B52C807E2A00167058 /* MembershipImpl.swift in Sources */,
@@ -786,6 +793,7 @@
 				3DB73A512C539421007FE249 /* InputFile.swift in Sources */,
 				3D842D242C9DC0AA005C0B55 /* ErrorConstants.swift in Sources */,
 				AA00000000000000000001B1 /* ChannelStream.swift in Sources */,
+				AA00000000000000000005B5 /* ChannelGroupStream.swift in Sources */,
 				AA00000000000000000002B2 /* UserStream.swift in Sources */,
 				AA00000000000000000003B3 /* MessageStream.swift in Sources */,
 				AA00000000000000000004B4 /* MembershipStream.swift in Sources */,
@@ -1168,7 +1176,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		3DBEDAFA2F59A47300D7BB8F /* XCRemoteSwiftPackageReference "kmp-chat" */ = {
+		3DCA168A2F631E6100DE8045 /* XCRemoteSwiftPackageReference "kmp-chat" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/pubnub/kmp-chat";
 			requirement = {
@@ -1187,9 +1195,9 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		3DBEDAFB2F59A47300D7BB8F /* PubNubChat */ = {
+		3DCA168B2F631E6100DE8045 /* PubNubChat */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 3DBEDAFA2F59A47300D7BB8F /* XCRemoteSwiftPackageReference "kmp-chat" */;
+			package = 3DCA168A2F631E6100DE8045 /* XCRemoteSwiftPackageReference "kmp-chat" */;
 			productName = PubNubChat;
 		};
 		3DCF7DFB2CD0FFCC00889326 /* PubNubSDK */ = {

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/Channel.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/Channel.md
@@ -21,8 +21,8 @@
 
 - ``update(name:custom:description:status:type:)``
 - ``update(name:custom:description:status:type:completion:)``
-- ``delete(soft:)``
-- ``delete(soft:completion:)``
+- ``delete()``
+- ``delete(completion:)``
 
 ### Typing Indicator
 

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/Channel.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/Channel.md
@@ -4,18 +4,30 @@
 
 ### Receiving Updates
 
+- ``stream``
 - ``streamUpdates()``
 - ``streamUpdates(callback:)``
 - ``streamUpdatesOn(channels:)``
 - ``streamUpdatesOn(channels:callback:)``
 - ``streamReadReceipts()``
 - ``streamReadReceipts(callback:)``
-- ``fetchReadReceipts(limit:page:filter:sort:)``
-- ``fetchReadReceipts(limit:page:filter:sort:completion:)``
 - ``streamMessageReports()``
 - ``streamMessageReports(callback:)``
 - ``streamPresence()``
 - ``streamPresence(callback:)``
+- ``onUpdated(callback:)``
+- ``onDeleted(callback:)``
+- ``onTypingChanged(callback:)``
+- ``onMessageReceived(callback:)``
+- ``onReadReceiptReceived(callback:)``
+- ``onPresenceChanged(callback:)``
+- ``onMessageReported(callback:)``
+- ``onCustomEvent(messageType:callback:)``
+
+### Read Receipts
+
+- ``fetchReadReceipts(limit:page:filter:sort:)``
+- ``fetchReadReceipts(limit:page:filter:sort:completion:)``
 
 ### Update and Delete a Channel
 
@@ -39,8 +51,8 @@
 - ``whoIsPresent(limit:offset:completion:)``
 - ``isPresent(userId:)``
 - ``isPresent(userId:completion:)``
-- ``join(custom:)``
-- ``join(custom:callback:completion:)``
+- ``join(custom:status:type:)``
+- ``join(custom:status:type:completion:)``
 - ``leave()``
 - ``leave(completion:)``
 - ``streamPresence()``
@@ -54,6 +66,8 @@
 - ``inviteMultiple(users:completion:)``
 - ``getMembers(limit:page:filter:sort:)``
 - ``getMembers(limit:page:filter:sort:completion:)``
+- ``getInvitees(limit:page:filter:sort:)``
+- ``getInvitees(limit:page:filter:sort:completion:)``
 - ``hasMember(userId:)``
 - ``hasMember(userId:completion:)``
 - ``getMember(userId:)``

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/Channel.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/Channel.md
@@ -10,6 +10,8 @@
 - ``streamUpdatesOn(channels:callback:)``
 - ``streamReadReceipts()``
 - ``streamReadReceipts(callback:)``
+- ``fetchReadReceipts(limit:page:filter:sort:)``
+- ``fetchReadReceipts(limit:page:filter:sort:completion:)``
 - ``streamMessageReports()``
 - ``streamMessageReports(callback:)``
 - ``streamPresence()``
@@ -33,8 +35,8 @@
 
 ### Presence Management
 
-- ``whoIsPresent()``
-- ``whoIsPresent(completion:)``
+- ``whoIsPresent(limit:offset:)``
+- ``whoIsPresent(limit:offset:completion:)``
 - ``isPresent(userId:)``
 - ``isPresent(userId:completion:)``
 - ``join(custom:)``
@@ -52,6 +54,10 @@
 - ``inviteMultiple(users:completion:)``
 - ``getMembers(limit:page:filter:sort:)``
 - ``getMembers(limit:page:filter:sort:completion:)``
+- ``hasMember(userId:)``
+- ``hasMember(userId:completion:)``
+- ``getMember(userId:)``
+- ``getMember(userId:completion:)``
 
 ### Sending a text
 

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ChannelImpl.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ChannelImpl.md
@@ -21,8 +21,8 @@
 
 - ``update(name:custom:description:status:type:)``
 - ``update(name:custom:description:status:type:completion:)``
-- ``delete(soft:)``
-- ``delete(soft:completion:)``
+- ``delete()``
+- ``delete(completion:)``
 
 ### Typing Indicator
 

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ChannelImpl.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ChannelImpl.md
@@ -4,18 +4,30 @@
 
 ### Receiving Updates
 
+- ``stream``
 - ``streamUpdates()``
 - ``streamUpdates(callback:)``
 - ``streamUpdatesOn(channels:)``
 - ``streamUpdatesOn(channels:callback:)``
 - ``streamReadReceipts()``
 - ``streamReadReceipts(callback:)``
-- ``fetchReadReceipts(limit:page:filter:sort:)``
-- ``fetchReadReceipts(limit:page:filter:sort:completion:)``
 - ``streamMessageReports()``
 - ``streamMessageReports(callback:)``
 - ``streamPresence()``
 - ``streamPresence(callback:)``
+- ``onUpdated(callback:)``
+- ``onDeleted(callback:)``
+- ``onTypingChanged(callback:)``
+- ``onMessageReceived(callback:)``
+- ``onReadReceiptReceived(callback:)``
+- ``onPresenceChanged(callback:)``
+- ``onMessageReported(callback:)``
+- ``onCustomEvent(messageType:callback:)``
+
+### Read Receipts
+
+- ``fetchReadReceipts(limit:page:filter:sort:)``
+- ``fetchReadReceipts(limit:page:filter:sort:completion:)``
 
 ### Update and Delete a Channel
 
@@ -39,8 +51,8 @@
 - ``whoIsPresent(limit:offset:completion:)``
 - ``isPresent(userId:)``
 - ``isPresent(userId:completion:)``
-- ``join(custom:)``
-- ``join(custom:callback:completion:)``
+- ``join(custom:status:type:)``
+- ``join(custom:status:type:completion:)``
 - ``leave()``
 - ``leave(completion:)``
 - ``streamPresence()``
@@ -54,6 +66,8 @@
 - ``inviteMultiple(users:completion:)``
 - ``getMembers(limit:page:filter:sort:)``
 - ``getMembers(limit:page:filter:sort:completion:)``
+- ``getInvitees(limit:page:filter:sort:)``
+- ``getInvitees(limit:page:filter:sort:completion:)``
 - ``hasMember(userId:)``
 - ``hasMember(userId:completion:)``
 - ``getMember(userId:)``

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ChannelImpl.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ChannelImpl.md
@@ -10,6 +10,8 @@
 - ``streamUpdatesOn(channels:callback:)``
 - ``streamReadReceipts()``
 - ``streamReadReceipts(callback:)``
+- ``fetchReadReceipts(limit:page:filter:sort:)``
+- ``fetchReadReceipts(limit:page:filter:sort:completion:)``
 - ``streamMessageReports()``
 - ``streamMessageReports(callback:)``
 - ``streamPresence()``
@@ -33,8 +35,8 @@
 
 ### Presence Management
 
-- ``whoIsPresent()``
-- ``whoIsPresent(completion:)``
+- ``whoIsPresent(limit:offset:)``
+- ``whoIsPresent(limit:offset:completion:)``
 - ``isPresent(userId:)``
 - ``isPresent(userId:completion:)``
 - ``join(custom:)``
@@ -52,6 +54,10 @@
 - ``inviteMultiple(users:completion:)``
 - ``getMembers(limit:page:filter:sort:)``
 - ``getMembers(limit:page:filter:sort:completion:)``
+- ``hasMember(userId:)``
+- ``hasMember(userId:completion:)``
+- ``getMember(userId:)``
+- ``getMember(userId:completion:)``
 
 ### Sending a text
 

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/Chat.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/Chat.md
@@ -28,8 +28,8 @@
 - ``updateChannel(id:name:custom:description:status:type:completion:)``
 - ``deleteChannel(id:)``
 - ``deleteChannel(id:completion:)``
-- ``whoIsPresent(channelId:)``
-- ``whoIsPresent(channelId:completion:)``
+- ``whoIsPresent(channelId:limit:offset:)``
+- ``whoIsPresent(channelId:limit:offset:completion:)``
 - ``getPushChannels()``
 - ``getPushChannels(completion:)``
 - ``registerPushChannels(channels:)``

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/Chat.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/Chat.md
@@ -26,8 +26,8 @@
 - ``getChannels(filter:sort:limit:page:completion:)``
 - ``updateChannel(id:name:custom:description:status:type:)``
 - ``updateChannel(id:name:custom:description:status:type:completion:)``
-- ``deleteChannel(id:soft:)``
-- ``deleteChannel(id:soft:completion:)``
+- ``deleteChannel(id:)``
+- ``deleteChannel(id:completion:)``
 - ``whoIsPresent(channelId:)``
 - ``whoIsPresent(channelId:completion:)``
 - ``getPushChannels()``
@@ -49,8 +49,8 @@
 - ``getUsers(filter:sort:limit:page:completion:)``
 - ``updateUser(id:name:externalId:profileUrl:email:custom:status:type:)``
 - ``updateUser(id:name:externalId:profileUrl:email:custom:status:type:completion:)``
-- ``deleteUser(id:soft:)``
-- ``deleteUser(id:soft:completion:)``
+- ``deleteUser(id:)``
+- ``deleteUser(id:completion:)``
 - ``wherePresent(userId:)``
 - ``wherePresent(userId:completion:)``
 - ``isPresent(userId:channelId:)``

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ChatImpl.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ChatImpl.md
@@ -27,8 +27,8 @@
 - ``getChannels(filter:sort:limit:page:completion:)``
 - ``updateChannel(id:name:custom:description:status:type:)``
 - ``updateChannel(id:name:custom:description:status:type:completion:)``
-- ``deleteChannel(id:soft:)``
-- ``deleteChannel(id:soft:completion:)``
+- ``deleteChannel(id:)``
+- ``deleteChannel(id:completion:)``
 - ``whoIsPresent(channelId:)``
 - ``whoIsPresent(channelId:completion:)``
 - ``getPushChannels()``
@@ -50,8 +50,8 @@
 - ``getUsers(filter:sort:limit:page:completion:)``
 - ``updateUser(id:name:externalId:profileUrl:email:custom:status:type:)``
 - ``updateUser(id:name:externalId:profileUrl:email:custom:status:type:completion:)``
-- ``deleteUser(id:soft:)``
-- ``deleteUser(id:soft:completion:)``
+- ``deleteUser(id:)``
+- ``deleteUser(id:completion:)``
 - ``wherePresent(userId:)``
 - ``wherePresent(userId:completion:)``
 - ``isPresent(userId:channelId:)``

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ChatImpl.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ChatImpl.md
@@ -29,8 +29,8 @@
 - ``updateChannel(id:name:custom:description:status:type:completion:)``
 - ``deleteChannel(id:)``
 - ``deleteChannel(id:completion:)``
-- ``whoIsPresent(channelId:)``
-- ``whoIsPresent(channelId:completion:)``
+- ``whoIsPresent(channelId:limit:offset:)``
+- ``whoIsPresent(channelId:limit:offset:completion:)``
 - ``getPushChannels()``
 - ``getPushChannels(completion:)``
 - ``registerPushChannels(channels:)``

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/Membership.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/Membership.md
@@ -4,10 +4,13 @@
 
 ### Receiving Updates
 
+- ``stream``
 - ``streamUpdates()``
 - ``streamUpdates(callback:)``
 - ``streamUpdatesOn(memberships:)``
 - ``streamUpdatesOn(memberships:callback:)``
+- ``onUpdated(callback:)``
+- ``onDeleted(callback:)``
 
 ### Read Receipts
 
@@ -20,10 +23,11 @@
 
 ### Updating Membership
 
-- ``update(custom:)``
-- ``update(custom:completion:)``
+- ``update(custom:status:type:)``
+- ``update(custom:status:type:completion:)``
 
 ### Deleting Membership
 
 - ``delete()``
 - ``delete(completion:)``
+

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/Membership.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/Membership.md
@@ -22,3 +22,8 @@
 
 - ``update(custom:)``
 - ``update(custom:completion:)``
+
+### Deleting Membership
+
+- ``delete()``
+- ``delete(completion:)``

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/Membership.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/Membership.md
@@ -1,0 +1,24 @@
+# ``PubNubSwiftChatSDK/Membership``
+
+## Topics
+
+### Receiving Updates
+
+- ``streamUpdates()``
+- ``streamUpdates(callback:)``
+- ``streamUpdatesOn(memberships:)``
+- ``streamUpdatesOn(memberships:callback:)``
+
+### Read Receipts
+
+- ``setLastReadMessage(message:)``
+- ``setLastReadMessage(message:completion:)``
+- ``setLastReadMessageTimetoken(_:)``
+- ``setLastReadMessageTimetoken(_:completion:)``
+- ``getUnreadMessagesCount()``
+- ``getUnreadMessagesCount(completion:)``
+
+### Updating Membership
+
+- ``update(custom:)``
+- ``update(custom:completion:)``

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/MembershipImpl.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/MembershipImpl.md
@@ -4,10 +4,13 @@
 
 ### Receiving Updates
 
+- ``stream``
 - ``streamUpdates()``
 - ``streamUpdates(callback:)``
 - ``streamUpdatesOn(memberships:)``
 - ``streamUpdatesOn(memberships:callback:)``
+- ``onUpdated(callback:)``
+- ``onDeleted(callback:)``
 
 ### Read Receipts
 
@@ -20,10 +23,11 @@
 
 ### Updating Membership
 
-- ``update(custom:)``
-- ``update(custom:completion:)``
+- ``update(custom:status:type:)``
+- ``update(custom:status:type:completion:)``
 
 ### Deleting Membership
 
 - ``delete()``
 - ``delete(completion:)``
+

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/MembershipImpl.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/MembershipImpl.md
@@ -1,0 +1,24 @@
+# ``PubNubSwiftChatSDK/MembershipImpl``
+
+## Topics
+
+### Receiving Updates
+
+- ``streamUpdates()``
+- ``streamUpdates(callback:)``
+- ``streamUpdatesOn(memberships:)``
+- ``streamUpdatesOn(memberships:callback:)``
+
+### Read Receipts
+
+- ``setLastReadMessage(message:)``
+- ``setLastReadMessage(message:completion:)``
+- ``setLastReadMessageTimetoken(_:)``
+- ``setLastReadMessageTimetoken(_:completion:)``
+- ``getUnreadMessagesCount()``
+- ``getUnreadMessagesCount(completion:)``
+
+### Updating Membership
+
+- ``update(custom:)``
+- ``update(custom:completion:)``

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/MembershipImpl.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/MembershipImpl.md
@@ -22,3 +22,8 @@
 
 - ``update(custom:)``
 - ``update(custom:completion:)``
+
+### Deleting Membership
+
+- ``delete()``
+- ``delete(completion:)``

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/Message.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/Message.md
@@ -14,10 +14,12 @@
 
 ### Receiving Updates
 
+- ``stream``
 - ``streamUpdates()``
 - ``streamUpdates(completion:)``
 - ``streamUpdatesOn(messages:)``
 - ``streamUpdatesOn(messages:callback:)``
+- ``onUpdated(callback:)``
 
 ### Reactions
 
@@ -44,8 +46,8 @@
 
 - ``getThread()``
 - ``getThread(completion:)``
-- ``createThread()``
-- ``createThread(completion:)``
+- ``createThread(text:params:)``
+- ``createThread(text:params:completion:)``
 - ``removeThread()``
 - ``removeThread(completion:)``
 
@@ -63,3 +65,4 @@
 
 - ``report(reason:)``
 - ``report(reason:completion:)``
+

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/MessageImpl.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/MessageImpl.md
@@ -14,10 +14,12 @@
 
 ### Receiving Updates
 
+- ``stream``
 - ``streamUpdates()``
 - ``streamUpdates(completion:)``
 - ``streamUpdatesOn(messages:)``
 - ``streamUpdatesOn(messages:callback:)``
+- ``onUpdated(callback:)``
 
 ### Reactions
 
@@ -44,8 +46,8 @@
 
 - ``getThread()``
 - ``getThread(completion:)``
-- ``createThread()``
-- ``createThread(completion:)``
+- ``createThread(text:params:)``
+- ``createThread(text:params:completion:)``
 - ``removeThread()``
 - ``removeThread(completion:)``
 
@@ -63,3 +65,4 @@
 
 - ``report(reason:)``
 - ``report(reason:completion:)``
+

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ThreadChannel.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ThreadChannel.md
@@ -1,0 +1,10 @@
+# ``PubNubSwiftChatSDK/ThreadChannel``
+
+## Topics
+
+### Pinning Messages to Parent Channel
+
+- ``pinMessageToParentChannel(message:)``
+- ``pinMessageToParentChannel(message:completion:)``
+- ``unpinMessageFromParentChannel()``
+- ``unpinMessageFromParentChannel(completion:)``

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ThreadChannel.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ThreadChannel.md
@@ -8,3 +8,14 @@
 - ``pinMessageToParentChannel(message:completion:)``
 - ``unpinMessageFromParentChannel()``
 - ``unpinMessageFromParentChannel(completion:)``
+
+### Receiving Updates
+
+- ``onUpdated(callback:)``
+- ``onDeleted(callback:)``
+- ``onTypingChanged(callback:)``
+- ``onMessageReceived(callback:)``
+- ``onReadReceiptReceived(callback:)``
+- ``onPresenceChanged(callback:)``
+- ``onMessageReported(callback:)``
+- ``onCustomEvent(messageType:callback:)``

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ThreadChannelImpl.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ThreadChannelImpl.md
@@ -1,0 +1,10 @@
+# ``PubNubSwiftChatSDK/ThreadChannelImpl``
+
+## Topics
+
+### Pinning Messages to Parent Channel
+
+- ``pinMessageToParentChannel(message:)``
+- ``pinMessageToParentChannel(message:completion:)``
+- ``unpinMessageFromParentChannel()``
+- ``unpinMessageFromParentChannel(completion:)``

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ThreadChannelImpl.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ThreadChannelImpl.md
@@ -8,3 +8,14 @@
 - ``pinMessageToParentChannel(message:completion:)``
 - ``unpinMessageFromParentChannel()``
 - ``unpinMessageFromParentChannel(completion:)``
+
+### Receiving Updates
+
+- ``onUpdated(callback:)``
+- ``onDeleted(callback:)``
+- ``onTypingChanged(callback:)``
+- ``onMessageReceived(callback:)``
+- ``onReadReceiptReceived(callback:)``
+- ``onPresenceChanged(callback:)``
+- ``onMessageReported(callback:)``
+- ``onCustomEvent(messageType:callback:)``

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ThreadMessage.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ThreadMessage.md
@@ -1,0 +1,10 @@
+# ``PubNubSwiftChatSDK/ThreadMessage``
+
+## Topics
+
+### Pinning to Parent Channel
+
+- ``pinToParentChannel()``
+- ``pinToParentChannel(completion:)``
+- ``unpinFromParentChannel()``
+- ``unpinFromParentChannel(completion:)``

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ThreadMessage.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ThreadMessage.md
@@ -8,3 +8,7 @@
 - ``pinToParentChannel(completion:)``
 - ``unpinFromParentChannel()``
 - ``unpinFromParentChannel(completion:)``
+
+### Receiving Updates
+
+- ``onUpdated(callback:)``

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ThreadMessageImpl.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ThreadMessageImpl.md
@@ -1,0 +1,10 @@
+# ``PubNubSwiftChatSDK/ThreadMessageImpl``
+
+## Topics
+
+### Pinning to Parent Channel
+
+- ``pinToParentChannel()``
+- ``pinToParentChannel(completion:)``
+- ``unpinFromParentChannel()``
+- ``unpinFromParentChannel(completion:)``

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ThreadMessageImpl.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/ThreadMessageImpl.md
@@ -8,3 +8,7 @@
 - ``pinToParentChannel(completion:)``
 - ``unpinFromParentChannel()``
 - ``unpinFromParentChannel(completion:)``
+
+### Receiving Updates
+
+- ``onUpdated(callback:)``

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/User.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/User.md
@@ -1,0 +1,35 @@
+# ``PubNubSwiftChatSDK/User``
+
+## Topics
+
+### Receiving Updates
+
+- ``streamUpdates()``
+- ``streamUpdates(callback:)``
+- ``streamUpdatesOn(users:)``
+- ``streamUpdatesOn(users:callback:)``
+
+### Update and Delete a User
+
+- ``update(name:externalId:profileUrl:email:custom:status:type:)``
+- ``update(name:externalId:profileUrl:email:custom:status:type:completion:)``
+- ``update(updateAction:)``
+- ``update(updateAction:completion:)``
+- ``delete(soft:)``
+- ``delete(soft:completion:)``
+
+### Presence Management
+
+- ``wherePresent()``
+- ``wherePresent(completion:)``
+- ``isPresentOn(channelId:)``
+- ``isPresentOn(channelId:completion:)``
+
+### Memberships Management
+
+- ``getMemberships(limit:page:filter:sort:)``
+- ``getMemberships(limit:page:filter:sort:completion:)``
+- ``isMemberOf(channelId:)``
+- ``isMemberOf(channelId:completion:)``
+- ``getMembership(channelId:)``
+- ``getMembership(channelId:completion:)``

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/User.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/User.md
@@ -4,10 +4,16 @@
 
 ### Receiving Updates
 
+- ``stream``
 - ``streamUpdates()``
 - ``streamUpdates(callback:)``
 - ``streamUpdatesOn(users:)``
 - ``streamUpdatesOn(users:callback:)``
+- ``onUpdated(callback:)``
+- ``onDeleted(callback:)``
+- ``onMentioned(callback:)``
+- ``onInvited(callback:)``
+- ``onRestrictionChanged(callback:)``
 
 ### Update and Delete a User
 
@@ -33,3 +39,4 @@
 - ``isMemberOf(channelId:completion:)``
 - ``getMembership(channelId:)``
 - ``getMembership(channelId:completion:)``
+

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/User.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/User.md
@@ -15,8 +15,8 @@
 - ``update(name:externalId:profileUrl:email:custom:status:type:completion:)``
 - ``update(updateAction:)``
 - ``update(updateAction:completion:)``
-- ``delete(soft:)``
-- ``delete(soft:completion:)``
+- ``delete()``
+- ``delete(completion:)``
 
 ### Presence Management
 

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/UserImpl.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/UserImpl.md
@@ -4,10 +4,16 @@
 
 ### Receiving Updates
 
+- ``stream``
 - ``streamUpdates()``
 - ``streamUpdates(callback:)``
 - ``streamUpdatesOn(users:)``
 - ``streamUpdatesOn(users:callback:)``
+- ``onUpdated(callback:)``
+- ``onDeleted(callback:)``
+- ``onMentioned(callback:)``
+- ``onInvited(callback:)``
+- ``onRestrictionChanged(callback:)``
 
 ### Update and Delete a User
 
@@ -33,3 +39,4 @@
 - ``isMemberOf(channelId:completion:)``
 - ``getMembership(channelId:)``
 - ``getMembership(channelId:completion:)``
+

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/UserImpl.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/UserImpl.md
@@ -1,0 +1,35 @@
+# ``PubNubSwiftChatSDK/UserImpl``
+
+## Topics
+
+### Receiving Updates
+
+- ``streamUpdates()``
+- ``streamUpdates(callback:)``
+- ``streamUpdatesOn(users:)``
+- ``streamUpdatesOn(users:callback:)``
+
+### Update and Delete a User
+
+- ``update(name:externalId:profileUrl:email:custom:status:type:)``
+- ``update(name:externalId:profileUrl:email:custom:status:type:completion:)``
+- ``update(updateAction:)``
+- ``update(updateAction:completion:)``
+- ``delete(soft:)``
+- ``delete(soft:completion:)``
+
+### Presence Management
+
+- ``wherePresent()``
+- ``wherePresent(completion:)``
+- ``isPresentOn(channelId:)``
+- ``isPresentOn(channelId:completion:)``
+
+### Memberships Management
+
+- ``getMemberships(limit:page:filter:sort:)``
+- ``getMemberships(limit:page:filter:sort:completion:)``
+- ``isMemberOf(channelId:)``
+- ``isMemberOf(channelId:completion:)``
+- ``getMembership(channelId:)``
+- ``getMembership(channelId:completion:)``

--- a/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/UserImpl.md
+++ b/PubNubSwiftChatSDK/PubNubSwiftChatSDK.docc/UserImpl.md
@@ -15,8 +15,8 @@
 - ``update(name:externalId:profileUrl:email:custom:status:type:completion:)``
 - ``update(updateAction:)``
 - ``update(updateAction:completion:)``
-- ``delete(soft:)``
-- ``delete(soft:completion:)``
+- ``delete()``
+- ``delete(completion:)``
 
 ### Presence Management
 

--- a/Snippets/ChannelSnippets.swift
+++ b/Snippets/ChannelSnippets.swift
@@ -672,3 +672,43 @@ func pinMessageToChannel() {
   }
   // snippet.end
 }
+
+// MARK: - Check if User is Channel Member
+
+func hasMember() {
+  // snippet.channels.hasMember
+  // Assumes a "ChatImpl" reference named "chat"
+  Task {
+    if let channel = try await chat.getChannel(channelId: "support") {
+      let isMember = try await channel.hasMember(userId: "support_agent_15")
+      if isMember {
+        debugPrint("User 'support_agent_15' is a member of the 'support' channel")
+      } else {
+        debugPrint("User 'support_agent_15' is not a member of the 'support' channel")
+      }
+    } else {
+      debugPrint("Channel not found")
+    }
+  }
+  // snippet.end
+}
+
+// MARK: - Get Specific Channel Member
+
+func getMember() {
+  // snippet.channels.getMember
+  // Assumes a "ChatImpl" reference named "chat"
+  Task {
+    if let channel = try await chat.getChannel(channelId: "support") {
+      if let membership = try await channel.getMember(userId: "support_agent_15") {
+        debugPrint("Found membership for user: \(membership.user.id)")
+        debugPrint("Membership custom data: \(String(describing: membership.custom))")
+      } else {
+        debugPrint("User 'support_agent_15' is not a member of the 'support' channel")
+      }
+    } else {
+      debugPrint("Channel not found")
+    }
+  }
+  // snippet.end
+}

--- a/Snippets/ChannelSnippets.swift
+++ b/Snippets/ChannelSnippets.swift
@@ -110,9 +110,9 @@ func joinChannel() {
   // Assumes a "ChatImpl" reference named "chat"
   Task {
     if let channel = try await chat.getChannel(channelId: "support") {
-      let joinResult = try await channel.join(custom: ["support_plan": "premium"])
-      debugPrint("Channel membership: \(joinResult.membership)")
-      debugPrint("Membership channel ID: \(joinResult.membership.channel.id)")
+      let membership = try await channel.join(custom: ["support_plan": "premium"])
+      debugPrint("Channel membership: \(membership)")
+      debugPrint("Membership channel ID: \(membership.channel.id)")
     } else {
       debugPrint("Channel not found")
     }
@@ -128,9 +128,10 @@ func joinChannelAsyncStream() {
   Task {
     if let channel = try await chat.getChannel(channelId: "support") {
       // Join the channel
-      let joinResult = try await channel.join(custom: ["support_plan": "premium"])
-      // Continuously fetch and process values from the stream
-      for await message in joinResult.messagesStream {
+      let membership = try await channel.join(custom: ["support_plan": "premium"])
+      debugPrint("Joined channel: \(membership.channel.id)")
+      // Continuously listen for new messages on the channel
+      for await message in channel.stream.messages() {
         debugPrint("Received a new message: \(message)")
       }
     } else {
@@ -145,19 +146,21 @@ func joinChannelAsyncStream() {
 func joinChannelClosure() {
   // snippet.channels.join.closure
   // Assumes a "ChannelImpl" reference named "channel"
-  channel.join(custom: ["support_plan": "premium"]) { message in
-    debugPrint("Received a new message: \(message)")
-  } completion: { result in
+
+  channel.join(custom: ["support_plan": "premium"]) { result in
     switch result {
-    case let .success((_, disconnect)):
-      // Important: Keep a strong reference to the returned "AutoCloseable" object as long as you want
-      // to receive new messages. If the "AutoCloseable" is deallocated, the stream will be cancelled,
-      // and no further items will be produced. You can also stop receiving messages manually
-      // by calling the "close()" method on the "AutoCloseable" object.
-      autoCloseable = disconnect
+    case let .success(membership):
+      debugPrint("Joined channel: \(membership.channel.id)")
     case let .failure(error):
       debugPrint("An error occurred: \(error)")
     }
+  }
+  // Important: Keep a strong reference to the returned "AutoCloseable" object as long as you want
+  // to receive new messages. If the "AutoCloseable" is deallocated, the stream will be cancelled,
+  // and no further items will be produced. You can also stop receiving messages manually
+  // by calling the "close()" method on the "AutoCloseable" object.
+  autoCloseable = channel.onMessageReceived { message in
+    debugPrint("Received a new message: \(message)")
   }
   // snippet.end
 }

--- a/Snippets/ChannelSnippets.swift
+++ b/Snippets/ChannelSnippets.swift
@@ -88,23 +88,6 @@ func deleteChannel() {
   // snippet.end
 }
 
-// MARK: - Delete Channel (Soft)
-
-func deleteChannelSoft() {
-  // snippet.channels.deleteSoft
-  // Assumes a "ChatImpl" reference named "chat"
-  Task {
-    if let channel = try await chat.getChannel(channelId: "support") {
-      let deletionResult = try await channel.delete(soft: true)
-      debugPrint(String(describing: deletionResult?.id))
-      debugPrint(String(describing: deletionResult?.status))
-    } else {
-      debugPrint("Channel not found")
-    }
-  }
-  // snippet.end
-}
-
 // MARK: - Get Channel Details
 
 func getChannel() {

--- a/Snippets/ConfigurationSnippets.swift
+++ b/Snippets/ConfigurationSnippets.swift
@@ -11,6 +11,8 @@
 import PubNubSDK
 import PubNubSwiftChatSDK
 
+var chat: ChatImpl!
+
 // MARK: - Basic Initialization
 
 func initializeChat() async throws {
@@ -206,5 +208,53 @@ func initializeChatWithLogging() {
     chatConfiguration: chatConfiguration,
     pubNubConfiguration: pubNubConfiguration
   )
+  // snippet.end
+}
+
+// MARK: - Connection Status Listener
+
+func connectionStatusListener() {
+  // snippet.configuration.connectionStatusListener
+  // Important: Keep a strong reference to the returned "AutoCloseable" object as long as you want
+  // to receive updates. If the "AutoCloseable" is deallocated, the stream will be cancelled,
+  // and no further items will be produced. You can also stop receiving updates manually
+  // by calling the "close()" method on the "AutoCloseable" object.
+  autoCloseable = chat.addConnectionStatusListener { status in
+    switch status {
+    case .online:
+      print("Connected to PubNub")
+    case .offline:
+      print("Disconnected from PubNub")
+    case .connectionError(let error):
+      print("Connection error: \(error)")
+    }
+  }
+  // snippet.end
+}
+
+// MARK: - Disconnect Subscriptions
+
+func disconnectSubscriptions() {
+  // snippet.configuration.disconnectSubscriptions
+  // Pause all subscriptions when the app enters the background.
+  chat.disconnectSubscriptions()
+  // snippet.end
+}
+
+// MARK: - Reconnect Subscriptions
+
+func reconnectSubscriptions() {
+  // snippet.configuration.reconnectSubscriptions
+  // Resume all subscriptions when the app returns to the foreground.
+  chat.reconnectSubscriptions()
+  // snippet.end
+}
+
+// MARK: - Destroy
+
+func destroyChat() {
+  // snippet.configuration.destroy
+  // Release all Chat SDK resources on logout.
+  chat.destroy()
   // snippet.end
 }

--- a/Snippets/CustomEventSnippets.swift
+++ b/Snippets/CustomEventSnippets.swift
@@ -1,0 +1,208 @@
+//
+//  CustomEventSnippets.swift
+//
+//  Copyright (c) PubNub Inc.
+//  All rights reserved.
+//
+//  This source code is licensed under the license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import PubNubSwiftChatSDK
+import PubNubSDK
+
+var chat: ChatImpl!
+var channel: ChannelImpl!
+var autoCloseable: AutoCloseable!
+
+// MARK: - Emit Custom Event
+
+func emitCustomEvent() {
+  // snippet.customEvents.emit
+  // Assumes a "ChatImpl" reference named "chat"
+  Task {
+    if let channel = try await chat.getChannel(channelId: "support") {
+      let timetoken = try await channel.emitCustomEvent(
+        payload: [
+          "action": "confetti",
+          "sender": "user-123"
+        ]
+      )
+      debugPrint("Custom event emitted at timetoken: \(timetoken)")
+    } else {
+      debugPrint("Channel not found")
+    }
+  }
+  // snippet.end
+}
+
+// MARK: - Emit Custom Event with Message Type
+
+func emitCustomEventWithMessageType() {
+  // snippet.customEvents.emitWithType
+  // Assumes a "ChatImpl" reference named "chat"
+  Task {
+    if let channel = try await chat.getChannel(channelId: "support") {
+      let timetoken = try await channel.emitCustomEvent(
+        payload: [
+          "action": "confetti",
+          "sender": "user-123"
+        ],
+        messageType: "celebration"
+      )
+      debugPrint("Custom event emitted at timetoken: \(timetoken)")
+    } else {
+      debugPrint("Channel not found")
+    }
+  }
+  // snippet.end
+}
+
+// MARK: - Listen for Custom Events (AsyncStream)
+
+func listenForCustomEventsAsyncStream() {
+  // snippet.customEvents.listen.asyncStream
+  // Assumes a "ChatImpl" reference named "chat"
+  Task {
+    if let channel = try await chat.getChannel(channelId: "support") {
+      for await customEvent in channel.stream.customEvents() {
+        debugPrint("Custom event received from user \(customEvent.userId)")
+        debugPrint("Payload: \(customEvent.payload)")
+        if let type = customEvent.type {
+          debugPrint("Message type: \(type)")
+        }
+      }
+    } else {
+      debugPrint("Channel not found")
+    }
+  }
+  // snippet.end
+}
+
+// MARK: - Listen for Custom Events (Closure)
+
+func listenForCustomEventsClosure() {
+  // snippet.customEvents.listen.closure
+  // Assumes a "ChannelImpl" reference named "channel"
+
+  // Important: Keep a strong reference to the returned "AutoCloseable" object as long as you want
+  // to receive events. If the "AutoCloseable" is deallocated, the stream will be cancelled,
+  // and no further items will be produced. You can also stop receiving events manually
+  // by calling the "close()" method on the "AutoCloseable" object.
+  autoCloseable = channel.onCustomEvent { customEvent in
+    debugPrint("Custom event received from user \(customEvent.userId)")
+    debugPrint("Payload: \(customEvent.payload)")
+    if let type = customEvent.type {
+      debugPrint("Message type: \(type)")
+    }
+  }
+  // snippet.end
+}
+
+// MARK: - Get Historical Events
+
+func getEventsHistory() {
+  // snippet.customEvents.history
+  // Assumes a "ChatImpl" reference named "chat"
+  Task {
+    let result = try await chat.getEventsHistory(
+      channelId: "support",
+      count: 25
+    )
+    result.events.forEach { eventWrapper in
+      debugPrint("Event at \(eventWrapper.event.timetoken) by \(eventWrapper.event.userId)")
+      debugPrint("Payload: \(eventWrapper.event.payload)")
+    }
+    if result.isMore {
+      debugPrint("More events available")
+    }
+  }
+  // snippet.end
+}
+
+// MARK: - Emit Custom Event (Documentation Sample)
+
+func emitCustomEventSample() {
+  // snippet.customEvents.emitSample
+  // Emit the custom event to the "CUSTOMER-SATISFACTION-CREW" channel.
+  // Assuming you have a reference of type "ChannelImpl" named "channel".
+  Task {
+    try await channel.emitCustomEvent(
+      payload: [
+        "chatID": "chat1234",
+        "timestamp": "2022-04-30T10:30:00Z",
+        "customerID": "customer5678",
+        "triggerWord": "frustrated"
+      ],
+      messageType: "customer-satisfaction",
+      storeInHistory: true
+    )
+  }
+  // snippet.end
+}
+
+// MARK: - Listen for Custom Events (Documentation Sample)
+
+func onCustomEventSample() {
+  // snippet.customEvents.onCustomEventSample
+  // Function to handle the "frustrated" event and respond to the customer
+  func handleFrustratedEvent(customerID: String, triggerWord: String) {
+    let response = "Thank you for reaching out. We're sorry to hear that you're \(triggerWord). Our team is here to help."
+    // Send the response back to the customer's chat (mocked function)
+    sendResponseToCustomerChat(customerID: customerID, response: response)
+  }
+
+  // Mocked function to send a response back to the customer's chat
+  func sendResponseToCustomerChat(customerID: String, response: String) {
+    debugPrint("Sent response to customer \(customerID): \(response)")
+  }
+
+  // Listen for custom events on the "CUSTOMER-SATISFACTION-CREW" channel.
+  // Assuming you have a reference of type "ChannelImpl" named "channel".
+  // Hold a strong reference to the returned "AutoCloseable"; otherwise, it will be canceled.
+  let stopCustomEvents = channel.onCustomEvent(messageType: "customer-satisfaction") { event in
+    if let triggerWord = event.payload["triggerWord"]?.rawValue as? String {
+      if triggerWord == "frustrated" {
+        if let customerID = event.payload["customerID"]?.rawValue as? String {
+          handleFrustratedEvent(customerID: customerID, triggerWord: triggerWord)
+        }
+      }
+    }
+  }
+
+  // AsyncStream equivalent
+  Task {
+    for await event in channel.stream.customEvents(messageType: "customer-satisfaction") {
+      if let triggerWord = event.payload["triggerWord"]?.rawValue as? String {
+        debugPrint("Trigger word received: \(triggerWord)")
+      }
+    }
+  }
+
+  // To stop listening:
+  stopCustomEvents.close()
+  // snippet.end
+}
+
+// MARK: - Get Historical Events (Documentation Sample)
+
+func getEventsHistorySample() {
+  // snippet.customEvents.historySample
+  // Pull historical events from the "CUSTOMER-SATISFACTION-CREW" channel with count of 10.
+  // Assuming you have a reference of type "ChatImpl" named "chat"
+  Task {
+    let historyResponse = try await chat.getEventsHistory(
+      channelId: "CUSTOMER-SATISFACTION-CREW",
+      count: 10
+    )
+    historyResponse.events.forEach { wrapper in
+      debugPrint("Event at \(wrapper.event.timetoken) by \(wrapper.event.userId)")
+      debugPrint("Payload: \(wrapper.event.payload)")
+    }
+    if historyResponse.isMore {
+      debugPrint("More events available")
+    }
+  }
+  // snippet.end
+}

--- a/Snippets/MessageSnippets.swift
+++ b/Snippets/MessageSnippets.swift
@@ -33,9 +33,11 @@ func sendText() {
     if let channel = try await chat.getChannel(channelId: "support") {
       let timetoken = try await channel.sendText(
         text: "Hi Everyone",
-        meta: ["messageImportance": "high"],
-        shouldStore: true,
-        ttl: 15
+        params: SendTextParams(
+          meta: ["messageImportance": "high"],
+          shouldStore: true,
+          ttl: 15
+        )
       )
       debugPrint("Message sent successfully at \(timetoken)")
     } else {
@@ -402,10 +404,11 @@ func quoteMessage() {
   Task {
     if let channel = try await chat.getChannel(channelId: "support") {
       if let message = try await channel.getMessage(timetoken: timetoken) {
-        try await channel.sendText(
-          text: "Quoting the message with timetoken \(timetoken)",
-          quotedMessage: message
-        )
+        // Create a message draft and set the quoted message
+        let messageDraft = channel.createMessageDraft()
+        messageDraft.update(text: "Quoting the message with timetoken \(timetoken)")
+        messageDraft.quotedMessage = message
+        try await messageDraft.send()
       } else {
         debugPrint("Message with the specified timetoken not found")
       }
@@ -584,9 +587,11 @@ func createThread() {
     if let channel = try await chat.getChannel(channelId: "support") {
       let timetoken: Timetoken = 16200000000000001
       if let message = try await channel.getMessage(timetoken: timetoken) {
-        let threadChannel = try await message.createThread()
-        debugPrint("Thread created successfully with ID: \(threadChannel.id)")
-        debugPrint("Parent channel ID: \(threadChannel.parentChannelId)")
+        // Create a thread by sending the first reply
+        let result = try await message.createThread(text: "Starting a thread on this topic")
+        debugPrint("Thread created successfully with ID: \(result.threadChannel.id)")
+        debugPrint("Parent channel ID: \(result.threadChannel.parentChannelId)")
+        debugPrint("Updated parent message: \(result.parentMessage.hasThread)")
       } else {
         debugPrint("No message found with this timetoken")
       }
@@ -843,6 +848,21 @@ func createMessageDraft() {
   // snippet.end
 }
 
+// MARK: - Create Thread Message Draft
+
+func createThreadMessageDraft() async throws {
+  // snippet.messages.createThreadMessageDraft
+  // Assuming you have a reference of type "MessageImpl" named "message"
+  let threadDraft = try await message.createThreadMessageDraft(
+      isTypingIndicatorTriggered: true
+  )
+
+  threadDraft.update(text: "This is my thread reply draft")
+
+  let timetoken = try await threadDraft.send()
+  // snippet.end
+}
+
 // MARK: - Add Message Draft Change Listener
 
 func addMessageDraftChangeListener() {
@@ -871,6 +891,39 @@ func addMessageDraftChangeListener() {
   // snippet.end
 }
 
+// MARK: - Remove Message Draft Change Listener
+
+func removeMessageDraftChangeListener() {
+  // snippet.messages.removeDraftChangeListener
+  // Create a message draft.
+  // Assuming you have a reference of type "ChannelImpl" named "channel"
+  let messageDraft = channel.createMessageDraft(isTypingIndicatorTriggered: channel.type != .public)
+  // Define the listener
+  let listener = ClosureMessageDraftChangeListener() { elements, suggestedMentions in
+    // updateUI(with:) is your own function for updating UI
+    updateUI(with: elements)
+
+    suggestedMentions.async { result in
+      switch result {
+      case .success(let mentions):
+        // updateSuggestions(with:) is your own function for displaying suggestions
+        updateSuggestions(with: mentions)
+      case .failure(let error):
+        print("Error retrieving suggestions: \(error)")
+      }
+    }
+  }
+
+  // Add the listener to the message draft
+  messageDraft.addChangeListener(listener)
+  // Remove the listener from the message draft
+  messageDraft.removeChangeListener(listener)
+
+  func updateUI(with elements: [MessageElement]) {}
+  func updateSuggestions(with: [SuggestedMention]) {}
+  // snippet.end
+}
+
 // MARK: - Add Mention
 
 func addMention() {
@@ -894,6 +947,42 @@ func removeMention() {
   // Assume the message reads: "Hello Alex! I have sent you this link on the #offtopic channel."
   // Remove the link mention
   messageDraft.removeMention(offset: 33)
+  // snippet.end
+}
+
+// MARK: - Insert Suggested Mention
+
+func insertSuggestedMention() {
+  // snippet.messages.insertSuggestedMention
+  // Create a message draft.
+  // Assuming you have a reference of type "ChannelImpl" named "channel"
+  let messageDraft = channel.createMessageDraft(isTypingIndicatorTriggered: channel?.type != .public)
+  // Create the listener
+  let listener = ClosureMessageDraftChangeListener() { elements, suggestedMentions in
+    // updateUI() is your own function for updating the UI:
+    updateUI(elements)
+    suggestedMentions.async { result in
+      switch result {
+      case .success(let mentions):
+        // updateSuggestions() is your own function for displaying suggestions
+        updateSuggestions(mentions)
+      case .failure(let error):
+        print("Error retrieving suggestions: \(error)")
+      }
+    }
+  }
+
+  messageDraft.addChangeListener(listener)
+
+  // Assuming that getSelectedSuggestion() is your own function that returns a suggestion selected by the user.
+  // When the user selects a suggestion in the UI:
+  if let suggestion = getSelectedSuggestion() {
+      messageDraft.insertSuggestedMention(mention: suggestion, text: suggestion.replaceWith)
+  }
+
+  func updateUI(_ elements: [MessageElement]) {}
+  func updateSuggestions(_ mentions: [SuggestedMention]) {}
+  func getSelectedSuggestion() -> SuggestedMention? { nil }
   // snippet.end
 }
 
@@ -1177,6 +1266,153 @@ func pinMessageToThreadChannel() {
   // snippet.end
 }
 
+// MARK: - Pin Thread Message to Parent Channel
+
+func pinThreadMessageToParentChannel() {
+  // snippet.messages.pinThreadMessageToParentChannel
+  // Assuming you have a reference of type "ChatImpl" named "chat"
+  Task {
+    if let channel = try await chat.getChannel(channelId: "support") {
+      // Get the last message on the channel, which is the root message for the thread
+      if let message = try await channel.getHistory(count: 1).messages.first {
+        // Get the thread channel
+        let threadChannel = try await message.getThread()
+        // Get the last message on the thread channel
+        if let threadMessage = try await threadChannel.getHistory(count: 1).messages.first {
+          // Pin the message to the parent channel
+          let updatedChannel = try await threadMessage.pinToParentChannel()
+          debugPrint("Message pinned successfully to the parent channel")
+          debugPrint("Updated channel object: \(updatedChannel)")
+        } else {
+          debugPrint("No messages found in the thread channel")
+        }
+      } else {
+        debugPrint("Message not found")
+      }
+    } else {
+      debugPrint("Channel not found")
+    }
+  }
+  // snippet.end
+}
+
+// MARK: - Pin Message to Parent Channel via ThreadChannel
+
+func pinMessageToParentChannel() {
+  // snippet.messages.pinMessageToParentChannel
+  // Assuming you have a reference of type "ChatImpl" named "chat"
+  Task {
+    if let channel = try await chat.getChannel(channelId: "support") {
+      // Get the last message on the channel, which is the root message for the thread
+      if let message = try await channel.getHistory(count: 1).messages.first {
+        // Get the thread channel
+        let threadChannel = try await message.getThread()
+        // Get the last message on the thread channel
+        if let threadMessage = try await threadChannel.getHistory(count: 1).messages.first {
+          // Pin the message to the parent channel
+          let updatedChannel = try await threadChannel.pinMessageToParentChannel(message: threadMessage)
+          debugPrint("Message pinned successfully to the parent channel")
+          debugPrint("Updated channel object: \(updatedChannel)")
+        } else {
+          debugPrint("No messages found in the thread channel")
+        }
+      } else {
+        debugPrint("Message not found")
+      }
+    } else {
+      debugPrint("Channel not found")
+    }
+  }
+  // snippet.end
+}
+
+// MARK: - Unpin Thread Message from Parent Channel
+
+func unpinThreadMessageFromParentChannel() {
+  // snippet.messages.unpinThreadMessageFromParentChannel
+  // Assuming you have a reference of type "ChatImpl" named "chat"
+  Task {
+    if let channel = try await chat.getChannel(channelId: "support") {
+      // Get the last message on the channel, which is the root message for the thread
+      if let message = try await channel.getHistory(count: 1).messages.first {
+        // Get the thread channel
+        let threadChannel = try await message.getThread()
+        // Get the last message on the thread channel
+        if let threadMessage = try await threadChannel.getHistory(count: 1).messages.first {
+          let updatedChannel = try await threadMessage.unpinFromParentChannel()
+          debugPrint("Message unpinned successfully from the parent channel")
+          debugPrint("Updated channel object: \(updatedChannel)")
+        } else {
+          debugPrint("No messages found in the thread channel")
+        }
+      } else {
+        debugPrint("Message not found")
+      }
+    } else {
+      debugPrint("Channel not found")
+    }
+  }
+  // snippet.end
+}
+
+// MARK: - Unpin Message from Parent Channel via ThreadChannel
+
+func unpinMessageFromParentChannel() {
+  // snippet.messages.unpinMessageFromParentChannel
+  // Assuming you have a reference of type "ChatImpl" named "chat"
+  Task {
+    if let channel = try await chat.getChannel(channelId: "support") {
+      // Get the last message on the channel, which is the root message for the thread
+      if let message = try await channel.getHistory(count: 1).messages.first {
+        // Get the thread channel
+        let threadChannel = try await message.getThread()
+        // Get the last message on the thread channel
+        if let threadMessage = try await threadChannel.getHistory(count: 1).messages.first {
+          let updatedChannel = try await threadChannel.unpinMessageFromParentChannel()
+          debugPrint("Message unpinned successfully from the parent channel")
+          debugPrint("Updated channel object: \(updatedChannel)")
+        } else {
+          debugPrint("No messages found in the thread channel")
+        }
+      } else {
+        debugPrint("Message not found")
+      }
+    } else {
+      debugPrint("Channel not found")
+    }
+  }
+  // snippet.end
+}
+
+// MARK: - Unpin Thread Message from Thread Channel
+
+func unpinThreadMessageFromThreadChannel() {
+  // snippet.messages.unpinThreadMessageFromThreadChannel
+  // Assuming you have a reference of type "ChatImpl" named "chat"
+  Task {
+    if let channel = try await chat.getChannel(channelId: "support") {
+      // Get the last message on the channel, which is the root message for the thread
+      if let message = try await channel.getHistory(count: 1).messages.first {
+        // Get the thread channel
+        let threadChannel = try await message.getThread()
+        // Get the last message on the thread channel
+        if let threadMessage = try await threadChannel.getHistory(count: 1).messages.first {
+          let updatedChannel = try await threadChannel.unpinMessage()
+          debugPrint("Message unpinned successfully from the thread channel")
+          debugPrint("Updated channel object: \(updatedChannel)")
+        } else {
+          debugPrint("No messages found in the thread channel.")
+        }
+      } else {
+        debugPrint("Message not found")
+      }
+    } else {
+      debugPrint("Channel not found")
+    }
+  }
+  // snippet.end
+}
+
 // MARK: - Get Unread Messages Count (Deprecated)
 
 func getUnreadMessagesCountDeprecated() {
@@ -1269,8 +1505,12 @@ func streamReadReceiptsAsyncStream() {
   // Assumes a "ChatImpl" reference named "chat"
   Task {
     if let channel = try await chat.getChannel(channelId: "support") {
-      for await readReceipt in channel.streamReadReceipts() {
-        debugPrint("User \(readReceipt.userId) has read up to timetoken: \(readReceipt.lastReadTimetoken)")
+      for await readReceipts in channel.streamReadReceipts() {
+        // readReceipts is a [Timetoken: [String]] dictionary
+        // mapping each last-read timetoken to the list of user IDs who read up to that point
+        for (timetoken, userIds) in readReceipts {
+          debugPrint("Timetoken \(timetoken) was last read by users: \(userIds)")
+        }
       }
     } else {
       debugPrint("Channel not found")
@@ -1284,8 +1524,16 @@ func streamReadReceiptsAsyncStream() {
 func streamReadReceiptsClosure() {
   // snippet.messages.readReceipts.closure
   // Assumes a "ChannelImpl" reference named "channel"
-  autoCloseable = channel.streamReadReceipts { readReceipt in
-    print("User \(readReceipt.userId) has read up to timetoken: \(readReceipt.lastReadTimetoken)")
+
+  // Important: Keep a strong reference to the returned "AutoCloseable" object as long as you want
+  // to receive updates. If the "AutoCloseable" is deallocated, the stream will be cancelled,
+  // and no further items will be produced. You can also stop receiving updates manually
+  // by calling the "close()" method on the "AutoCloseable" object.
+  autoCloseable = channel.streamReadReceipts { readReceipts in
+    // readReceipts is a [Timetoken: [String]] dictionary
+    for (timetoken, userIds) in readReceipts {
+      print("Timetoken \(timetoken) was last read by users: \(userIds)")
+    }
   }
   // snippet.end
 }

--- a/Snippets/MessageSnippets.swift
+++ b/Snippets/MessageSnippets.swift
@@ -1270,9 +1270,7 @@ func streamReadReceiptsAsyncStream() {
   Task {
     if let channel = try await chat.getChannel(channelId: "support") {
       for await readReceipt in channel.streamReadReceipts() {
-        readReceipt.forEach { (messageTimetoken, users) in
-          debugPrint("Message timetoken: \(messageTimetoken) was read by users: \(users)")
-        }
+        debugPrint("User \(readReceipt.userId) has read up to timetoken: \(readReceipt.lastReadTimetoken)")
       }
     } else {
       debugPrint("Channel not found")
@@ -1286,10 +1284,27 @@ func streamReadReceiptsAsyncStream() {
 func streamReadReceiptsClosure() {
   // snippet.messages.readReceipts.closure
   // Assumes a "ChannelImpl" reference named "channel"
-  autoCloseable = channel.streamReadReceipts { receipts in
-    print("Read Receipts Received:")
-    receipts.forEach { (messageTimetoken, users) in
-      print("Message Timetoken: \(messageTimetoken) was read by users: \(users)")
+  autoCloseable = channel.streamReadReceipts { readReceipt in
+    print("User \(readReceipt.userId) has read up to timetoken: \(readReceipt.lastReadTimetoken)")
+  }
+  // snippet.end
+}
+
+// MARK: - Fetch Read Receipts
+
+func fetchReadReceipts() {
+  // snippet.messages.readReceipts.fetch
+  // Assumes a "ChatImpl" reference named "chat"
+  Task {
+    if let channel = try await chat.getChannel(channelId: "support") {
+      let result = try await channel.fetchReadReceipts()
+      let receipts = result.receipts
+      // Use for subsequent call: channel.fetchReadReceipts(page: nextPage)
+      let nextPage = result.page
+
+      receipts.forEach { receipt in
+        print("User \(receipt.userId) has read up to timetoken: \(receipt.lastReadTimetoken)")
+      }
     }
   }
   // snippet.end

--- a/Snippets/TypingIndicatorSnippets.swift
+++ b/Snippets/TypingIndicatorSnippets.swift
@@ -44,7 +44,40 @@ func stopTyping() {
   // snippet.end
 }
 
-// MARK: - Get Typing Events (AsyncStream)
+// MARK: - On Typing Changed (AsyncStream)
+
+func onTypingChangedAsyncStream() {
+  // snippet.typingIndicator.onTypingChanged.asyncStream
+  // Assumes a "ChatImpl" reference named "chat"
+  Task {
+    if let channel = try await chat.getChannel(channelId: "support") {
+      for await typingUsers in channel.stream.typingChanges() {
+        debugPrint("Typing users: \(typingUsers)")
+      }
+    } else {
+      debugPrint("Channel not found")
+    }
+  }
+  // snippet.end
+}
+
+// MARK: - On Typing Changed (Closure)
+
+func onTypingChangedClosure() {
+  // snippet.typingIndicator.onTypingChanged.closure
+  // Assumes a "ChannelImpl" reference named "channel"
+
+  // Important: Keep a strong reference to the returned "AutoCloseable" object as long as you want
+  // to receive updates. If the "AutoCloseable" is deallocated, the stream will be cancelled,
+  // and no further items will be produced. You can also stop receiving updates manually
+  // by calling the "close()" method on the "AutoCloseable" object.
+  autoCloseable = channel.onTypingChanged { typingUsers in
+    debugPrint("Typing users: \(typingUsers)")
+  }
+  // snippet.end
+}
+
+// MARK: - Get Typing Events (AsyncStream) [Deprecated]
 
 func getTypingAsyncStream() {
   // snippet.typingIndicator.getTyping.asyncStream
@@ -61,12 +94,12 @@ func getTypingAsyncStream() {
   // snippet.end
 }
 
-// MARK: - Get Typing Events (Closure)
+// MARK: - Get Typing Events (Closure) [Deprecated]
 
 func getTypingClosure() {
   // snippet.typingIndicator.getTyping.closure
   // Assumes a "ChannelImpl" reference named "channel"
-  
+
   // Important: Keep a strong reference to the returned "AutoCloseable" object as long as you want
   // to receive updates. If the "AutoCloseable" is deallocated, the stream will be cancelled,
   // and no further items will be produced. You can also stop receiving updates manually

--- a/Snippets/UserSnippets.swift
+++ b/Snippets/UserSnippets.swift
@@ -158,7 +158,7 @@ func deleteUser() {
   // Assumes a "ChatImpl" reference named "chat"
   Task {
     if let user = try await chat.getUser(userId: "support_agent_15") {
-      try await user.delete(soft: false)
+      try await user.delete()
     } else {
       debugPrint("User not found")
     }
@@ -175,29 +175,6 @@ func deleteUserOnChat() {
   // snippet.end
 }
 
-func softDeleteUser() {
-  // snippet.users.delete.soft
-  // Assumes a "ChatImpl" reference named "chat"
-  Task {
-    if let user = try await chat.getUser(userId: "support_agent_15") {
-      let updatedUser = try await user.delete(soft: true)
-      debugPrint("User marked as deleted")
-      debugPrint("Updated user object: \(String(describing: updatedUser))")
-    } else {
-      debugPrint("User not found")
-    }
-  }
-  // snippet.end
-}
-
-func softDeleteUserOnChat() {
-  // snippet.users.deleteUser.soft
-  // Assumes a "ChatImpl" reference named "chat"
-  Task {
-    try await chat.deleteUser(id: "support_agent_15", soft: true)
-  }
-  // snippet.end
-}
 
 // MARK: - Stream User Updates
 

--- a/Snippets/UserSnippets.swift
+++ b/Snippets/UserSnippets.swift
@@ -383,6 +383,44 @@ func streamPresence() {
   // snippet.end
 }
 
+// MARK: - Channel Membership
+
+func isMemberOf() {
+  // snippet.users.isMemberOf
+  // Assumes a "ChatImpl" reference named "chat"
+  Task {
+    if let user = try await chat.getUser(userId: "support_agent_15") {
+      let isMember = try await user.isMemberOf(channelId: "support")
+      if isMember {
+        debugPrint("User 'support_agent_15' is a member of the 'support' channel")
+      } else {
+        debugPrint("User 'support_agent_15' is not a member of the 'support' channel")
+      }
+    } else {
+      debugPrint("User not found")
+    }
+  }
+  // snippet.end
+}
+
+func getMembership() {
+  // snippet.users.getMembership
+  // Assumes a "ChatImpl" reference named "chat"
+  Task {
+    if let user = try await chat.getUser(userId: "support_agent_15") {
+      if let membership = try await user.getMembership(channelId: "support") {
+        debugPrint("Found membership in channel: \(membership.channel.id)")
+        debugPrint("Membership custom data: \(String(describing: membership.custom))")
+      } else {
+        debugPrint("User 'support_agent_15' is not a member of the 'support' channel")
+      }
+    } else {
+      debugPrint("User not found")
+    }
+  }
+  // snippet.end
+}
+
 // MARK: - Global Presence
 
 func checkUserActive() {

--- a/Sources/Chat/Chat+AsyncAwait.swift
+++ b/Sources/Chat/Chat+AsyncAwait.swift
@@ -354,6 +354,7 @@ public extension Chat {
   ///   - payload: The payload of the emitted event. Use one of ``EventContent`` subclasses. For example: `EventContent.TextMessageContent`, `EventContent.Mention`
   ///   - otherPayload: Metadata in the form of key-value pairs you want to pass as events from your chat app. Can contain anything in case of custom events, but has a predefined structure for other types of events
   /// - Returns: A `Timetoken` value that holds the timestamp of the emitted event
+  @available(*, deprecated, message: "Use `Channel.emitCustomEvent(payload:messageType:storeInHistory:)` for custom events")
   @discardableResult
   func emitEvent(
     channelId: String,

--- a/Sources/Chat/Chat+AsyncAwait.swift
+++ b/Sources/Chat/Chat+AsyncAwait.swift
@@ -430,7 +430,7 @@ public extension Chat {
   ///   - membershipCustom: Any custom properties or metadata associated with the user-channel membership in the form of a map of key-value pairs
   /// - Returns: A ``CreateDirectConversationResult`` value representing the result of creating a direct conversation (private channel) between two users.
   func createDirectConversation(
-    invitedUser: UserImpl,
+    invitedUser: ChatUserType,
     channelId: String? = nil,
     channelName: String? = nil,
     channelDescription: String? = nil,
@@ -470,7 +470,7 @@ public extension Chat {
   ///   - membershipCustom: Any custom properties or metadata associated with the membership in the form of key-value pairs
   /// - Returns: A  ``CreateGroupConversationResult`` value representing the result of creating a group conversation (group channel) for collaborative communication
   func createGroupConversation(
-    invitedUsers: [UserImpl],
+    invitedUsers: [ChatUserType],
     channelId: String? = nil,
     channelName: String? = nil,
     channelDescription: String? = nil,
@@ -580,7 +580,7 @@ public extension Chat {
     page: PubNubHashedPage? = nil,
     filter: String? = nil,
     sort: [PubNub.MembershipSortField] = []
-  ) async throws -> [GetUnreadMessagesCount<ChannelImpl, MembershipImpl>] {
+  ) async throws -> [GetUnreadMessagesCount<ChatChannelType, ChatMembershipType>] {
     try await withCheckedThrowingContinuation { continuation in
       getUnreadMessagesCount(
         limit: limit,
@@ -612,7 +612,7 @@ public extension Chat {
     page: PubNubHashedPage? = nil,
     filter: String? = nil,
     sort: [PubNub.MembershipSortField] = []
-  ) async throws -> (countsByChannel: [GetUnreadMessagesCount<ChannelImpl, MembershipImpl>], page: PubNubHashedPage?) {
+  ) async throws -> (countsByChannel: [GetUnreadMessagesCount<ChatChannelType, ChatMembershipType>], page: PubNubHashedPage?) {
     try await withCheckedThrowingContinuation { continuation in
       fetchUnreadMessagesCounts(
         limit: limit,

--- a/Sources/Chat/Chat+AsyncAwait.swift
+++ b/Sources/Chat/Chat+AsyncAwait.swift
@@ -169,21 +169,17 @@ public extension Chat {
     }
   }
 
-  /// Deletes a user with or without deleting its historical data from the App Context storage.
+  /// Deletes a user and its historical data from the App Context storage.
   ///
-  /// - Parameters:
-  ///   - id: Unique user identifier
-  ///   - soft: Decide if you want to permanently remove user metadata
-  /// - Returns: For hard delete, the method returns `nil`. Otherwise, an updated ``User`` instance with the status field set to `"deleted"`
+  /// - Parameter id: Unique user identifier
   func deleteUser(
-    id: String,
-    soft: Bool = false
-  ) async throws -> ChatUserType? {
-    try await withCheckedThrowingContinuation { continuation in
-      deleteUser(id: id, soft: soft) {
+    id: String
+  ) async throws {
+    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+      deleteUser(id: id) {
         switch $0 {
-        case let .success(user):
-          continuation.resume(returning: user)
+        case .success:
+          continuation.resume()
         case let .failure(error):
           continuation.resume(throwing: error)
         }
@@ -315,18 +311,15 @@ public extension Chat {
     }
   }
 
-  /// Allows to delete ``Channel`` with or without deleting its historical data from the App Context storage.
+  /// Deletes a ``Channel`` and its historical data from the App Context storage.
   ///
-  /// - Parameters:
-  ///   - id: Unique channel identifier (up to 92 UTF-8 byte sequences)
-  ///   - soft: Decide if you want to permanently remove channel metadata. If you set this parameter to true, the ``Channel`` object gets the deleted status, and you can still restore/get its data
-  /// - Returns: For hard delete, the method returns `nil`. Otherwise, an updated ``Channel`` instance with the status field set to `"deleted"`
-  func deleteChannel(id: String, soft: Bool = false) async throws -> ChatChannelType? {
-    try await withCheckedThrowingContinuation { continuation in
-      deleteChannel(id: id, soft: soft) {
+  /// - Parameter id: Unique channel identifier (up to 92 UTF-8 byte sequences)
+  func deleteChannel(id: String) async throws {
+    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+      deleteChannel(id: id) {
         switch $0 {
-        case let .success(channel):
-          continuation.resume(returning: channel)
+        case .success:
+          continuation.resume()
         case let .failure(error):
           continuation.resume(throwing: error)
         }

--- a/Sources/Chat/Chat.swift
+++ b/Sources/Chat/Chat.swift
@@ -13,7 +13,7 @@ import PubNubSDK
 
 /// A protocol that defines the basic structure and behavior for a chat.
 ///
-/// For example, you can use ``deleteChannel(id:soft:completion:)``
+/// For example, you can use ``deleteChannel(id:completion:)``
 /// to remove a given channel or ``wherePresent(userId:completion:)`` to check which channels a given user is subscribed to.
 ///
 /// By calling methods on the ``Chat`` entity, you create chat objects like ``Channel``, ``User``, ``Message``, ``Membership``,  ``ThreadChannel``,
@@ -146,18 +146,16 @@ public protocol Chat: AnyObject {
     completion: ((Swift.Result<ChatUserType, Error>) -> Void)?
   )
 
-  /// Deletes a user with or without deleting its historical data from the App Context storage.
+  /// Deletes a user and its historical data from the App Context storage.
   ///
   /// - Parameters:
   ///   - id: Unique user identifier
-  ///   - soft: Decide if you want to permanently remove user metadata
   ///   - completion: The async `Result` of the method call
-  ///     - **Success**: For hard delete, the method returns `nil`. Otherwise, an updated ``User`` instance with the status field set to `"deleted"`
+  ///     - **Success**: A `Void` indicating a success
   ///     - **Failure**: An `Error` describing the failure
   func deleteUser(
     id: String,
-    soft: Bool,
-    completion: ((Swift.Result<ChatUserType?, Error>) -> Void)?
+    completion: ((Swift.Result<Void, Error>) -> Void)?
   )
 
   /// Retrieves list of channel identifiers where a given user is present.
@@ -238,18 +236,16 @@ public protocol Chat: AnyObject {
     completion: ((Swift.Result<ChatChannelType, Error>) -> Void)?
   )
 
-  /// Allows to delete ``Channel`` with or without deleting its historical data from the App Context storage.
+  /// Deletes a ``Channel`` and its historical data from the App Context storage.
   ///
   /// - Parameters:
   ///   - id: Unique channel identifier (up to 92 UTF-8 byte sequences)
-  ///   - soft: Decide if you want to permanently remove channel metadata. If you set this parameter to true, the ``Channel`` object gets the deleted status, and you can still restore/get its data
   ///   - completion: The async `Result` of the method call
-  ///     - **Success**: For hard delete, the method returns `nil`. Otherwise, an updated ``Channel`` instance with the status field set to `"deleted"`
+  ///     - **Success**: A `Void` indicating a success
   ///     - **Failure**: An `Error` describing the failure
   func deleteChannel(
     id: String,
-    soft: Bool,
-    completion: ((Swift.Result<ChatChannelType?, Error>) -> Void)?
+    completion: ((Swift.Result<Void, Error>) -> Void)?
   )
 
   /// Returns a list of ``User`` identifiers present on the given ``Channel``.

--- a/Sources/Chat/Chat.swift
+++ b/Sources/Chat/Chat.swift
@@ -323,7 +323,7 @@ public protocol Chat: AnyObject {
   ///     - **Success**: A ``CreateDirectConversationResult`` value representing the result of creating a direct conversation (private channel) between two users.
   ///     - **Failure**: An `Error` describing the failure
   func createDirectConversation(
-    invitedUser: UserImpl,
+    invitedUser: ChatUserType,
     channelId: String?,
     channelName: String?,
     channelDescription: String?,
@@ -347,7 +347,7 @@ public protocol Chat: AnyObject {
   ///     - **Success**: A  ``CreateGroupConversationResult`` value representing the result of creating a group conversation (group channel) for collaborative communication
   ///     - **Failure**: An `Error` describing the failure
   func createGroupConversation(
-    invitedUsers: [UserImpl],
+    invitedUsers: [ChatUserType],
     channelId: String?,
     channelName: String?,
     channelDescription: String?,
@@ -426,7 +426,7 @@ public protocol Chat: AnyObject {
     page: PubNubHashedPage?,
     filter: String?,
     sort: [PubNub.MembershipSortField],
-    completion: ((Swift.Result<[GetUnreadMessagesCount<ChannelImpl, MembershipImpl>], Error>) -> Void)?
+    completion: ((Swift.Result<[GetUnreadMessagesCount<ChatChannelType, ChatMembershipType>], Error>) -> Void)?
   )
 
   /// Returns info on all messages you didn't read on all joined channels. You can display this number on UI in the channel list of your chat app.
@@ -444,7 +444,10 @@ public protocol Chat: AnyObject {
     page: PubNubHashedPage?,
     filter: String?,
     sort: [PubNub.MembershipSortField],
-    completion: ((Swift.Result<(countsByChannel: [GetUnreadMessagesCount<ChannelImpl, MembershipImpl>], page: PubNubHashedPage?), Error>) -> Void)?
+    completion: ((Swift.Result<(
+      countsByChannel: [GetUnreadMessagesCount<ChatChannelType, ChatMembershipType>],
+      page: PubNubHashedPage?), Error>) -> Void
+    )?
   )
 
   /// Allows you to mark as read all messages you didn't read on all joined channels.

--- a/Sources/Chat/Chat.swift
+++ b/Sources/Chat/Chat.swift
@@ -448,6 +448,8 @@ public protocol Chat: AnyObject {
 
   /// Allows you to mark as read all messages you didn't read on all joined channels.
   ///
+  /// This method emits a read receipt event on each affected channel, unless ``ChatConfiguration/emitReadReceiptEvents`` is set to `false` for the channel's type.
+  ///
   /// - Parameters:
   ///   - limit: Number of objects to return in response. The maximum value is 100
   ///   - page: Object used for pagination to define which previous or next result page you want to fetch

--- a/Sources/Chat/Chat.swift
+++ b/Sources/Chat/Chat.swift
@@ -368,6 +368,7 @@ public protocol Chat: AnyObject {
   ///   - customMethod: An optional custom method for emitting events
   ///   - callback: A function that is called with an ``EventWrapper`` as its parameter. It defines the custom behavior to be executed whenever an event is detected on the specified channel
   /// - Returns: ``AutoCloseable`` interface you can call to stop listening for new events and clean up resources when they re no longer needed by invoking the ``AutoCloseable/close()`` method
+  @available(*, deprecated, message: "Use entity-specific methods instead")
   func listenForEvents<T: EventContent>(
     type: T.Type,
     channelId: String,

--- a/Sources/Chat/Chat.swift
+++ b/Sources/Chat/Chat.swift
@@ -516,10 +516,10 @@ public protocol Chat: AnyObject {
   /// Returns a reference to a ``ChannelGroup`` with the specified id.
   ///
   /// This does **not** create a group on the server. If the group exists, the reference points to it. If the group does not exist, it serves as a handle to create
-  /// and modify it via channel changes. For example, ``ChannelGroup/add(channels:completion:)``, ``ChannelGroup/addChannelIdentifiers(ids:completion:)``
+  /// and modify it via channel changes. For example, ``ChannelGroup/add(channels:completion:)``, ``ChannelGroup/addChannelIdentifiers(_:completion:)``
   ///
   /// - Parameter id: The ID of the ``ChannelGroup`` to get
-  /// - Returns: A ``ChatChannelGroupType`` instance
+  /// - Returns: A ``ChannelGroup`` instance
   func getChannelGroup(id: String) -> ChatChannelGroupType
 
   /// Removes a channel group with the specified id.
@@ -538,17 +538,9 @@ public protocol Chat: AnyObject {
   func addConnectionStatusListener(_ listener: @escaping (ConnectionStatus) -> Void) -> AutoCloseable
 
   /// Reconnects the client to the PubNub system.
-  ///
-  /// - Parameter completion: The async `Result` of the method call
-  ///     - **Success**: A `Void` indicating a success
-  ///     - **Failure**: An `Error` describing the failure
   func reconnectSubscriptions()
 
   /// Disconnects the client from the PubNub system.
-  ///
-  /// - Parameter completion: The async `Result` of the method call
-  ///     - **Success**: A `Void` indicating a success
-  ///     - **Failure**: An `Error` describing the failure
   func disconnectSubscriptions()
 
   // swiftlint:disable:next file_length

--- a/Sources/Chat/Chat.swift
+++ b/Sources/Chat/Chat.swift
@@ -273,6 +273,7 @@ public protocol Chat: AnyObject {
   ///   - completion: The async `Result` of the method call
   ///     - **Success**: A `Timetoken` value that holds the timestamp of the emitted event
   ///     - **Failure**: An `Error` describing the failure
+  @available(*, deprecated, message: "Use `Channel.emitCustomEvent(payload:messageType:storeInHistory:completion:)` for custom events")
   func emitEvent<T: EventContent>(
     channelId: String,
     payload: T,

--- a/Sources/Chat/ChatConfiguration.swift
+++ b/Sources/Chat/ChatConfiguration.swift
@@ -190,6 +190,9 @@ public struct ChatConfiguration {
   ///
   public var syncMutedUsers: Bool
 
+  /// Specifies whether read receipt events should be emitted, per channel type. Defaults to `true` for all channel types except `.public`, which defaults to `false`
+  public var emitReadReceiptEvents: [ChannelType: Bool]
+
   /// Creates a new ``ChatConfiguration`` object
   ///
   /// - Parameters:
@@ -202,6 +205,7 @@ public struct ChatConfiguration {
   ///   - rateLimitPerChannel: Client-side limit that states the rate at which messages can be published on a given channel type
   ///   - customPayloads: Custom message payload to be sent and/or received by Chat SDK
   ///   - syncMutedUsers: A boolean value that controls syncing of muted users
+  ///   - emitReadReceiptEvents: Per-channel-type dictionary for emitting read receipt events. Defaults to `true` for all channel types except `.public`
   public init(
     logLevel: LogLevel = .off,
     typingTimeout: Int = 5,
@@ -211,7 +215,8 @@ public struct ChatConfiguration {
     rateLimitFactor: Int = 2,
     rateLimitPerChannel: [ChannelType: Int64] = ChannelType.allCases.reduce(into: [ChannelType: Int64]()) { res, type in res[type] = 0 },
     customPayloads: CustomPayloads? = nil,
-    syncMutedUsers: Bool = false
+    syncMutedUsers: Bool = false,
+    emitReadReceiptEvents: [ChannelType: Bool] = [.direct: true, .group: true, .public: false, .unknown: true]
   ) {
     self.logLevel = logLevel
     self.typingTimeout = typingTimeout
@@ -222,6 +227,7 @@ public struct ChatConfiguration {
     self.rateLimitPerChannel = rateLimitPerChannel
     self.customPayloads = customPayloads
     self.syncMutedUsers = syncMutedUsers
+    self.emitReadReceiptEvents = emitReadReceiptEvents
   }
 
   func transform() -> any PubNubChat.ChatConfiguration {
@@ -240,6 +246,7 @@ public struct ChatConfiguration {
       rateLimitFactor: Int32(rateLimitFactor),
       rateLimitPerChannel: rateLimitPerChannel.transform(),
       customPayloads: customPayloads?.transform(),
+      emitReadReceiptEvents: emitReadReceiptEvents.transform(),
       syncMutedUsers: syncMutedUsers
     )
   }

--- a/Sources/Chat/ChatImpl.swift
+++ b/Sources/Chat/ChatImpl.swift
@@ -249,16 +249,12 @@ extension ChatImpl: Chat {
 
   public func deleteUser(
     id: String,
-    soft: Bool = false,
-    completion: ((Swift.Result<UserImpl?, Error>) -> Void)? = nil
+    completion: ((Swift.Result<Void, Error>) -> Void)? = nil
   ) {
-    chat.deleteUser(
-      id: id,
-      soft: soft
-    ).async(caller: self) { (result: FutureResult<ChatImpl, PubNubChat.User?>) in
+    chat.deleteUser(id: id).async(caller: self) { (result: FutureResult<ChatImpl, PubNubChat.KotlinUnit>) in
       switch result.result {
-      case let .success(user):
-        completion?(.success(UserImpl(user: user, chat: result.caller)))
+      case .success:
+        completion?(.success(()))
       case let .failure(error):
         completion?(.failure(error))
       }
@@ -376,16 +372,12 @@ extension ChatImpl: Chat {
 
   public func deleteChannel(
     id: String,
-    soft: Bool = false,
-    completion: ((Swift.Result<ChannelImpl?, Error>) -> Void)? = nil
+    completion: ((Swift.Result<Void, Error>) -> Void)? = nil
   ) {
-    chat.deleteChannel(
-      id: id,
-      soft: soft
-    ).async(caller: self) { (result: FutureResult<ChatImpl, PubNubChat.Channel_?>) in
+    chat.deleteChannel(id: id).async(caller: self) { (result: FutureResult<ChatImpl, PubNubChat.KotlinUnit>) in
       switch result.result {
-      case let .success(channel):
-        completion?(.success(ChannelImpl(channel: channel, chat: result.caller)))
+      case .success:
+        completion?(.success(()))
       case let .failure(error):
         completion?(.failure(error))
       }

--- a/Sources/Chat/ChatImpl.swift
+++ b/Sources/Chat/ChatImpl.swift
@@ -532,11 +532,11 @@ extension ChatImpl: Chat {
         channelId: channelId,
         customMethod: customMethod == .publish ? .publish : .signal,
         callback: { [weak self] in
-          if let selfRef = self, let payload = $0.payload.map() as? T {
+          if let self = self, let payload = $0.payload.map() as? T {
             callback(
               EventWrapper(
                 event: EventImpl(
-                  chat: selfRef,
+                  chat: self,
                   timetoken: Timetoken($0.timetoken_),
                   payload: payload,
                   channelId: $0.channelId,

--- a/Sources/Entities/BaseChannel.swift
+++ b/Sources/Entities/BaseChannel.swift
@@ -348,20 +348,18 @@ final class BaseChannel<C: PubNubChat.Channel_, M: PubNubChat.Message>: Channel 
 
   func join(
     custom: [String: JSONCodableScalar]?,
-    callback: ((ChatType.ChatMessageType) -> Void)?,
-    completion: ((Swift.Result<(membership: MembershipImpl, disconnect: AutoCloseable?), Error>) -> Void)?
+    status: String?,
+    type: String?,
+    completion: ((Swift.Result<ChatType.ChatMembershipType, Error>) -> Void)?
   ) {
-    channel.join(custom: custom?.asCustomObject(), callback: { [weak self] in
-      if let self = self {
-        callback?(MessageImpl(message: $0, chat: self.chat))
-      }
-    }).async(caller: self) { (result: FutureResult<BaseChannel, PubNubChat.JoinResult>) in
+    channel.join(
+      status: status,
+      type: type,
+      custom: custom?.asCustomObject()
+    ).async(caller: self) { (result: FutureResult<BaseChannel, PubNubChat.Membership>) in
       switch result.result {
-      case let .success(joinRes):
-        completion?(.success((
-          membership: MembershipImpl(membership: joinRes.membership, chat: result.caller.chat),
-          disconnect: AutoCloseableImpl(joinRes.disconnect, owner: result.caller)
-        )))
+      case let .success(membership):
+        completion?(.success(MembershipImpl(membership: membership, chat: result.caller.chat)))
       case let .failure(error):
         completion?(.failure(error))
       }
@@ -724,6 +722,47 @@ final class BaseChannel<C: PubNubChat.Channel_, M: PubNubChat.Message>: Channel 
       channel.onMessageReported { [weak self] in
         if self != nil {
           callback($0.transform())
+        }
+      },
+      owner: self
+    )
+  }
+
+  func emitCustomEvent(
+    payload: [String: JSONCodable],
+    messageType: String?,
+    storeInHistory: Bool,
+    completion: ((Swift.Result<Timetoken, Error>) -> Void)?
+  ) {
+    channel.emitCustomEvent(
+      payload: payload,
+      messageType: messageType,
+      storeInHistory: storeInHistory
+    ).async(caller: self) { (result: FutureResult<BaseChannel, PubNubChat.PNPublishResult>) in
+      switch result.result {
+      case let .success(response):
+        completion?(.success(Timetoken(response.timetoken)))
+      case let .failure(error):
+        completion?(.failure(error))
+      }
+    }
+  }
+
+  func onCustomEvent(
+    messageType: String?,
+    callback: @escaping (CustomEvent) -> Void
+  ) -> AutoCloseable {
+    AutoCloseableImpl(
+      channel.onCustomEvent(messageType: messageType) { [weak self] in
+        if self != nil {
+          callback(
+            CustomEvent(
+              timetoken: Timetoken($0.timetoken),
+              userId: $0.userId,
+              type: $0.type,
+              payload: ($0.payload as? [String: Any])?.compactMapValues { AnyJSON($0) } ?? [:]
+            )
+          )
         }
       },
       owner: self

--- a/Sources/Entities/BaseChannel.swift
+++ b/Sources/Entities/BaseChannel.swift
@@ -479,11 +479,15 @@ final class BaseChannel<C: PubNubChat.Channel_, M: PubNubChat.Message>: Channel 
     )
   }
 
-  func streamReadReceipts(callback: @escaping ((ReadReceipt) -> Void)) -> AutoCloseable {
+  func streamReadReceipts(callback: @escaping (([Timetoken: [String]]) -> Void)) -> AutoCloseable {
     AutoCloseableImpl(
       channel.streamReadReceipts { [weak self] in
         if self != nil {
-          callback($0.transform())
+          callback(
+            $0.reduce(into: [Timetoken: [String]]()) { res, currentItem in
+              res[Timetoken(currentItem.key.uint64Value)] = currentItem.value
+            }
+          )
         }
       },
       owner: self
@@ -633,16 +637,93 @@ final class BaseChannel<C: PubNubChat.Channel_, M: PubNubChat.Message>: Channel 
   func streamMessageReports(callback: @escaping (any Event<EventContent.Report>) -> Void) -> AutoCloseable {
     AutoCloseableImpl(
       channel.streamMessageReports { [weak self] in
-        if let selfRef = self, let payload = $0.payload.map() as? EventContent.Report {
+        if let self = self, let payload = $0.payload.map() as? EventContent.Report {
           callback(
             EventImpl(
-              chat: selfRef.chat,
+              chat: self.chat,
               timetoken: Timetoken($0.timetoken_),
               payload: payload,
               channelId: $0.channelId,
               userId: $0.userId
             )
           )
+        }
+      },
+      owner: self
+    )
+  }
+
+  func onTypingChanged(callback: @escaping (([String]) -> Void)) -> AutoCloseable {
+    AutoCloseableImpl(
+      channel.onTypingChanged { [weak self] in
+        if let typingUserIdentifiers = $0 as? [String], self != nil {
+          callback(typingUserIdentifiers)
+        }
+      },
+      owner: self
+    )
+  }
+
+  func onMessageReceived(callback: @escaping (BaseMessage<M>) -> Void) -> AutoCloseable {
+    AutoCloseableImpl(
+      channel.onMessageReceived { [weak self] in
+        if let self = self, let message = $0 as? M {
+          callback(BaseMessage(message: message, chat: self.chat))
+        }
+      },
+      owner: self
+    )
+  }
+
+  func onUpdated(callback: @escaping (BaseChannel<C, M>) -> Void) -> AutoCloseable {
+    AutoCloseableImpl(
+      channel.onUpdated { [weak self] in
+        if let self = self, let channel = $0 as? C {
+          callback(BaseChannel(channel: channel, chat: self.chat))
+        }
+      },
+      owner: self
+    )
+  }
+
+  func onDeleted(callback: @escaping () -> Void) -> AutoCloseable {
+    AutoCloseableImpl(
+      channel.onDeleted { [weak self] in
+        if self != nil {
+          callback()
+        }
+      },
+      owner: self
+    )
+  }
+
+  func onReadReceiptReceived(callback: @escaping (ReadReceipt) -> Void) -> AutoCloseable {
+    AutoCloseableImpl(
+      channel.onReadReceiptReceived { [weak self] in
+        if self != nil {
+          callback($0.transform())
+        }
+      },
+      owner: self
+    )
+  }
+
+  func onPresenceChanged(callback: @escaping (Set<String>) -> Void) -> AutoCloseable {
+    AutoCloseableImpl(
+      channel.onPresenceChanged { [weak self] in
+        if let userIds = $0 as? Set<String>, self != nil {
+          callback(userIds)
+        }
+      },
+      owner: self
+    )
+  }
+
+  func onMessageReported(callback: @escaping (Report) -> Void) -> AutoCloseable {
+    AutoCloseableImpl(
+      channel.onMessageReported { [weak self] in
+        if self != nil {
+          callback($0.transform())
         }
       },
       owner: self

--- a/Sources/Entities/BaseChannel.swift
+++ b/Sources/Entities/BaseChannel.swift
@@ -305,6 +305,36 @@ final class BaseChannel<C: PubNubChat.Channel_, M: PubNubChat.Message>: Channel 
     }
   }
 
+  func hasMember(userId: String, completion: ((Swift.Result<Bool, Error>) -> Void)?) {
+    channel.hasMember(
+      userId: userId
+    ).async(caller: self) { (result: FutureResult<BaseChannel, Bool>) in
+      switch result.result {
+      case let .success(hasMember):
+        completion?(.success(hasMember))
+      case let .failure(error):
+        completion?(.failure(error))
+      }
+    }
+  }
+
+  func getMember(userId: String, completion: ((Swift.Result<ChatType.ChatMembershipType?, Error>) -> Void)?) {
+    channel.getMember(
+      userId: userId
+    ).async(caller: self) { (result: FutureResult<BaseChannel, PubNubChat.Membership?>) in
+      switch result.result {
+      case let .success(membership):
+        if let membership {
+          completion?(.success(MembershipImpl(membership: membership, chat: result.caller.chat)))
+        } else {
+          completion?(.success(nil))
+        }
+      case let .failure(error):
+        completion?(.failure(error))
+      }
+    }
+  }
+
   func connect(callback: @escaping (ChatType.ChatMessageType) -> Void) -> AutoCloseable {
     AutoCloseableImpl(
       channel.connect { [weak self] in
@@ -449,19 +479,44 @@ final class BaseChannel<C: PubNubChat.Channel_, M: PubNubChat.Message>: Channel 
     )
   }
 
-  func streamReadReceipts(callback: @escaping (([Timetoken: [String]]) -> Void)) -> AutoCloseable {
+  func streamReadReceipts(callback: @escaping ((ReadReceipt) -> Void)) -> AutoCloseable {
     AutoCloseableImpl(
       channel.streamReadReceipts { [weak self] in
         if self != nil {
-          callback(
-            $0.reduce(into: [Timetoken: [String]]()) { res, currentItem in
-              res[Timetoken(currentItem.key.uint64Value)] = currentItem.value
-            }
-          )
+          callback($0.transform())
         }
       },
       owner: self
     )
+  }
+
+  func fetchReadReceipts(
+    limit: Int?,
+    page: PubNubHashedPage?,
+    filter: String?,
+    sort: [PubNub.MembershipSortField],
+    completion: ((Swift.Result<(receipts: [ReadReceipt], page: PubNubHashedPage?), Error>) -> Void)?
+  ) {
+    channel.fetchReadReceipts(
+      limit: limit?.asKotlinInt,
+      page: page?.transform(),
+      filter: filter,
+      sort: sort.compactMap { $0.transform() }
+    ).async(caller: self) { (result: FutureResult<BaseChannel, PubNubChat.ReadReceiptsResponse>) in
+      switch result.result {
+      case let .success(response):
+        completion?(.success((
+          receipts: response.receipts.transform(),
+          page: PubNubHashedPageBase(
+            start: response.next?.pageHash,
+            end: response.prev?.pageHash,
+            totalCount: Int(response.total)
+          ))
+        ))
+      case let .failure(error):
+        completion?(.failure(error))
+      }
+    }
   }
 
   func getFiles(

--- a/Sources/Entities/BaseChannel.swift
+++ b/Sources/Entities/BaseChannel.swift
@@ -587,6 +587,39 @@ final class BaseChannel<C: PubNubChat.Channel_, M: PubNubChat.Message>: Channel 
     )
   }
 
+  func getInvitees(
+    limit: Int?,
+    page: PubNubHashedPage?,
+    filter: String?,
+    sort: [PubNub.MembershipSortField],
+    completion: ((Swift.Result<(memberships: [ChatType.ChatMembershipType], page: PubNubHashedPage?), Error>) -> Void)?
+  ) {
+    channel.getInvitees(
+      limit: limit?.asKotlinInt,
+      page: page?.transform(),
+      filter: filter,
+      sort: sort.compactMap { $0.transform() }
+    ).async(caller: self) { (result: FutureResult<BaseChannel, PubNubChat.MembersResponse>) in
+      switch result.result {
+      case let .success(response):
+        completion?(.success(
+          (
+            memberships: response.members.map {
+              MembershipImpl(membership: $0, chat: result.caller.chat)
+            },
+            page: PubNubHashedPageBase(
+              start: response.next?.pageHash,
+              end: response.prev?.pageHash,
+              totalCount: Int(response.total)
+            )
+          )
+        ))
+      case let .failure(error):
+        completion?(.failure(error))
+      }
+    }
+  }
+
   func getUserSuggestions(
     text: String,
     limit: Int,

--- a/Sources/Entities/BaseChannel.swift
+++ b/Sources/Entities/BaseChannel.swift
@@ -72,13 +72,11 @@ final class BaseChannel<C: PubNubChat.Channel_, M: PubNubChat.Message>: Channel 
     }
   }
 
-  func delete(soft: Bool, completion: ((Swift.Result<ChatType.ChatChannelType?, Error>) -> Void)?) {
-    channel.delete(
-      soft: soft
-    ).async(caller: self) { (result: FutureResult<BaseChannel, C?>) in
+  func delete(completion: ((Swift.Result<Void, Error>) -> Void)?) {
+    channel.delete().async(caller: self) { (result: FutureResult<BaseChannel, PubNubChat.KotlinUnit>) in
       switch result.result {
-      case let .success(channel):
-        completion?(.success(ChannelImpl(channel: channel, chat: result.caller.chat)))
+      case .success:
+        completion?(.success(()))
       case let .failure(error):
         completion?(.failure(error))
       }

--- a/Sources/Entities/BaseChannel.swift
+++ b/Sources/Entities/BaseChannel.swift
@@ -54,7 +54,7 @@ final class BaseChannel<C: PubNubChat.Channel_, M: PubNubChat.Message>: Channel 
     description: String?,
     status: String?,
     type: ChannelType?,
-    completion: ((Swift.Result<ChatType.ChatChannelType, Error>) -> Void)?
+    completion: ((Swift.Result<BaseChannel, Error>) -> Void)?
   ) {
     channel.update(
       name: name,
@@ -65,7 +65,7 @@ final class BaseChannel<C: PubNubChat.Channel_, M: PubNubChat.Message>: Channel 
     ).async(caller: self) { (result: FutureResult<BaseChannel, C>) in
       switch result.result {
       case let .success(channel):
-        completion?(.success(ChannelImpl(channel: channel, chat: result.caller.chat)))
+        completion?(.success(BaseChannel(channel: channel, chat: result.caller.chat)))
       case let .failure(error):
         completion?(.failure(error))
       }
@@ -246,6 +246,24 @@ final class BaseChannel<C: PubNubChat.Channel_, M: PubNubChat.Message>: Channel 
     }
   }
 
+  func sendText(
+    text: String,
+    params: SendTextParams,
+    completion: ((Swift.Result<Timetoken, Error>) -> Void)?
+  ) {
+    channel.sendText(
+      text: text,
+      params: params.transform()
+    ).async(caller: self) { (result: FutureResult<BaseChannel, PubNubChat.PNPublishResult>) in
+      switch result.result {
+      case let .success(response):
+        completion?(.success(Timetoken(response.timetoken)))
+      case let .failure(error):
+        completion?(.failure(error))
+      }
+    }
+  }
+
   func invite(user: ChatType.ChatUserType, completion: ((Swift.Result<MembershipImpl, Error>) -> Void)?) {
     channel.invite(
       user: user.user
@@ -377,15 +395,11 @@ final class BaseChannel<C: PubNubChat.Channel_, M: PubNubChat.Message>: Channel 
     }
   }
 
-  func getPinnedMessage(completion: ((Swift.Result<(ChatType.ChatMessageType)?, Error>) -> Void)?) {
+  func getPinnedMessage(completion: ((Swift.Result<(BaseMessage<M>)?, Error>) -> Void)?) {
     channel.getPinnedMessage().async(caller: self) { (result: FutureResult<BaseChannel, M?>) in
       switch result.result {
       case let .success(message):
-        if let message {
-          completion?(.success(MessageImpl(message: message, chat: result.caller.chat)))
-        } else {
-          completion?(.success(nil))
-        }
+        completion?(.success(BaseMessage(message: message, chat: result.caller.chat)))
       case let .failure(error):
         completion?(.failure(error))
       }
@@ -394,18 +408,14 @@ final class BaseChannel<C: PubNubChat.Channel_, M: PubNubChat.Message>: Channel 
 
   func getMessage(
     timetoken: Timetoken,
-    completion: ((Swift.Result<ChatType.ChatMessageType?, Error>) -> Void)?
+    completion: ((Swift.Result<BaseMessage<M>?, Error>) -> Void)?
   ) {
     channel.getMessage(
       timetoken: Int64(timetoken)
-    ).async(caller: self) { (result: FutureResult<BaseChannel, PubNubChat.Message?>) in
+    ).async(caller: self) { (result: FutureResult<BaseChannel, M?>) in
       switch result.result {
       case let .success(message):
-        if let message {
-          completion?(.success(MessageImpl(message: message, chat: result.caller.chat)))
-        } else {
-          completion?(.success(nil))
-        }
+        completion?(.success(BaseMessage(message: message, chat: result.caller.chat)))
       case let .failure(error):
         completion?(.failure(error))
       }

--- a/Sources/Entities/BaseMessage.swift
+++ b/Sources/Entities/BaseMessage.swift
@@ -225,13 +225,13 @@ extension BaseMessage: Message {
     }
   }
 
-  public func removeThread(completion: ((Swift.Result<ChannelImpl?, Error>) -> Void)?) {
+  public func removeThread(completion: ((Swift.Result<Void, Error>) -> Void)?) {
     message.removeThread().async(
       caller: self
-    ) { (result: FutureResult<BaseMessage, KotlinPair<PNRemoveMessageActionResult, PubNubChat.ThreadChannel>>) in
+    ) { (result: FutureResult<BaseMessage, PubNubChat.KotlinUnit>) in
       switch result.result {
       case let .success(pair):
-        completion?(.success(ChannelImpl(channel: pair.second, chat: result.caller.chat)))
+        completion?(.success(()))
       case let .failure(error):
         completion?(.failure(error))
       }

--- a/Sources/Entities/BaseMessage.swift
+++ b/Sources/Entities/BaseMessage.swift
@@ -244,6 +244,17 @@ extension BaseMessage: Message {
     )
   }
 
+  func onUpdated(callback: @escaping (BaseMessage<M>) -> Void) -> AutoCloseable {
+    AutoCloseableImpl(
+      message.onUpdated { [weak self] in
+        if let message = $0 as? M, let self = self {
+          callback(BaseMessage(message: message, chat: self.chat))
+        }
+      },
+      owner: self
+    )
+  }
+
   func restore(completion: ((Swift.Result<BaseMessage<M>, Error>) -> Void)?) {
     message.restore().async(caller: self) { (result: FutureResult<BaseMessage, M>) in
       switch result.result {

--- a/Sources/Entities/BaseMessage.swift
+++ b/Sources/Entities/BaseMessage.swift
@@ -75,14 +75,14 @@ extension BaseMessage: Message {
 
   public func editText(
     newText: String,
-    completion: ((Swift.Result<MessageImpl, Error>) -> Void)?
+    completion: ((Swift.Result<BaseMessage, Error>) -> Void)?
   ) {
     message.editText(
       newText: newText
     ).async(caller: self) { (result: FutureResult<BaseMessage, M>) in
       switch result.result {
       case let .success(message):
-        completion?(.success(MessageImpl(message: message, chat: result.caller.chat)))
+        completion?(.success(BaseMessage(message: message, chat: result.caller.chat)))
       case let .failure(error):
         completion?(.failure(error))
       }
@@ -198,6 +198,27 @@ extension BaseMessage: Message {
       switch result.result {
       case let .success(threadChannel):
         completion?(.success(ThreadChannelImpl(channel: threadChannel, chat: result.caller.chat)))
+      case let .failure(error):
+        completion?(.failure(error))
+      }
+    }
+  }
+
+  func createThreadWithResult(
+    text: String,
+    params: SendTextParams,
+    completion: ((Swift.Result<CreateThreadResult<ThreadChannelImpl, MessageImpl>, Error>) -> Void)?
+  ) {
+    message.createThreadWithResult(
+      text: text,
+      params: params.transform()
+    ).async(caller: self) { (result: FutureResult<BaseMessage, PubNubChat.CreateThreadResult>) in
+      switch result.result {
+      case let .success(kmpResult):
+        completion?(.success(CreateThreadResult(
+          threadChannel: ThreadChannelImpl(channel: kmpResult.threadChannel, chat: result.caller.chat),
+          parentMessage: MessageImpl(message: kmpResult.parentMessage, chat: result.caller.chat)
+        )))
       case let .failure(error):
         completion?(.failure(error))
       }

--- a/Sources/Entities/BaseMessage.swift
+++ b/Sources/Entities/BaseMessage.swift
@@ -45,7 +45,7 @@ extension BaseMessage: Message {
   public var hasThread: Bool { message.hasThread }
   public var type: String { message.type }
   public var files: [File] { message.files.transform() }
-  public var reactions: [String: [Action]] { message.reactions.transform() }
+  public var reactions: [MessageReaction] { message.reactions.transform() }
   public var textLinks: [TextLink]? { message.textLinks?.transform() }
   public var error: Error? { message.error }
 

--- a/Sources/Entities/BaseMessage.swift
+++ b/Sources/Entities/BaseMessage.swift
@@ -204,7 +204,7 @@ extension BaseMessage: Message {
     }
   }
 
-  func createThreadWithResult(
+  func createThread(
     text: String,
     params: SendTextParams,
     completion: ((Swift.Result<CreateThreadResult<ThreadChannelImpl, MessageImpl>, Error>) -> Void)?

--- a/Sources/Entities/Channel+AsyncAwait.swift
+++ b/Sources/Entities/Channel+AsyncAwait.swift
@@ -379,33 +379,24 @@ public extension Channel {
     }
   }
 
-  /// Connects a user to the ``Channel`` and sets membership - this way, the chat user can both watch the channel's content and be its full-fledged member.
+  /// Sets the caller's membership on this channel.
   ///
   /// - Parameters:
   ///   - custom: Any custom properties or metadata associated with the channel-user membership in the form of key-value pairs
-  /// - Returns: A `Tuple` containing the user's membership in the channel, and an asynchronous stream that produces a new value every time a new message is published on the current channel
+  ///   - status: Optional membership status value
+  ///   - type: Optional membership type value
+  /// - Returns: The caller's membership in the channel
   @discardableResult
   func join(
-    custom: [String: JSONCodableScalar]? = nil
-  ) async throws -> (
-    membership: ChatType.ChatMembershipType,
-    messagesStream: AsyncStream<ChatType.ChatMessageType>
-  ) {
-    let messagesStream = AsyncStream { continuation in
-      let autoCloseable = connect {
-        continuation.yield($0)
-      }
-      continuation.onTermination = { _ in
-        autoCloseable.close()
-      }
-    }
-
+    custom: [String: JSONCodableScalar]? = nil,
+    status: String? = nil,
+    type: String? = nil
+  ) async throws -> ChatType.ChatMembershipType {
     return try await withCheckedThrowingContinuation { continuation in
-      join(custom: custom, callback: nil) {
+      join(custom: custom, status: status, type: type) {
         switch $0 {
-        case let .success(joinResult):
-          joinResult.disconnect?.close()
-          continuation.resume(returning: (membership: joinResult.membership, messagesStream: messagesStream))
+        case let .success(membership):
+          continuation.resume(returning: membership)
         case let .failure(error):
           continuation.resume(throwing: error)
         }
@@ -677,6 +668,35 @@ public extension Channel {
         switch $0 {
         case let .success(reportsTuple):
           continuation.resume(returning: reportsTuple)
+        case let .failure(error):
+          continuation.resume(throwing: error)
+        }
+      }
+    }
+  }
+
+  /// Emits a custom event on this channel.
+  ///
+  /// - Parameters:
+  ///   - payload: Arbitrary key-value payload to publish
+  ///   - messageType: Optional custom message type used for filtering
+  ///   - storeInHistory: If true, event is stored in Message Persistence (if enabled)
+  /// - Returns: The timetoken of the emitted event
+  @discardableResult
+  func emitCustomEvent(
+    payload: [String: JSONCodable],
+    messageType: String? = nil,
+    storeInHistory: Bool = true
+  ) async throws -> Timetoken {
+    try await withCheckedThrowingContinuation { continuation in
+      emitCustomEvent(
+        payload: payload,
+        messageType: messageType,
+        storeInHistory: storeInHistory
+      ) {
+        switch $0 {
+        case let .success(timetoken):
+          continuation.resume(returning: timetoken)
         case let .failure(error):
           continuation.resume(throwing: error)
         }

--- a/Sources/Entities/Channel+AsyncAwait.swift
+++ b/Sources/Entities/Channel+AsyncAwait.swift
@@ -303,7 +303,7 @@ public extension Channel {
   ///   - limit: Number of objects to return in response
   ///   - page: Object used for pagination to define which previous or next result page you want to fetch
   ///   - filter: Expression used to filter the results. Returns only these members whose properties satisfy the given expression
-  ///   - sort: A collection to specify the sort order. Available options are id, name, and updated
+  ///   - sort: A collection to specify the sort order
   /// - Returns: A `Tuple` containing an array of the members of the channel, and the next pagination `PubNubHashedPage` (if one exists)
   func getMembers(
     limit: Int? = nil,
@@ -316,6 +316,40 @@ public extension Channel {
         switch $0 {
         case let .success(getMembersResult):
           continuation.resume(returning: getMembersResult)
+        case let .failure(error):
+          continuation.resume(throwing: error)
+        }
+      }
+    }
+  }
+
+  /// Checks if a specific user is a member of this channel.
+  ///
+  /// - Parameter userId: Unique identifier of the user to check
+  /// - Returns: A `Bool` value indicating whether the user is a member of this channel
+  func hasMember(userId: String) async throws -> Bool {
+    try await withCheckedThrowingContinuation { continuation in
+      hasMember(userId: userId) {
+        switch $0 {
+        case let .success(hasMember):
+          continuation.resume(returning: hasMember)
+        case let .failure(error):
+          continuation.resume(throwing: error)
+        }
+      }
+    }
+  }
+
+  /// Retrieves the membership of a specific user in this channel.
+  ///
+  /// - Parameter userId: Unique identifier of the user whose membership to retrieve
+  /// - Returns: The user's ``Membership`` in this channel, or `nil` if not a member
+  func getMember(userId: String) async throws -> ChatType.ChatMembershipType? {
+    try await withCheckedThrowingContinuation { continuation in
+      getMember(userId: userId) {
+        switch $0 {
+        case let .success(membership):
+          continuation.resume(returning: membership)
         case let .failure(error):
           continuation.resume(throwing: error)
         }
@@ -491,13 +525,39 @@ public extension Channel {
   }
 
   /// Lets you get a read confirmation status for messages you published on a channel.
-  func streamReadReceipts() -> AsyncStream<[Timetoken: [String]]> {
+  func streamReadReceipts() -> AsyncStream<ReadReceipt> {
     AsyncStream { continuation in
       let autoCloseable = streamReadReceipts {
         continuation.yield($0)
       }
       continuation.onTermination = { _ in
         autoCloseable.close()
+      }
+    }
+  }
+
+  /// Fetches the read receipts for members of this channel.
+  ///
+  /// - Parameters:
+  ///   - limit: Number of objects to return in response
+  ///   - page: Object used for pagination to define which previous or next result page you want to fetch
+  ///   - filter: Expression used to filter the results. Returns only these members whose properties satisfy the given expression
+  ///   - sort: A collection to specify the sort order
+  /// - Returns: A `Tuple` containing an array of ``ReadReceipt``, and the next pagination `PubNubHashedPage` (if one exists)
+  func fetchReadReceipts(
+    limit: Int? = nil,
+    page: PubNubHashedPage? = nil,
+    filter: String? = nil,
+    sort: [PubNub.MembershipSortField] = []
+  ) async throws -> (receipts: [ReadReceipt], page: PubNubHashedPage?) {
+    try await withCheckedThrowingContinuation { continuation in
+      fetchReadReceipts(limit: limit, page: page, filter: filter, sort: sort) {
+        switch $0 {
+        case let .success(result):
+          continuation.resume(returning: result)
+        case let .failure(error):
+          continuation.resume(throwing: error)
+        }
       }
     }
   }

--- a/Sources/Entities/Channel+AsyncAwait.swift
+++ b/Sources/Entities/Channel+AsyncAwait.swift
@@ -15,6 +15,12 @@ import PubNubSDK
 /// Extension providing `async-await` support for ``Channel``.
 ///
 public extension Channel {
+
+  /// Namespace for `AsyncStream`-based streaming methods.
+  var stream: ChannelStream<Self> {
+    ChannelStream(channel: self)
+  }
+
   /// Receive updates when specific channels are updated or removed.
   ///
   /// Emits the complete list of monitored channels whenever any one of them changes, excluding any that were removed.
@@ -143,6 +149,7 @@ public extension Channel {
   /// Enables continuous tracking of typing activity within the ``Channel``.
   ///
   /// - Returns: An asynchronous stream producing typing user identifiers
+  @available(*, deprecated, message: "Use `stream.typingChanges()` instead")
   func getTyping() -> AsyncStream<[String]> {
     AsyncStream { continuation in
       let autoCloseable = getTyping {
@@ -360,6 +367,7 @@ public extension Channel {
   /// Watch the ``Channel`` content without a need to join the ``Channel``.
   ///
   /// - Returns: An asynchronous stream that produces a new value every time a new message is published on the current channel
+  @available(*, deprecated, message: "Use `stream.messages()` instead")
   func connect() -> AsyncStream<ChatType.ChatMessageType> {
     AsyncStream { continuation in
       let autoCloseable = connect {
@@ -383,7 +391,14 @@ public extension Channel {
     membership: ChatType.ChatMembershipType,
     messagesStream: AsyncStream<ChatType.ChatMessageType>
   ) {
-    let messagesStream = connect()
+    let messagesStream = AsyncStream { continuation in
+      let autoCloseable = connect {
+        continuation.yield($0)
+      }
+      continuation.onTermination = { _ in
+        autoCloseable.close()
+      }
+    }
 
     return try await withCheckedThrowingContinuation { continuation in
       join(custom: custom, callback: nil) {
@@ -513,6 +528,7 @@ public extension Channel {
   /// Receives updates on a single ``Channel`` object.
   ///
   /// - Returns: An asynchronous stream that produces updates when the current ``Channel`` is edited or `nil` if the channel was removed.
+  @available(*, deprecated, message: "Use `stream.updates()` and `stream.deletions()` instead")
   func streamUpdates() -> AsyncStream<ChatType.ChatChannelType?> {
     AsyncStream { continuation in
       let autoCloseable = streamUpdates {
@@ -525,7 +541,8 @@ public extension Channel {
   }
 
   /// Lets you get a read confirmation status for messages you published on a channel.
-  func streamReadReceipts() -> AsyncStream<ReadReceipt> {
+  @available(*, deprecated, message: "Use `stream.readReceipts()` instead")
+  func streamReadReceipts() -> AsyncStream<[Timetoken: [String]]> {
     AsyncStream { continuation in
       let autoCloseable = streamReadReceipts {
         continuation.yield($0)
@@ -606,6 +623,7 @@ public extension Channel {
   }
 
   /// Enables real-time tracking of users connecting to or disconnecting from a ``Channel``.
+  @available(*, deprecated, message: "Use `stream.presenceChanges()` instead")
   func streamPresence() -> AsyncStream<Set<String>> {
     AsyncStream { continuation in
       let autoCloseable = streamPresence {
@@ -667,6 +685,7 @@ public extension Channel {
   }
 
   /// As an admin of your chat app, monitor all events emitted when someone reports an offensive message.
+  @available(*, deprecated, message: "Use `stream.reports()` instead")
   func streamMessageReports() -> AsyncStream<EventWrapper<EventContent.Report>> {
     AsyncStream { continuation in
       let autoCloseable = streamMessageReports {

--- a/Sources/Entities/Channel+AsyncAwait.swift
+++ b/Sources/Entities/Channel+AsyncAwait.swift
@@ -72,16 +72,13 @@ public extension Channel {
     }
   }
 
-  /// Allows to delete  an existing ``Channel`` with or without deleting its historical data from the App Context storage.
-  ///
-  /// - Parameter soft: Decide if you want to permanently remove channel metadata
-  /// - Returns: For hard delete, the method returns `nil`. Otherwise, an updated ``Channel`` instance with the status field set to `"deleted"`
-  func delete(soft: Bool = false) async throws -> ChatType.ChatChannelType? {
-    try await withCheckedThrowingContinuation { continuation in
-      delete(soft: soft) {
+  /// Deletes an existing ``Channel`` and its historical data from the App Context storage.
+  func delete() async throws {
+    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+      delete {
         switch $0 {
-        case let .success(message):
-          continuation.resume(returning: message)
+        case .success:
+          continuation.resume()
         case let .failure(error):
           continuation.resume(throwing: error)
         }

--- a/Sources/Entities/Channel+AsyncAwait.swift
+++ b/Sources/Entities/Channel+AsyncAwait.swift
@@ -650,6 +650,32 @@ public extension Channel {
     }
   }
 
+  /// Returns the list of all invited members of the channel.
+  ///
+  /// - Parameters:
+  ///   - limit: Number of objects to return in response
+  ///   - page: Object used for pagination to define which previous or next result page you want to fetch
+  ///   - filter: Expression used to filter the results. Returns only these members whose properties satisfy the given expression
+  ///   - sort: A collection to specify the sort order
+  /// - Returns: A `Tuple` containing an array of the invitees of the channel, and the next pagination `PubNubHashedPage` (if one exists)
+  func getInvitees(
+    limit: Int? = nil,
+    page: PubNubHashedPage? = nil,
+    filter: String? = nil,
+    sort: [PubNub.MembershipSortField] = []
+  ) async throws -> (memberships: [ChatType.ChatMembershipType], page: PubNubHashedPage?) {
+    try await withCheckedThrowingContinuation { continuation in
+      getInvitees(limit: limit, page: page, filter: filter, sort: sort) {
+        switch $0 {
+        case let .success(getInviteesResult):
+          continuation.resume(returning: getInviteesResult)
+        case let .failure(error):
+          continuation.resume(throwing: error)
+        }
+      }
+    }
+  }
+
   /// Fetches all suggested users that match the provided 3-letter string from ``Channel``.
   ///
   /// - Parameters:

--- a/Sources/Entities/Channel+AsyncAwait.swift
+++ b/Sources/Entities/Channel+AsyncAwait.swift
@@ -53,7 +53,7 @@ public extension Channel {
     description: String? = nil,
     status: String? = nil,
     type: ChannelType? = nil
-  ) async throws -> ChatType.ChatChannelType {
+  ) async throws -> Self {
     try await withCheckedThrowingContinuation { continuation in
       update(
         name: name,
@@ -233,6 +233,7 @@ public extension Channel {
   ///   - usersToMention: A collection of user ids to automatically notify with a mention after this message is sent
   ///   - customPushData: Additional key-value pairs that will be added to the FCM and/or APNS push messages for the message itself and any user mentions
   /// - Returns: The timetoken of the sent message
+  @available(*, deprecated, message: "Use `sendText(text:params:)` instead")
   @discardableResult
   func sendText(
     text: String,
@@ -256,6 +257,32 @@ public extension Channel {
         files: files,
         usersToMention: usersToMention,
         customPushData: customPushData
+      ) {
+        switch $0 {
+        case let .success(timetoken):
+          continuation.resume(returning: timetoken)
+        case let .failure(error):
+          continuation.resume(throwing: error)
+        }
+      }
+    }
+  }
+
+  /// Sends text to the ``Channel``.
+  ///
+  /// - Parameters:
+  ///   - text: Text that you want to send to the selected channel
+  ///   - params: Additional parameters for sending text, encapsulated in a ``SendTextParams`` object
+  /// - Returns: The timetoken of the sent message
+  @discardableResult
+  func sendText(
+    text: String,
+    params: SendTextParams = SendTextParams()
+  ) async throws -> Timetoken {
+    try await withCheckedThrowingContinuation { continuation in
+      sendText(
+        text: text,
+        params: params
       ) {
         switch $0 {
         case let .success(timetoken):
@@ -423,7 +450,7 @@ public extension Channel {
   /// There can be only one pinned message on a channel at a time.
   ///
   /// - Returns: A pinned ``Message``
-  func getPinnedMessage() async throws -> ChatType.ChatMessageType? {
+  func getPinnedMessage() async throws -> MessageType? {
     try await withCheckedThrowingContinuation { continuation in
       getPinnedMessage {
         switch $0 {
@@ -440,7 +467,7 @@ public extension Channel {
   ///
   /// - Parameter timetoken: Timetoken of the message you want to retrieve from Message Persistence
   /// - Returns: A message object (if any)
-  func getMessage(timetoken: Timetoken) async throws -> ChatType.ChatMessageType? {
+  func getMessage(timetoken: Timetoken) async throws -> MessageType? {
     try await withCheckedThrowingContinuation { continuation in
       getMessage(timetoken: timetoken) {
         switch $0 {

--- a/Sources/Entities/Channel.swift
+++ b/Sources/Entities/Channel.swift
@@ -67,7 +67,7 @@ public protocol Channel: CustomStringConvertible {
     description: String?,
     status: String?,
     type: ChannelType?,
-    completion: ((Swift.Result<ChatType.ChatChannelType, Error>) -> Void)?
+    completion: ((Swift.Result<Self, Error>) -> Void)?
   )
 
   /// Allows to delete  an existing ``Channel`` with or without deleting its historical data from the App Context storage.
@@ -202,8 +202,7 @@ public protocol Channel: CustomStringConvertible {
   ///   - completion: The async `Result` of the method callnel
   ///     - **Success**: The timetoken of the sent message
   ///     - **Failure**: An `Error` describing the failure
-  @available(*, deprecated, message: "Use `sendText(text:meta:shouldStore:usePost:ttl:quotedMessage:files:usersToMention:customPushData:completion:)` instead")
-  // swiftlint:disable:previous line_length
+  @available(*, deprecated, message: "Use `sendText(text:params:completion:)` instead")
   func sendText(
     text: String,
     meta: [String: JSONCodable]?,
@@ -221,11 +220,6 @@ public protocol Channel: CustomStringConvertible {
 
   /// Sends text to the ``Channel``.
   ///
-  /// The following example describes how `mentionedUsers` and `referencedChannels` work.
-  /// For example, `{ 0: { id: 123, name: "Mark" }, 2: { id: 345, name: "Rob" } }` means that Mark will be shown on the first mention (@) in the message
-  /// and Rob on the third. The same rule applies for referenced channels. For example, `{ 0: { id: 123, name: "Support" }, 2: { id: 345, name: "Off-topic" } }`
-  /// means that Support will be shown on the first reference in the message and Off-topic on the third.
-  ///
   /// - Parameters:
   ///   - text: Text that you want to send to the selected channel
   ///   - meta: Publish additional details with the request
@@ -239,6 +233,7 @@ public protocol Channel: CustomStringConvertible {
   ///   - completion: The async `Result` of the method call
   ///     - **Success**: The timetoken of the sent message
   ///     - **Failure**: An `Error` describing the failure
+  @available(*, deprecated, message: "Use `sendText(text:params:completion:)` instead")
   func sendText(
     text: String,
     meta: [String: JSONCodable]?,
@@ -249,6 +244,20 @@ public protocol Channel: CustomStringConvertible {
     files: [InputFile]?,
     usersToMention: [String]?,
     customPushData: [String: String]?,
+    completion: ((Swift.Result<Timetoken, Error>) -> Void)?
+  )
+
+  /// Sends text to the ``Channel``.
+  ///
+  /// - Parameters:
+  ///   - text: Text that you want to send to the selected channel
+  ///   - params: Additional parameters for sending text, encapsulated in a ``SendTextParams`` object
+  ///   - completion: The async `Result` of the method call
+  ///     - **Success**: The timetoken of the sent message
+  ///     - **Failure**: An `Error` describing the failure
+  func sendText(
+    text: String,
+    params: SendTextParams,
     completion: ((Swift.Result<Timetoken, Error>) -> Void)?
   )
 
@@ -406,7 +415,7 @@ public protocol Channel: CustomStringConvertible {
   ///     - **Success**: A pinned ``Message``
   ///     - **Failure**: An `Error` describing the failure
   func getPinnedMessage(
-    completion: ((Swift.Result<(ChatType.ChatMessageType)?, Error>) -> Void)?
+    completion: ((Swift.Result<MessageType?, Error>) -> Void)?
   )
 
   /// Fetches the message from Message Persistence based on the message `timetoken`.
@@ -418,7 +427,7 @@ public protocol Channel: CustomStringConvertible {
   ///     - **Failure**: An `Error` describing the failure
   func getMessage(
     timetoken: Timetoken,
-    completion: ((Swift.Result<(ChatType.ChatMessageType)?, Error>) -> Void)?
+    completion: ((Swift.Result<MessageType?, Error>) -> Void)?
   )
 
   /// Register a device on the ``Channel`` to receive push notifications. Push options can be configured in ``ChatConfiguration``.

--- a/Sources/Entities/Channel.swift
+++ b/Sources/Entities/Channel.swift
@@ -273,7 +273,7 @@ public protocol Channel: CustomStringConvertible {
   ///   - limit: Number of objects to return in response
   ///   - page: Object used for pagination to define which previous or next result page you want to fetch
   ///   - filter: Expression used to filter the results. Returns only these members whose properties satisfy the given expression
-  ///   - sort: A collection to specify the sort order. Available options are id, name, and updated
+  ///   - sort: A collection to specify the sort order
   ///   - completion: The async `Result` of the method call
   ///     - **Success**: A `Tuple` containing an array of the members of the channel, and the next pagination `PubNubHashedPage` (if one exists)
   ///     - **Failure**: An `Error` describing the failure
@@ -283,6 +283,30 @@ public protocol Channel: CustomStringConvertible {
     filter: String?,
     sort: [PubNub.MembershipSortField],
     completion: ((Swift.Result<(memberships: [ChatType.ChatMembershipType], page: PubNubHashedPage?), Error>) -> Void)?
+  )
+
+  /// Checks if a specific user is a member of this channel.
+  ///
+  /// - Parameters:
+  ///   - userId: Unique identifier of the user to check
+  ///   - completion: The async `Result` of the method call
+  ///     - **Success**: A `Bool` value indicating whether the user is a member of this channel
+  ///     - **Failure**: An `Error` describing the failure
+  func hasMember(
+    userId: String,
+    completion: ((Swift.Result<Bool, Error>) -> Void)?
+  )
+
+  /// Retrieves the membership of a specific user in this channel.
+  ///
+  /// - Parameters:
+  ///   - userId: Unique identifier of the user whose membership to retrieve
+  ///   - completion: The async `Result` of the method call
+  ///     - **Success**: The user's ``Membership`` in this channel, or `nil` if not a member
+  ///     - **Failure**: An `Error` describing the failure
+  func getMember(
+    userId: String,
+    completion: ((Swift.Result<ChatType.ChatMembershipType?, Error>) -> Void)?
   )
 
   /// Watch the ``Channel`` content without a need to join the ``Channel``.
@@ -404,11 +428,29 @@ public protocol Channel: CustomStringConvertible {
   /// - Important: Keep a strong reference to the returned ``AutoCloseable`` object as long as you want to receive updates. If ``AutoCloseable`` is deallocated,
   /// the stream will be canceled, and no further items will be produced. You can also stop receiving updates manually by calling ``AutoCloseable/close()``.
   ///
-  /// - Parameter callback: Defines the custom behavior to be executed when receiving a read confirmation status on the joined channel.
+  /// - Parameter callback: Defines the custom behavior to be executed when receiving read receipts on the joined channel
   /// - Returns: AutoCloseable Interface you can call to stop listening for message read receipts and clean up resources by invoking the close() method
   func streamReadReceipts(
-    callback: @escaping (([Timetoken: [String]]) -> Void)
+    callback: @escaping ((ReadReceipt) -> Void)
   ) -> AutoCloseable
+
+  /// Fetches the read receipts for members of this channel.
+  ///
+  /// - Parameters:
+  ///   - limit: Number of objects to return in response
+  ///   - page: Object used for pagination to define which previous or next result page you want to fetch
+  ///   - filter: Expression used to filter the results. Returns only these members whose properties satisfy the given expression
+  ///   - sort: A collection to specify the sort order
+  ///   - completion: The async `Result` of the method call
+  ///     - **Success**: A `Tuple` containing an array of ``ReadReceipt``, and the next pagination `PubNubHashedPage` (if one exists)
+  ///     - **Failure**: An `Error` describing the failure
+  func fetchReadReceipts(
+    limit: Int?,
+    page: PubNubHashedPage?,
+    filter: String?,
+    sort: [PubNub.MembershipSortField],
+    completion: ((Swift.Result<(receipts: [ReadReceipt], page: PubNubHashedPage?), Error>) -> Void)?
+  )
 
   /// Returns all files attached to messages on a given channel.
   ///

--- a/Sources/Entities/Channel.swift
+++ b/Sources/Entities/Channel.swift
@@ -125,7 +125,16 @@ public protocol Channel: CustomStringConvertible {
   ///
   /// - Parameter callback: Callback function passed as a parameter. It defines the custom behavior to be executed whenever a user starts/stops typing
   /// - Returns: ``AutoCloseable`` you can call to disconnect (unsubscribe) from the channel and stop receiving signal events for someone typing by invoking the `close()` method
+  @available(*, deprecated, message: "Use `onTypingChanged(callback:)` instead")
   func getTyping(
+    callback: @escaping (([String]) -> Void)
+  ) -> AutoCloseable
+
+  /// Emits a list of user IDs whenever the typing status changes on this channel.
+  ///
+  /// - Parameter callback: A closure invoked with the list of user IDs currently typing
+  /// - Returns: An ``AutoCloseable`` that stops listening when closed
+  func onTypingChanged(
     callback: @escaping (([String]) -> Void)
   ) -> AutoCloseable
 
@@ -316,8 +325,19 @@ public protocol Channel: CustomStringConvertible {
   ///
   /// - Parameter callback: Defines the custom behavior to be executed whenever a message is received on the ``Channel``
   /// - Returns: ``AutoCloseable`` interface you can call to stop listening for new messages and clean up resources when they are no longer needed by invoking the `close()` method
+  @available(*, deprecated, message: "Use `onMessageReceived(callback:)` instead")
   func connect(
     callback: @escaping (ChatType.ChatMessageType) -> Void
+  ) -> AutoCloseable
+
+  /// Emits the received message whenever a new message is published on this channel.
+  ///
+  /// For a ``ThreadChannel``, this returns thread messages (``ChatType/ChatThreadMessageType``).
+  ///
+  /// - Parameter callback: A closure invoked with the received message
+  /// - Returns: An ``AutoCloseable`` that stops listening when closed
+  func onMessageReceived(
+    callback: @escaping (MessageType) -> Void
   ) -> AutoCloseable
 
   /// Connects a user to the ``Channel`` and sets membership - this way, the chat user can both watch the channel's ontent and be its full-fledged member.
@@ -419,8 +439,27 @@ public protocol Channel: CustomStringConvertible {
   ///
   /// - Parameter callback: A closure to be executed when detecting channel changes. Takes a single Channel object or `nil` if the channel was removed
   /// - Returns: ``AutoCloseable`` interface that lets you stop receiving channel-related updates (objects events) and clean up resources by invoking the `close()` method
+  @available(*, deprecated, message: "Use `onUpdated(callback:)` and `onDeleted(callback:)` instead")
   func streamUpdates(
     callback: @escaping ((ChatType.ChatChannelType)?) -> Void
+  ) -> AutoCloseable
+
+  /// Emits the updated channel entity whenever this channel's metadata is modified.
+  ///
+  /// For a ``ThreadChannel``, this returns the updated ``ThreadChannel`` (not the base ``Channel``).
+  ///
+  /// - Parameter callback: A closure invoked with the updated channel
+  /// - Returns: An ``AutoCloseable`` that stops listening when closed
+  func onUpdated(
+    callback: @escaping (Self) -> Void
+  ) -> AutoCloseable
+
+  /// Emits an event whenever this channel is permanently deleted.
+  ///
+  /// - Parameter callback: A closure invoked when the channel is deleted
+  /// - Returns: An ``AutoCloseable`` that stops listening when closed
+  func onDeleted(
+    callback: @escaping () -> Void
   ) -> AutoCloseable
 
   /// Lets you get a read confirmation status for messages you published on a channel.
@@ -430,9 +469,14 @@ public protocol Channel: CustomStringConvertible {
   ///
   /// - Parameter callback: Defines the custom behavior to be executed when receiving read receipts on the joined channel
   /// - Returns: AutoCloseable Interface you can call to stop listening for message read receipts and clean up resources by invoking the close() method
-  func streamReadReceipts(
-    callback: @escaping ((ReadReceipt) -> Void)
-  ) -> AutoCloseable
+  @available(*, deprecated, message: "Use `onReadReceiptReceived(callback:)` instead")
+  func streamReadReceipts(callback: @escaping (([Timetoken: [String]]) -> Void)) -> AutoCloseable
+
+  /// Emits a read receipt whenever a member reads a message on this channel.
+  ///
+  /// - Parameter callback: A closure invoked with the ``ReadReceipt`` containing the user ID and last read timetoken
+  /// - Returns: An ``AutoCloseable`` that stops listening when closed
+  func onReadReceiptReceived(callback: @escaping (ReadReceipt) -> Void) -> AutoCloseable
 
   /// Fetches the read receipts for members of this channel.
   ///
@@ -487,7 +531,16 @@ public protocol Channel: CustomStringConvertible {
   ///
   /// - Parameter callback: Defines the custom behavior to be executed when detecting user presence event
   /// - Returns: ``AutoCloseable`` interface that lets you stop receiving presence-related updates (presence events) by invoking the `close()` method
+  @available(*, deprecated, message: "Use `onPresenceChanged(callback:)` instead")
   func streamPresence(
+    callback: @escaping (Set<String>) -> Void
+  ) -> AutoCloseable
+
+  /// Emits the list of user IDs whenever the presence state changes on this channel.
+  ///
+  /// - Parameter callback: A closure invoked with the list of currently present user IDs
+  /// - Returns: An ``AutoCloseable`` that stops listening when closed
+  func onPresenceChanged(
     callback: @escaping (Set<String>) -> Void
   ) -> AutoCloseable
 
@@ -528,8 +581,17 @@ public protocol Channel: CustomStringConvertible {
   ///
   /// - Parameter callback: Callback function passed as a parameter. It defines the custom behavior to be executed when detecting new message report events
   /// - Returns: ``AutoCloseable`` interface that lets you stop receiving report-related updates (report events) by invoking the close() method
+  @available(*, deprecated, message: "Use `onMessageReported(callback:)` instead")
   func streamMessageReports(
     callback: @escaping (any Event<EventContent.Report>) -> Void
+  ) -> AutoCloseable
+
+  /// Emits a report whenever a message in this channel is reported by a user.
+  ///
+  /// - Parameter callback: A closure invoked with the ``Report`` containing details about the reported message
+  /// - Returns: An ``AutoCloseable`` that stops listening when closed
+  func onMessageReported(
+    callback: @escaping (Report) -> Void
   ) -> AutoCloseable
 
   /// Creates a ``MessageDraft`` for composing a message that will be sent to this ``Channel``

--- a/Sources/Entities/Channel.swift
+++ b/Sources/Entities/Channel.swift
@@ -340,18 +340,51 @@ public protocol Channel: CustomStringConvertible {
     callback: @escaping (MessageType) -> Void
   ) -> AutoCloseable
 
-  /// Connects a user to the ``Channel`` and sets membership - this way, the chat user can both watch the channel's ontent and be its full-fledged member.
+  /// Emits a custom event on this channel.
+  ///
+  /// - Parameters:
+  ///   - payload: Arbitrary key-value payload to publish
+  ///   - messageType: Optional custom message type used for filtering
+  ///   - storeInHistory: If true, event is stored in Message Persistence (if enabled)
+  ///   - completion: The async `Result` of the method call
+  ///     - **Success**: The timetoken of the emitted event
+  ///     - **Failure**: An `Error` describing the failure
+  func emitCustomEvent(
+    payload: [String: JSONCodable],
+    messageType: String?,
+    storeInHistory: Bool,
+    completion: ((Swift.Result<Timetoken, Error>) -> Void)?
+  )
+
+  /// Listens for custom events on this channel.
+  ///
+  /// - Important: Keep a strong reference to the returned ``AutoCloseable`` object as long as you want to receive updates. If ``AutoCloseable`` is deallocated,
+  /// the stream will be canceled, and no further items will be produced. You can also stop receiving updates manually by calling ``AutoCloseable/close()``.
+  ///
+  /// - Parameters:
+  ///   - messageType: Optional custom message type filter. If nil, all custom message types are accepted
+  ///   - callback: A closure invoked for each matching custom event
+  /// - Returns: An ``AutoCloseable`` that stops listening when closed
+  func onCustomEvent(
+    messageType: String?,
+    callback: @escaping (CustomEvent) -> Void
+  ) -> AutoCloseable
+
+  /// Sets the caller's membership on this channel.
   ///
   /// - Parameters:
   ///   - custom: Any custom properties or metadata associated with the channel-user membership in the form of key-value pairs
-  ///   - callback: Defines the custom behavior to be executed whenever a message is received on the [Channel]
+  ///   - status: Optional membership status value
+  ///   - type: Optional membership type value
   ///   - completion: The async `Result` of the method call
   ///     - **Success**: A `Tuple` containing the user's ``Membership`` in the channel, and ``AutoCloseable`` that  lets you stop listening to new channel messages while remaining a channel membership
   ///     - **Failure**: An `Error` describing the failure
+  /// - Returns: The caller's membership in the channel
   func join(
     custom: [String: JSONCodableScalar]?,
-    callback: ((ChatType.ChatMessageType) -> Void)?,
-    completion: ((Swift.Result<(membership: ChatType.ChatMembershipType, disconnect: AutoCloseable?), Error>) -> Void)?
+    status: String?,
+    type: String?,
+    completion: ((Swift.Result<ChatType.ChatMembershipType, Error>) -> Void)?
   )
 
   /// Remove user's channel membership.

--- a/Sources/Entities/Channel.swift
+++ b/Sources/Entities/Channel.swift
@@ -339,7 +339,7 @@ public protocol Channel: CustomStringConvertible {
 
   /// Emits the received message whenever a new message is published on this channel.
   ///
-  /// For a ``ThreadChannel``, this returns thread messages (``ChatType/ChatThreadMessageType``).
+  /// For a ``ThreadChannel``, this returns thread messages (``ThreadMessage``).
   ///
   /// - Parameter callback: A closure invoked with the received message
   /// - Returns: An ``AutoCloseable`` that stops listening when closed
@@ -386,7 +386,6 @@ public protocol Channel: CustomStringConvertible {
   ///   - completion: The async `Result` of the method call
   ///     - **Success**: A `Tuple` containing the user's ``Membership`` in the channel, and ``AutoCloseable`` that  lets you stop listening to new channel messages while remaining a channel membership
   ///     - **Failure**: An `Error` describing the failure
-  /// - Returns: The caller's membership in the channel
   func join(
     custom: [String: JSONCodableScalar]?,
     status: String?,
@@ -583,6 +582,24 @@ public protocol Channel: CustomStringConvertible {
   func onPresenceChanged(
     callback: @escaping (Set<String>) -> Void
   ) -> AutoCloseable
+
+  /// Returns the list of all invited members of the channel.
+  ///
+  /// - Parameters:
+  ///   - limit: Number of objects to return in response
+  ///   - page: Object used for pagination to define which previous or next result page you want to fetch
+  ///   - filter: Expression used to filter the results. Returns only these members whose properties satisfy the given expression
+  ///   - sort: A collection to specify the sort order
+  ///   - completion: The async `Result` of the method call
+  ///     - **Success**: A `Tuple` containing an array of the invitees of the channel, and the next pagination `PubNubHashedPage` (if one exists)
+  ///     - **Failure**: An `Error` describing the failure
+  func getInvitees(
+    limit: Int?,
+    page: PubNubHashedPage?,
+    filter: String?,
+    sort: [PubNub.MembershipSortField],
+    completion: ((Swift.Result<(memberships: [ChatType.ChatMembershipType], page: PubNubHashedPage?), Error>) -> Void)?
+  )
 
   /// Fetches all suggested users that match the provided 3-letter string from ``Channel``.
   ///

--- a/Sources/Entities/Channel.swift
+++ b/Sources/Entities/Channel.swift
@@ -70,16 +70,14 @@ public protocol Channel: CustomStringConvertible {
     completion: ((Swift.Result<Self, Error>) -> Void)?
   )
 
-  /// Allows to delete  an existing ``Channel`` with or without deleting its historical data from the App Context storage.
+  /// Deletes an existing ``Channel`` and its historical data from the App Context storage.
   ///
   /// - Parameters:
-  ///   - soft: Decide if you want to permanently remove channel metadata
   ///   - completion: The async `Result` of the method call
-  ///     - **Success**: For hard delete, the method returns `nil`. Otherwise, an updated ``Channel`` instance with the status field set to `"deleted"`
+  ///     - **Success**: A `Void` indicating a success
   ///     - **Failure**: An `Error` describing the failure
   func delete(
-    soft: Bool,
-    completion: ((Swift.Result<ChatType.ChatChannelType?, Error>) -> Void)?
+    completion: ((Swift.Result<Void, Error>) -> Void)?
   )
 
   /// Forwards a message to existing channel.

--- a/Sources/Entities/ChannelGroup+AsyncAwait.swift
+++ b/Sources/Entities/ChannelGroup+AsyncAwait.swift
@@ -15,6 +15,11 @@ import PubNubSDK
 /// Extension providing `async-await` support for ``ChannelGroup``.
 ///
 public extension ChannelGroup {
+  /// Namespace for `AsyncStream`-based streaming methods.
+  var stream: ChannelGroupStream<Self> {
+    ChannelGroupStream(channelGroup: self)
+  }
+
   /// Returns a paginated list of all existing channels in a given ``ChannelGroup``.
   ///
   /// - Parameters:
@@ -140,11 +145,10 @@ public extension ChannelGroup {
   }
 
   /// Enables real-time tracking of users connecting to or disconnecting from the given ``ChannelGroup``.
-  ///
-  /// - Returns: An asynchronous stream that produces a dictionary of channel identifiers and their present user identifiers
+  @available(*, deprecated, message: "Use `stream.presenceChanges()` instead")
   func streamPresence() -> AsyncStream<[String: [String]]> {
     AsyncStream { continuation in
-      let autoCloseable = streamPresence {
+      let autoCloseable = onPresenceChanged {
         continuation.yield($0)
       }
       continuation.onTermination = { _ in
@@ -154,11 +158,10 @@ public extension ChannelGroup {
   }
 
   /// Watch the ``ChannelGroup`` content.
-  ///
-  /// - Returns: An asynchronous stream that produces new messages from any channel in the group
+  @available(*, deprecated, message: "Use `stream.messages()` instead")
   func connect() -> AsyncStream<ChatType.ChatMessageType> {
     AsyncStream { continuation in
-      let autoCloseable = connect {
+      let autoCloseable = onMessageReceived {
         continuation.yield($0)
       }
       continuation.onTermination = { _ in

--- a/Sources/Entities/ChannelGroup.swift
+++ b/Sources/Entities/ChannelGroup.swift
@@ -98,11 +98,31 @@ public protocol ChannelGroup {
   ///
   /// - Parameter callback: A closure that will be called with a dictionary of channel identifiers and their present user identifiers
   /// - Returns: ``AutoCloseable`` interface you can call to stop listening for present users by invoking the ``AutoCloseable/close()`` method.
+  @available(*, deprecated, message: "Use `onPresenceChanged(callback:)` instead")
   func streamPresence(callback: @escaping ([String: [String]]) -> Void) -> AutoCloseable
+
+  /// Emits presence data whenever the presence state changes on any channel within this channel group.
+  ///
+  /// - Important: Keep a strong reference to the returned ``AutoCloseable`` object as long as you want to receive updates. If ``AutoCloseable`` is deallocated,
+  /// the stream will be canceled, and no further items will be produced. You can also stop receiving updates manually by calling ``AutoCloseable/close()``.
+  ///
+  /// - Parameter callback: A closure invoked with a dictionary of channel identifiers and their present user identifiers
+  /// - Returns: An ``AutoCloseable`` that stops listening when closed
+  func onPresenceChanged(callback: @escaping ([String: [String]]) -> Void) -> AutoCloseable
 
   /// Watch the ``ChannelGroup`` content.
   ///
   /// - Parameter callback: Custom behavior whenever a message is received
   /// - Returns: ``AutoCloseable`` interface you can call to stop listening for new messages by invoking the ``AutoCloseable/close()`` method.
+  @available(*, deprecated, message: "Use `onMessageReceived(callback:)` instead")
   func connect(callback: @escaping (ChatType.ChatMessageType) -> Void) -> AutoCloseable
+
+  /// Emits the received message whenever a new message is published on any channel within this channel group.
+  ///
+  /// - Important: Keep a strong reference to the returned ``AutoCloseable`` object as long as you want to receive updates. If ``AutoCloseable`` is deallocated,
+  /// the stream will be canceled, and no further items will be produced. You can also stop receiving updates manually by calling ``AutoCloseable/close()``.
+  ///
+  /// - Parameter callback: A closure invoked with the received message
+  /// - Returns: An ``AutoCloseable`` that stops listening when closed
+  func onMessageReceived(callback: @escaping (ChatType.ChatMessageType) -> Void) -> AutoCloseable
 }

--- a/Sources/Entities/ChannelGroupImpl.swift
+++ b/Sources/Entities/ChannelGroupImpl.swift
@@ -129,6 +129,10 @@ public class ChannelGroupImpl: ChannelGroup {
   }
 
   public func streamPresence(callback: @escaping ([String: [String]]) -> Void) -> AutoCloseable {
+    onPresenceChanged(callback: callback)
+  }
+
+  public func onPresenceChanged(callback: @escaping ([String: [String]]) -> Void) -> AutoCloseable {
     AutoCloseableImpl(
       channelGroup.streamPresence { [weak self] in
         if let userIds = $0 as? [String: [String]], self != nil {
@@ -140,6 +144,10 @@ public class ChannelGroupImpl: ChannelGroup {
   }
 
   public func connect(callback: @escaping (MessageImpl) -> Void) -> AutoCloseable {
+    onMessageReceived(callback: callback)
+  }
+
+  public func onMessageReceived(callback: @escaping (MessageImpl) -> Void) -> AutoCloseable {
     AutoCloseableImpl(
       channelGroup.connect { [weak self] in
         if let self = self {

--- a/Sources/Entities/ChannelGroupStream.swift
+++ b/Sources/Entities/ChannelGroupStream.swift
@@ -1,0 +1,48 @@
+//
+//  ChannelGroupStream.swift
+//
+//  Copyright (c) PubNub Inc.
+//  All rights reserved.
+//
+//  This source code is licensed under the license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+
+/// Namespace providing `AsyncStream`-based streaming methods for a ``ChannelGroup``.
+public struct ChannelGroupStream<C: ChannelGroup> {
+  let channelGroup: C
+
+  /// Emits the received message whenever a new message is published on any channel within this channel group.
+  ///
+  /// Async equivalent of ``ChannelGroup/onMessageReceived(callback:)``.
+  ///
+  /// - Returns: An `AsyncStream` of messages
+  public func messages() -> AsyncStream<C.ChatType.ChatMessageType> {
+    AsyncStream { continuation in
+      let autoCloseable = channelGroup.onMessageReceived {
+        continuation.yield($0)
+      }
+      continuation.onTermination = { _ in
+        autoCloseable.close()
+      }
+    }
+  }
+
+  /// Emits presence data whenever the presence state changes on any channel within this channel group.
+  ///
+  /// Async equivalent of ``ChannelGroup/onPresenceChanged(callback:)``.
+  ///
+  /// - Returns: An `AsyncStream` of dictionaries mapping channel identifiers to present user identifiers
+  public func presenceChanges() -> AsyncStream<[String: [String]]> {
+    AsyncStream { continuation in
+      let autoCloseable = channelGroup.onPresenceChanged {
+        continuation.yield($0)
+      }
+      continuation.onTermination = { _ in
+        autoCloseable.close()
+      }
+    }
+  }
+}

--- a/Sources/Entities/ChannelImpl.swift
+++ b/Sources/Entities/ChannelImpl.swift
@@ -354,7 +354,7 @@ extension ChannelImpl: Channel {
     )
   }
 
-  public func streamReadReceipts(callback: @escaping ((ReadReceipt) -> Void)) -> AutoCloseable {
+  public func streamReadReceipts(callback: @escaping (([Timetoken: [String]]) -> Void)) -> AutoCloseable {
     target.streamReadReceipts(
       callback: callback
     )
@@ -432,6 +432,48 @@ extension ChannelImpl: Channel {
     target.streamMessageReports(
       callback: callback
     )
+  }
+
+  public func onTypingChanged(callback: @escaping (([String]) -> Void)) -> AutoCloseable {
+    target.onTypingChanged(callback: callback)
+  }
+
+  public func onMessageReceived(callback: @escaping (MessageImpl) -> Void) -> AutoCloseable {
+    AutoCloseableImpl(
+      target.channel.onMessageReceived { [weak self] in
+        if let self = self, let message = $0 as? PubNubChat.Message {
+          callback(MessageImpl(message: message, chat: self.chat))
+        }
+      },
+      owner: self
+    )
+  }
+
+  public func onUpdated(callback: @escaping (ChannelImpl) -> Void) -> AutoCloseable {
+    AutoCloseableImpl(
+      target.channel.onUpdated { [weak self] in
+        if let self = self {
+          callback(ChannelImpl(channel: $0, chat: self.chat))
+        }
+      },
+      owner: self
+    )
+  }
+
+  public func onDeleted(callback: @escaping () -> Void) -> AutoCloseable {
+    target.onDeleted(callback: callback)
+  }
+
+  public func onReadReceiptReceived(callback: @escaping (ReadReceipt) -> Void) -> AutoCloseable {
+    target.onReadReceiptReceived(callback: callback)
+  }
+
+  public func onPresenceChanged(callback: @escaping (Set<String>) -> Void) -> AutoCloseable {
+    target.onPresenceChanged(callback: callback)
+  }
+
+  public func onMessageReported(callback: @escaping (Report) -> Void) -> AutoCloseable {
+    target.onMessageReported(callback: callback)
   }
 
   public func createMessageDraft(

--- a/Sources/Entities/ChannelImpl.swift
+++ b/Sources/Entities/ChannelImpl.swift
@@ -265,6 +265,20 @@ extension ChannelImpl: Channel {
     )
   }
 
+  public func hasMember(userId: String, completion: ((Swift.Result<Bool, Error>) -> Void)? = nil) {
+    target.hasMember(
+      userId: userId,
+      completion: completion
+    )
+  }
+
+  public func getMember(userId: String, completion: ((Swift.Result<MembershipImpl?, Error>) -> Void)? = nil) {
+    target.getMember(
+      userId: userId,
+      completion: completion
+    )
+  }
+
   public func connect(callback: @escaping (MessageImpl) -> Void) -> AutoCloseable {
     target.connect(callback: callback)
   }
@@ -340,9 +354,25 @@ extension ChannelImpl: Channel {
     )
   }
 
-  public func streamReadReceipts(callback: @escaping (([Timetoken: [String]]) -> Void)) -> AutoCloseable {
+  public func streamReadReceipts(callback: @escaping ((ReadReceipt) -> Void)) -> AutoCloseable {
     target.streamReadReceipts(
       callback: callback
+    )
+  }
+
+  public func fetchReadReceipts(
+    limit: Int? = nil,
+    page: PubNubHashedPage? = nil,
+    filter: String? = nil,
+    sort: [PubNub.MembershipSortField] = [],
+    completion: ((Swift.Result<(receipts: [ReadReceipt], page: PubNubHashedPage?), Error>) -> Void)? = nil
+  ) {
+    target.fetchReadReceipts(
+      limit: limit,
+      page: page,
+      filter: filter,
+      sort: sort,
+      completion: completion
     )
   }
 

--- a/Sources/Entities/ChannelImpl.swift
+++ b/Sources/Entities/ChannelImpl.swift
@@ -114,11 +114,9 @@ extension ChannelImpl: Channel {
   }
 
   public func delete(
-    soft: Bool = false,
-    completion: ((Swift.Result<ChannelImpl?, Error>) -> Void)? = nil
+    completion: ((Swift.Result<Void, Error>) -> Void)? = nil
   ) {
     target.delete(
-      soft: soft,
       completion: completion
     )
   }

--- a/Sources/Entities/ChannelImpl.swift
+++ b/Sources/Entities/ChannelImpl.swift
@@ -102,9 +102,15 @@ extension ChannelImpl: Channel {
       custom: custom,
       description: description,
       status: status,
-      type: type,
-      completion: completion
-    )
+      type: type
+    ) {
+      switch $0 {
+      case let .success(channel):
+        completion?(.success(ChannelImpl(channel: channel.channel, chat: channel.chat)))
+      case let .failure(error):
+        completion?(.failure(error))
+      }
+    }
   }
 
   public func delete(
@@ -235,6 +241,18 @@ extension ChannelImpl: Channel {
     )
   }
 
+  public func sendText(
+    text: String,
+    params: SendTextParams = SendTextParams(),
+    completion: ((Swift.Result<Timetoken, Error>) -> Void)? = nil
+  ) {
+    target.sendText(
+      text: text,
+      params: params,
+      completion: completion
+    )
+  }
+
   public func invite(user: UserImpl, completion: ((Swift.Result<MembershipImpl, Error>) -> Void)? = nil) {
     target.invite(
       user: user,
@@ -304,16 +322,25 @@ extension ChannelImpl: Channel {
   }
 
   public func getPinnedMessage(completion: ((Swift.Result<MessageImpl?, Error>) -> Void)? = nil) {
-    target.getPinnedMessage(
-      completion: completion
-    )
+    target.getPinnedMessage {
+      switch $0 {
+      case let .success(message):
+        completion?(.success(MessageImpl(message: message?.message, chat: message?.chat)))
+      case let .failure(error):
+        completion?(.failure(error))
+      }
+    }
   }
 
   public func getMessage(timetoken: Timetoken, completion: ((Swift.Result<MessageImpl?, Error>) -> Void)? = nil) {
-    target.getMessage(
-      timetoken: timetoken,
-      completion: completion
-    )
+    target.getMessage(timetoken: timetoken) {
+      switch $0 {
+      case let .success(message):
+        completion?(.success(MessageImpl(message: message?.message, chat: message?.chat)))
+      case let .failure(error):
+        completion?(.failure(error))
+      }
+    }
   }
 
   public func registerForPush(completion: ((Swift.Result<Void, Error>) -> Void)? = nil) {

--- a/Sources/Entities/ChannelImpl.swift
+++ b/Sources/Entities/ChannelImpl.swift
@@ -81,7 +81,7 @@ extension ChannelImpl: Channel {
       return AutoCloseableImpl.empty()
     }
     return AutoCloseableImpl(
-      PubNubChat.ThreadChannelCompanion.shared.streamUpdatesOn(channels: channels.map(\.target.channel)) { [chat = firstChat] in
+      PubNubChat.BaseChannelCompanion.shared.streamUpdatesOn(channels: channels.map(\.target.channel)) { [chat = firstChat] in
         callback(($0 as? [PubNubChat.Channel_] ?? []).map {
           ChannelImpl(channel: $0, chat: chat)
         })
@@ -285,12 +285,14 @@ extension ChannelImpl: Channel {
 
   public func join(
     custom: [String: JSONCodableScalar]? = nil,
-    callback: ((MessageImpl) -> Void)? = nil,
-    completion: ((Swift.Result<(membership: MembershipImpl, disconnect: AutoCloseable?), Error>) -> Void)? = nil
+    status: String? = nil,
+    type: String? = nil,
+    completion: ((Swift.Result<MembershipImpl, any Error>) -> Void)? = nil
   ) {
     target.join(
       custom: custom,
-      callback: callback,
+      status: status,
+      type: type,
       completion: completion
     )
   }
@@ -439,25 +441,19 @@ extension ChannelImpl: Channel {
   }
 
   public func onMessageReceived(callback: @escaping (MessageImpl) -> Void) -> AutoCloseable {
-    AutoCloseableImpl(
-      target.channel.onMessageReceived { [weak self] in
-        if let self = self, let message = $0 as? PubNubChat.Message {
-          callback(MessageImpl(message: message, chat: self.chat))
-        }
-      },
-      owner: self
-    )
+    target.onMessageReceived { [weak self] in
+      if let self = self {
+        callback(MessageImpl(message: $0.message, chat: self.chat))
+      }
+    }
   }
 
   public func onUpdated(callback: @escaping (ChannelImpl) -> Void) -> AutoCloseable {
-    AutoCloseableImpl(
-      target.channel.onUpdated { [weak self] in
-        if let self = self {
-          callback(ChannelImpl(channel: $0, chat: self.chat))
-        }
-      },
-      owner: self
-    )
+    target.onUpdated { [weak self] in
+      if let self = self {
+        callback(ChannelImpl(channel: $0.channel, chat: self.chat))
+      }
+    }
   }
 
   public func onDeleted(callback: @escaping () -> Void) -> AutoCloseable {
@@ -474,6 +470,30 @@ extension ChannelImpl: Channel {
 
   public func onMessageReported(callback: @escaping (Report) -> Void) -> AutoCloseable {
     target.onMessageReported(callback: callback)
+  }
+
+  public func emitCustomEvent(
+    payload: [String: JSONCodable],
+    messageType: String? = nil,
+    storeInHistory: Bool = true,
+    completion: ((Swift.Result<Timetoken, Error>) -> Void)? = nil
+  ) {
+    target.emitCustomEvent(
+      payload: payload,
+      messageType: messageType,
+      storeInHistory: storeInHistory,
+      completion: completion
+    )
+  }
+
+  public func onCustomEvent(
+    messageType: String? = nil,
+    callback: @escaping (CustomEvent) -> Void
+  ) -> AutoCloseable {
+    target.onCustomEvent(
+      messageType: messageType,
+      callback: callback
+    )
   }
 
   public func createMessageDraft(

--- a/Sources/Entities/ChannelImpl.swift
+++ b/Sources/Entities/ChannelImpl.swift
@@ -429,6 +429,22 @@ extension ChannelImpl: Channel {
     )
   }
 
+  public func getInvitees(
+    limit: Int? = nil,
+    page: PubNubHashedPage? = nil,
+    filter: String? = nil,
+    sort: [PubNub.MembershipSortField] = [],
+    completion: ((Swift.Result<(memberships: [MembershipImpl], page: PubNubHashedPage?), Error>) -> Void)? = nil
+  ) {
+    target.getInvitees(
+      limit: limit,
+      page: page,
+      filter: filter,
+      sort: sort,
+      completion: completion
+    )
+  }
+
   public func getUserSuggestions(
     text: String,
     limit: Int = 10,

--- a/Sources/Entities/ChannelStream.swift
+++ b/Sources/Entities/ChannelStream.swift
@@ -1,0 +1,129 @@
+//
+//  ChannelStream.swift
+//
+//  Copyright (c) PubNub Inc.
+//  All rights reserved.
+//
+//  This source code is licensed under the license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+
+/// Namespace providing `AsyncStream`-based streaming methods for a ``Channel``.
+public struct ChannelStream<C: Channel> {
+  let channel: C
+
+  /// Emits the list of user IDs whenever the typing status changes on this channel.
+  ///
+  /// Async equivalent of ``Channel/onTypingChanged(callback:)``.
+  ///
+  /// - Returns: An `AsyncStream` of user ID arrays
+  public func typingChanges() -> AsyncStream<[String]> {
+    AsyncStream { continuation in
+      let autoCloseable = channel.onTypingChanged {
+        continuation.yield($0)
+      }
+      continuation.onTermination = { _ in
+        autoCloseable.close()
+      }
+    }
+  }
+
+  /// Emits the received message whenever a new message is published on this channel.
+  ///
+  /// Async equivalent of ``Channel/onMessageReceived(callback:)``.
+  ///
+  /// - Returns: An `AsyncStream` of messages
+  public func messages() -> AsyncStream<C.MessageType> {
+    AsyncStream { continuation in
+      let autoCloseable = channel.onMessageReceived {
+        continuation.yield($0)
+      }
+      continuation.onTermination = { _ in
+        autoCloseable.close()
+      }
+    }
+  }
+
+  /// Emits the updated channel entity whenever this channel's metadata is modified.
+  ///
+  /// Async equivalent of ``Channel/onUpdated(callback:)``.
+  ///
+  /// - Returns: An `AsyncStream` of updated channels
+  public func updates() -> AsyncStream<C> {
+    AsyncStream { continuation in
+      let autoCloseable = channel.onUpdated {
+        continuation.yield($0)
+      }
+      continuation.onTermination = { _ in
+        autoCloseable.close()
+      }
+    }
+  }
+
+  /// Emits an event whenever this channel is permanently deleted.
+  ///
+  /// Async equivalent of ``Channel/onDeleted(callback:)``.
+  ///
+  /// - Returns: An `AsyncStream` that yields `Void` on deletion
+  public func deletions() -> AsyncStream<Void> {
+    AsyncStream { continuation in
+      let autoCloseable = channel.onDeleted {
+        continuation.yield(())
+        continuation.finish()
+      }
+      continuation.onTermination = { _ in
+        autoCloseable.close()
+      }
+    }
+  }
+
+  /// Emits the set of user IDs whenever the presence state changes on this channel.
+  ///
+  /// Async equivalent of ``Channel/onPresenceChanged(callback:)``.
+  ///
+  /// - Returns: An `AsyncStream` of presence user ID sets
+  public func presenceChanges() -> AsyncStream<Set<String>> {
+    AsyncStream { continuation in
+      let autoCloseable = channel.onPresenceChanged {
+        continuation.yield($0)
+      }
+      continuation.onTermination = { _ in
+        autoCloseable.close()
+      }
+    }
+  }
+
+  /// Emits a read receipt whenever a member reads a message on this channel.
+  ///
+  /// Async equivalent of ``Channel/onReadReceiptReceived(callback:)``.
+  ///
+  /// - Returns: An `AsyncStream` of ``ReadReceipt`` values
+  public func readReceipts() -> AsyncStream<ReadReceipt> {
+    AsyncStream { continuation in
+      let autoCloseable = channel.onReadReceiptReceived {
+        continuation.yield($0)
+      }
+      continuation.onTermination = { _ in
+        autoCloseable.close()
+      }
+    }
+  }
+
+  /// Emits a report whenever a message in this channel is reported by a user.
+  ///
+  /// Async equivalent of ``Channel/onMessageReported(callback:)``.
+  ///
+  /// - Returns: An `AsyncStream` of ``Report`` values
+  public func reports() -> AsyncStream<Report> {
+    AsyncStream { continuation in
+      let autoCloseable = channel.onMessageReported {
+        continuation.yield($0)
+      }
+      continuation.onTermination = { _ in
+        autoCloseable.close()
+      }
+    }
+  }
+}

--- a/Sources/Entities/ChannelStream.swift
+++ b/Sources/Entities/ChannelStream.swift
@@ -111,6 +111,23 @@ public struct ChannelStream<C: Channel> {
     }
   }
 
+  /// Emits custom events published on this channel.
+  ///
+  /// Async equivalent of ``Channel/onCustomEvent(messageType:callback:)``.
+  ///
+  /// - Parameter messageType: Optional custom message type filter
+  /// - Returns: An `AsyncStream` of ``CustomEvent`` values
+  public func customEvents(messageType: String? = nil) -> AsyncStream<CustomEvent> {
+    AsyncStream { continuation in
+      let autoCloseable = channel.onCustomEvent(messageType: messageType) {
+        continuation.yield($0)
+      }
+      continuation.onTermination = { _ in
+        autoCloseable.close()
+      }
+    }
+  }
+
   /// Emits a report whenever a message in this channel is reported by a user.
   ///
   /// Async equivalent of ``Channel/onMessageReported(callback:)``.

--- a/Sources/Entities/Membership+AsyncAwait.swift
+++ b/Sources/Entities/Membership+AsyncAwait.swift
@@ -109,6 +109,20 @@ public extension Membership {
     }
   }
 
+  /// Deletes the membership.
+  func delete() async throws {
+    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+      delete {
+        switch $0 {
+        case .success:
+          continuation.resume()
+        case let .failure(error):
+          continuation.resume(throwing: error)
+        }
+      }
+    }
+  }
+
   /// You can receive updates when this user-channel Membership object is updated or removed.
   ///
   /// - Returns: An asynchronous stream that produces updates when the current ``Membership`` is updated or `nil` if the membership was removed.

--- a/Sources/Entities/Membership+AsyncAwait.swift
+++ b/Sources/Entities/Membership+AsyncAwait.swift
@@ -15,6 +15,12 @@ import PubNubSDK
 /// Extension providing `async-await` support for ``Membership``.
 ///
 public extension Membership {
+
+  /// Namespace for `AsyncStream`-based streaming methods
+  var stream: MembershipStream<Self> {
+    MembershipStream(membership: self)
+  }
+
   /// Receive updates when specific memberships are updated or removed.
   ///
   /// Emits the complete list of monitored memberships whenever any one of them changes, excluding any that were removed.
@@ -106,6 +112,7 @@ public extension Membership {
   /// You can receive updates when this user-channel Membership object is updated or removed.
   ///
   /// - Returns: An asynchronous stream that produces updates when the current ``Membership`` is updated or `nil` if the membership was removed.
+  @available(*, deprecated, message: "Use `stream.updates()` and `stream.deletions()` instead")
   func streamUpdates() -> AsyncStream<ChatType.ChatMembershipType?> {
     AsyncStream { continuation in
       let autoCloseable = streamUpdates {

--- a/Sources/Entities/Membership+AsyncAwait.swift
+++ b/Sources/Entities/Membership+AsyncAwait.swift
@@ -34,6 +34,8 @@ public extension Membership {
 
   /// Setting the last read message for users lets you implement the Read Receipts feature and monitor which channel member read which message.
   ///
+  /// This method emits a read receipt event on the channel, unless ``ChatConfiguration/emitReadReceiptEvents`` is set to `false` for the channel's type.
+  ///
   /// - Parameter message: Last read message on a given channel with the timestamp that gets added to the user-channel membership as the `lastReadMessageTimetoken` property
   /// - Returns: An updated ``Membership`` object
   func setLastReadMessage(message: ChatType.ChatMessageType) async throws -> ChatType.ChatMembershipType {
@@ -67,6 +69,8 @@ public extension Membership {
   }
 
   /// Setting the last read message timetoken for users lets you implement the Read Receipts feature and monitor which channel member read which message.
+  ///
+  /// This method emits a read receipt event on the channel, unless ``ChatConfiguration/emitReadReceiptEvents`` is set to `false` for the channel's type.
   ///
   /// - Parameter timetoken: Timetoken of the last read message on a given channel that gets added to the user-channel membership as the `lastReadMessageTimetoken` property
   /// - Returns: An updated ``Membership`` object

--- a/Sources/Entities/Membership+AsyncAwait.swift
+++ b/Sources/Entities/Membership+AsyncAwait.swift
@@ -59,11 +59,18 @@ public extension Membership {
 
   /// Updates the channel membership information for a given user.
   ///
-  /// - Parameter custom: Any custom properties or metadata associated with the channel-user membership in a form of key-value pairs
+  /// - Parameters:
+  ///   - custom: Any custom properties or metadata associated with the channel-user membership in a form of key-value pairs
+  ///   - status: Optional membership status value
+  ///   - type: Optional membership type value
   /// - Returns: An updated ``Membership`` object
-  func update(custom: [String: JSONCodableScalar]) async throws -> ChatType.ChatMembershipType {
+  func update(
+    custom: [String: JSONCodableScalar],
+    status: String? = nil,
+    type: String? = nil
+  ) async throws -> ChatType.ChatMembershipType {
     try await withCheckedThrowingContinuation { continuation in
-      update(custom: custom) {
+      update(custom: custom, status: status, type: type) {
         switch $0 {
         case let .success(membership):
           continuation.resume(returning: membership)

--- a/Sources/Entities/Membership.swift
+++ b/Sources/Entities/Membership.swift
@@ -107,8 +107,25 @@ public protocol Membership: CustomStringConvertible {
   ///
   /// - Parameter callback: A closure to be executed when detecting membership changes. Takes a Membership object or `nil` if the membership was removed
   /// - Returns: An ``AutoCloseable`` that you can use to stop receiving objects events by invoking its ``AutoCloseable/close()`` method
+  @available(*, deprecated, message: "Use `onUpdated(callback:)` and `onDeleted(callback:)` instead")
   func streamUpdates(
     callback: @escaping ((ChatType.ChatMembershipType?) -> Void)
+  ) -> AutoCloseable
+
+  /// Emits the updated membership entity whenever this membership's metadata is modified.
+  ///
+  /// - Parameter callback: A closure invoked with the updated ``Membership`` entity
+  /// - Returns: An ``AutoCloseable`` that stops listening when closed
+  func onUpdated(
+    callback: @escaping (ChatType.ChatMembershipType) -> Void
+  ) -> AutoCloseable
+
+  /// Emits an event whenever this membership is removed.
+  ///
+  /// - Parameter callback: A closure invoked when the membership is deleted
+  /// - Returns: An ``AutoCloseable`` that stops listening when closed
+  func onDeleted(
+    callback: @escaping () -> Void
   ) -> AutoCloseable
 }
 

--- a/Sources/Entities/Membership.swift
+++ b/Sources/Entities/Membership.swift
@@ -52,6 +52,8 @@ public protocol Membership: CustomStringConvertible {
 
   /// Setting the last read message for users lets you implement the Read Receipts feature and monitor which channel member read which message.
   ///
+  /// This method emits a read receipt event on the channel, unless ``ChatConfiguration/emitReadReceiptEvents`` is set to `false` for the channel's type.
+  ///
   /// - Parameters:
   ///   - message: Last read message on a given channel with the timestamp that gets added to the user-channel membership as the `lastReadMessageTimetoken` property
   ///   - completion: The async `Result` of the method call
@@ -75,6 +77,8 @@ public protocol Membership: CustomStringConvertible {
   )
 
   /// Setting the last read message timetoken for users lets you implement the Read Receipts feature and monitor which channel member read which message.
+  ///
+  /// This method emits a read receipt event on the channel, unless ``ChatConfiguration/emitReadReceiptEvents`` is set to `false` for the channel's type.
   ///
   /// - Parameters:
   ///   - timetoken: Timetoken of the last read message on a given channel that gets added to the user-channel membership as the `lastReadMessageTimetoken` property

--- a/Sources/Entities/Membership.swift
+++ b/Sources/Entities/Membership.swift
@@ -100,6 +100,16 @@ public protocol Membership: CustomStringConvertible {
     completion: ((Swift.Result<UInt64?, Error>) -> Void)?
   )
 
+  /// Deletes the membership.
+  ///
+  /// - Parameters:
+  ///   - completion: The async `Result` of the method call
+  ///     - **Success**: A `Void` indicating a success
+  ///     - **Failure**: An `Error` describing the failure
+  func delete(
+    completion: ((Swift.Result<Void, Error>) -> Void)?
+  )
+
   /// You can receive updates when this user-channel Membership object is updated or removed.
   ///
   /// - Important: Keep a strong reference to the returned ``AutoCloseable`` object as long as you want to receive updates. If ``AutoCloseable`` is deallocated,

--- a/Sources/Entities/Membership.swift
+++ b/Sources/Entities/Membership.swift
@@ -68,11 +68,15 @@ public protocol Membership: CustomStringConvertible {
   ///
   /// - Parameters:
   ///   - custom: Any custom properties or metadata associated with the channel-user membership in a form of key-value pairs
+  ///   - status: Optional membership status value
+  ///   - type: Optional membership type value
   ///   - completion: The async `Result` of the method call
   ///     - **Success**: An updated ``Membership`` object
   ///     - **Failure**: An `Error` describing the failure
   func update(
     custom: [String: JSONCodableScalar],
+    status: String?,
+    type: String?,
     completion: ((Swift.Result<ChatType.ChatMembershipType, Error>) -> Void)?
   )
 

--- a/Sources/Entities/MembershipImpl.swift
+++ b/Sources/Entities/MembershipImpl.swift
@@ -140,6 +140,28 @@ extension MembershipImpl: Membership {
     }
   }
 
+  public func onUpdated(callback: @escaping (MembershipImpl) -> Void) -> AutoCloseable {
+    AutoCloseableImpl(
+      membership.onUpdated { [weak self] in
+        if let self = self {
+          callback(MembershipImpl(membership: $0, chat: self.chat))
+        }
+      },
+      owner: self
+    )
+  }
+
+  public func onDeleted(callback: @escaping () -> Void) -> AutoCloseable {
+    AutoCloseableImpl(
+      membership.onDeleted { [weak self] in
+        if self != nil {
+          callback()
+        }
+      },
+      owner: self
+    )
+  }
+
   public func streamUpdates(callback: @escaping ((MembershipImpl?) -> Void)) -> AutoCloseable {
     AutoCloseableImpl(
       membership.streamUpdates { [weak self] in

--- a/Sources/Entities/MembershipImpl.swift
+++ b/Sources/Entities/MembershipImpl.swift
@@ -106,14 +106,74 @@ extension MembershipImpl: Membership {
     type: String? = nil,
     completion: ((Swift.Result<MembershipImpl, Error>) -> Void)? = nil
   ) {
-    membership.update(
-      status: status,
-      type: type,
-      custom: custom
-    ).async(caller: self) { (result: FutureResult<MembershipImpl, PubNubChat.Membership>) in
-      switch result.result {
-      case let .success(membership):
-        completion?(.success(MembershipImpl(membership: membership, chat: result.caller.chat)))
+    // We don't forward to KMP due to crash
+    let userId = user.id
+    let channelId = channel.id
+    let filter = "channel.id == '\(channelId)'"
+
+    chat.pubNub.fetchMemberships(
+      userId: userId,
+      filter: filter
+    ) { [weak self] result in
+      guard let self else { return }
+      switch result {
+      case let .success(response):
+        if response.memberships.isEmpty {
+          completion?(.failure(ChatError(message: "No such membership exists")))
+          return
+        }
+        let mergedCustom: [String: JSONCodableScalar] = {
+          if custom["lastReadMessageTimetoken"] == nil, let existingTimetoken = self.custom?["lastReadMessageTimetoken"] {
+            var result = custom
+            result["lastReadMessageTimetoken"] = existingTimetoken
+            return result
+          }
+          return custom
+        }()
+        let membershipMetadata = PubNubMembershipMetadataBase(
+          userMetadataId: userId,
+          channelMetadataId: channelId,
+          status: status,
+          type: type,
+          custom: mergedCustom
+        )
+        self.chat.pubNub.setMemberships(
+          userId: userId,
+          channels: [membershipMetadata],
+          include: PubNub.MembershipInclude(
+            customFields: true,
+            channelFields: true,
+            statusField: true,
+            typeField: true,
+            channelCustomFields: true,
+            channelTypeField: true,
+            channelStatusField: true,
+            totalCount: true
+          ),
+          filter: filter
+        ) { [weak self] result in
+          guard let self else { return }
+          switch result {
+          case let .success(response):
+            guard let first = response.memberships.first else {
+              completion?(.failure(ChatError(message: "Unexpected empty response from setMemberships")))
+              return
+            }
+            let updatedMembership = MembershipImpl(
+              chat: self.chat,
+              channel: self.channel,
+              user: self.user,
+              custom: first.custom,
+              updated: first.updated.map { DateFormatter.iso8601.string(from: $0) },
+              eTag: first.eTag,
+              status: first.status,
+              type: first.type
+            )
+            completion?(.success(updatedMembership))
+          case let .failure(error):
+            completion?(.failure(error))
+          }
+        }
       case let .failure(error):
         completion?(.failure(error))
       }

--- a/Sources/Entities/MembershipImpl.swift
+++ b/Sources/Entities/MembershipImpl.swift
@@ -140,6 +140,17 @@ extension MembershipImpl: Membership {
     }
   }
 
+  public func delete(completion: ((Swift.Result<Void, Error>) -> Void)? = nil) {
+    membership.delete().async(caller: self) { (result: FutureResult<MembershipImpl, PubNubChat.KotlinUnit>) in
+      switch result.result {
+      case .success:
+        completion?(.success(()))
+      case let .failure(error):
+        completion?(.failure(error))
+      }
+    }
+  }
+
   public func onUpdated(callback: @escaping (MembershipImpl) -> Void) -> AutoCloseable {
     AutoCloseableImpl(
       membership.onUpdated { [weak self] in

--- a/Sources/Entities/MembershipImpl.swift
+++ b/Sources/Entities/MembershipImpl.swift
@@ -102,9 +102,13 @@ extension MembershipImpl: Membership {
 
   public func update(
     custom: [String: JSONCodableScalar],
+    status: String? = nil,
+    type: String? = nil,
     completion: ((Swift.Result<MembershipImpl, Error>) -> Void)? = nil
   ) {
     membership.update(
+      status: status,
+      type: type,
       custom: custom
     ).async(caller: self) { (result: FutureResult<MembershipImpl, PubNubChat.Membership>) in
       switch result.result {

--- a/Sources/Entities/MembershipStream.swift
+++ b/Sources/Entities/MembershipStream.swift
@@ -1,0 +1,49 @@
+//
+//  MembershipStream.swift
+//
+//  Copyright (c) PubNub Inc.
+//  All rights reserved.
+//
+//  This source code is licensed under the license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+
+/// Namespace providing `AsyncStream`-based streaming methods for a ``Membership``.
+public struct MembershipStream<M: Membership> {
+  let membership: M
+
+  /// Emits the updated membership entity whenever this membership's metadata is modified.
+  ///
+  /// Async equivalent of ``Membership/onUpdated(callback:)``.
+  ///
+  /// - Returns: An `AsyncStream` of updated memberships
+  public func updates() -> AsyncStream<M.ChatType.ChatMembershipType> {
+    AsyncStream { continuation in
+      let autoCloseable = membership.onUpdated {
+        continuation.yield($0)
+      }
+      continuation.onTermination = { _ in
+        autoCloseable.close()
+      }
+    }
+  }
+
+  /// Emits an event whenever this membership is removed.
+  ///
+  /// Async equivalent of ``Membership/onDeleted(callback:)``.
+  ///
+  /// - Returns: An `AsyncStream` that yields `Void` on deletion
+  public func deletions() -> AsyncStream<Void> {
+    AsyncStream { continuation in
+      let autoCloseable = membership.onDeleted {
+        continuation.yield(())
+        continuation.finish()
+      }
+      continuation.onTermination = { _ in
+        autoCloseable.close()
+      }
+    }
+  }
+}

--- a/Sources/Entities/Message+AsyncAwait.swift
+++ b/Sources/Entities/Message+AsyncAwait.swift
@@ -42,7 +42,7 @@ public extension Message {
   ///
   /// - Parameter newText: New/updated text that you want to add in place of the existing message
   /// - Returns: An updated ``Message`` object
-  func editText(newText: String) async throws -> ChatType.ChatMessageType {
+  func editText(newText: String) async throws -> Self {
     try await withCheckedThrowingContinuation { continuation in
       editText(newText: newText) {
         switch $0 {
@@ -150,8 +150,7 @@ public extension Message {
   /// Create a thread (channel) for a selected message.
   ///
   /// - Returns: A ``ThreadChannel`` object which can be used for sending and reading messages from the newly created message thread
-  @available(*, deprecated, message: "Use `createThread(text:meta:shouldStore:usePost:ttl:quotedMessage:files:usersToMention:customPushData:)` instead")
-  // swiftlint:disable:previous line_length
+  @available(*, deprecated, message: "Use `createThreadWithResult(text:params:)` instead")
   func createThread() async throws -> ChatType.ChatThreadChannelType {
     try await withCheckedThrowingContinuation { continuation in
       createThread {
@@ -178,6 +177,7 @@ public extension Message {
   ///   - usersToMention: A collection of user ids to automatically notify with a mention after this message is sent
   ///   - customPushData: Additional key-value pairs that will be added to the FCM and/or APNS push messages for the message itself and any user mentions
   /// - Returns: A ``ThreadChannel`` object which can be used for sending and reading messages from the newly created message thread
+  @available(*, deprecated, message: "Use `createThreadWithResult(text:params:)` instead")
   func createThread(
     text: String,
     meta: [String: JSONCodable]? = nil,
@@ -204,6 +204,31 @@ public extension Message {
         switch $0 {
         case let .success(thread):
           continuation.resume(returning: thread)
+        case let .failure(error):
+          continuation.resume(throwing: error)
+        }
+      }
+    }
+  }
+
+  /// Create a thread by sending the first reply and return both the thread channel and updated parent message.
+  ///
+  /// - Parameters:
+  ///   - text: Text of the first reply to send in the thread
+  ///   - params: Additional parameters for sending text, encapsulated in a ``SendTextParams`` object
+  /// - Returns: A ``CreateThreadResult`` containing the thread channel and updated parent message
+  func createThreadWithResult(
+    text: String,
+    params: SendTextParams = SendTextParams()
+  ) async throws -> CreateThreadResult<ChatType.ChatThreadChannelType, ChatType.ChatMessageType> {
+    try await withCheckedThrowingContinuation { continuation in
+      createThreadWithResult(
+        text: text,
+        params: params
+      ) {
+        switch $0 {
+        case let .success(result):
+          continuation.resume(returning: result)
         case let .failure(error):
           continuation.resume(throwing: error)
         }

--- a/Sources/Entities/Message+AsyncAwait.swift
+++ b/Sources/Entities/Message+AsyncAwait.swift
@@ -15,6 +15,12 @@ import PubNubSDK
 /// Extension providing `async-await` support for ``Message``.
 ///
 public extension Message {
+
+  /// Namespace for `AsyncStream`-based streaming methods
+  var stream: MessageStream<Self> {
+    MessageStream(message: self)
+  }
+
   /// Receive updates when specific messages and related message reactions are updated or removed.
   ///
   /// Emits the complete list of monitored messages whenever any one of them changes, excluding any that were removed.
@@ -244,6 +250,7 @@ public extension Message {
   /// You can receive updates when this message and related message reactions are added, edited, or removed.
   ///
   /// - Returns: An asynchronous stream that produces updates when the current ``Message`` is edited.
+  @available(*, deprecated, message: "Use `stream.updates()` instead")
   func streamUpdates() -> AsyncStream<Self> {
     AsyncStream { continuation in
       let autoCloseable = streamUpdates {

--- a/Sources/Entities/Message+AsyncAwait.swift
+++ b/Sources/Entities/Message+AsyncAwait.swift
@@ -237,9 +237,7 @@ public extension Message {
   }
 
   /// Removes a thread (channel) for a selected message.
-  ///
-  /// - Returns: The updated ``Channel`` object after the removal of the thread
-  func removeThread() async throws -> ChatType.ChatChannelType? {
+  func removeThread() async throws {
     try await withCheckedThrowingContinuation { continuation in
       removeThread {
         switch $0 {

--- a/Sources/Entities/Message+AsyncAwait.swift
+++ b/Sources/Entities/Message+AsyncAwait.swift
@@ -150,7 +150,7 @@ public extension Message {
   /// Create a thread (channel) for a selected message.
   ///
   /// - Returns: A ``ThreadChannel`` object which can be used for sending and reading messages from the newly created message thread
-  @available(*, deprecated, message: "Use `createThreadWithResult(text:params:)` instead")
+  @available(*, deprecated, message: "Use `createThread(text:params:)` instead")
   func createThread() async throws -> ChatType.ChatThreadChannelType {
     try await withCheckedThrowingContinuation { continuation in
       createThread {
@@ -177,7 +177,7 @@ public extension Message {
   ///   - usersToMention: A collection of user ids to automatically notify with a mention after this message is sent
   ///   - customPushData: Additional key-value pairs that will be added to the FCM and/or APNS push messages for the message itself and any user mentions
   /// - Returns: A ``ThreadChannel`` object which can be used for sending and reading messages from the newly created message thread
-  @available(*, deprecated, message: "Use `createThreadWithResult(text:params:)` instead")
+  @available(*, deprecated, message: "Use `createThread(text:params:)` instead")
   func createThread(
     text: String,
     meta: [String: JSONCodable]? = nil,
@@ -217,12 +217,12 @@ public extension Message {
   ///   - text: Text of the first reply to send in the thread
   ///   - params: Additional parameters for sending text, encapsulated in a ``SendTextParams`` object
   /// - Returns: A ``CreateThreadResult`` containing the thread channel and updated parent message
-  func createThreadWithResult(
+  func createThread(
     text: String,
     params: SendTextParams = SendTextParams()
   ) async throws -> CreateThreadResult<ChatType.ChatThreadChannelType, ChatType.ChatMessageType> {
     try await withCheckedThrowingContinuation { continuation in
-      createThreadWithResult(
+      createThread(
         text: text,
         params: params
       ) {

--- a/Sources/Entities/Message.swift
+++ b/Sources/Entities/Message.swift
@@ -95,7 +95,7 @@ public protocol Message: CustomStringConvertible {
   ///     - **Failure**: An `Error` describing the failure
   func editText(
     newText: String,
-    completion: ((Swift.Result<ChatType.ChatMessageType, Error>) -> Void)?
+    completion: ((Swift.Result<Self, Error>) -> Void)?
   )
 
   /// Either permanently removes a historical message from Message Persistence or marks it as deleted (if you remove the message with the soft option).
@@ -162,8 +162,7 @@ public protocol Message: CustomStringConvertible {
   ///   - completion: The async `Result` of the method call
   ///     - **Success**:  Returns a ``ThreadChannel`` object which can be used for sending and reading messages from the newly created message thread
   ///     - **Failure**: An `Error` describing the failure
-  @available(*, deprecated, message: "Use `createThread(text:meta:shouldStore:usePost:ttl:quotedMessage:files:usersToMention:customPushData:completion:)` instead")
-  // swiftlint:disable:previous line_length
+  @available(*, deprecated, message: "Use `createThreadWithResult(text:params:completion:)` instead")
   func createThread(
     completion: ((Swift.Result<ChatType.ChatThreadChannelType, Error>) -> Void)?
   )
@@ -183,6 +182,7 @@ public protocol Message: CustomStringConvertible {
   ///   - completion: The async `Result` of the method call
   ///     - **Success**:  Returns a ``ThreadChannel`` object which can be used for sending and reading messages from the newly created message thread
   ///     - **Failure**: An `Error` describing the failure
+  @available(*, deprecated, message: "Use `createThreadWithResult(text:params:completion:)` instead")
   func createThread(
     text: String,
     meta: [String: JSONCodable]?,
@@ -194,6 +194,20 @@ public protocol Message: CustomStringConvertible {
     usersToMention: [String]?,
     customPushData: [String: String]?,
     completion: ((Swift.Result<ChatType.ChatThreadChannelType, Error>) -> Void)?
+  )
+
+  /// Create a thread by sending the first reply and return both the thread channel and updated parent message.
+  ///
+  /// - Parameters:
+  ///   - text: Text of the first reply to send in the thread
+  ///   - params: Additional parameters for sending text, encapsulated in a ``SendTextParams`` object
+  ///   - completion: The async `Result` of the method call
+  ///     - **Success**: A ``CreateThreadResult`` containing the thread channel and updated parent message
+  ///     - **Failure**: An `Error` describing the failure
+  func createThreadWithResult(
+    text: String,
+    params: SendTextParams,
+    completion: ((Swift.Result<CreateThreadResult<ChatType.ChatThreadChannelType, ChatType.ChatMessageType>, Error>) -> Void)?
   )
 
   /// Removes a thread (channel) for a selected message.

--- a/Sources/Entities/Message.swift
+++ b/Sources/Entities/Message.swift
@@ -162,7 +162,7 @@ public protocol Message: CustomStringConvertible {
   ///   - completion: The async `Result` of the method call
   ///     - **Success**:  Returns a ``ThreadChannel`` object which can be used for sending and reading messages from the newly created message thread
   ///     - **Failure**: An `Error` describing the failure
-  @available(*, deprecated, message: "Use `createThreadWithResult(text:params:completion:)` instead")
+  @available(*, deprecated, message: "Use `createThread(text:params:completion:)` instead")
   func createThread(
     completion: ((Swift.Result<ChatType.ChatThreadChannelType, Error>) -> Void)?
   )
@@ -182,7 +182,7 @@ public protocol Message: CustomStringConvertible {
   ///   - completion: The async `Result` of the method call
   ///     - **Success**:  Returns a ``ThreadChannel`` object which can be used for sending and reading messages from the newly created message thread
   ///     - **Failure**: An `Error` describing the failure
-  @available(*, deprecated, message: "Use `createThreadWithResult(text:params:completion:)` instead")
+  @available(*, deprecated, message: "Use `createThread(text:params:completion:)` instead")
   func createThread(
     text: String,
     meta: [String: JSONCodable]?,
@@ -204,7 +204,7 @@ public protocol Message: CustomStringConvertible {
   ///   - completion: The async `Result` of the method call
   ///     - **Success**: A ``CreateThreadResult`` containing the thread channel and updated parent message
   ///     - **Failure**: An `Error` describing the failure
-  func createThreadWithResult(
+  func createThread(
     text: String,
     params: SendTextParams,
     completion: ((Swift.Result<CreateThreadResult<ChatType.ChatThreadChannelType, ChatType.ChatMessageType>, Error>) -> Void)?

--- a/Sources/Entities/Message.swift
+++ b/Sources/Entities/Message.swift
@@ -214,10 +214,10 @@ public protocol Message: CustomStringConvertible {
   ///
   /// - Parameters:
   ///   - completion: The async `Result` of the method call
-  ///     - **Success**:  The updated ``Channel`` object after the removal of the thread
+  ///     - **Success**: A `Void` indicating a success
   ///     - **Failure**: An `Error` describing the failure
   func removeThread(
-    completion: ((Swift.Result<ChatType.ChatChannelType?, Error>) -> Void)?
+    completion: ((Swift.Result<Void, Error>) -> Void)?
   )
 
   /// Add or remove a reaction to a message.

--- a/Sources/Entities/Message.swift
+++ b/Sources/Entities/Message.swift
@@ -228,8 +228,19 @@ public protocol Message: CustomStringConvertible {
   ///
   /// - Parameter completion: Function that takes a single Message object. It defines the custom behavior to be executed when detecting message or message reaction changes
   /// - Returns: Interface that lets you stop receiving message-related updates by invoking the ``AutoCloseable/close()`` method
+  @available(*, deprecated, message: "Use `onUpdated(callback:)` instead")
   func streamUpdates(
     completion: @escaping ((Self) -> Void)
+  ) -> AutoCloseable
+
+  /// Emits the updated message entity whenever this message's content or reactions are modified.
+  ///
+  /// For a ``ThreadMessage``, this returns the updated ``ThreadMessage`` (not the base ``Message``).
+  ///
+  /// - Parameter callback: A closure invoked with the updated message
+  /// - Returns: An ``AutoCloseable`` that stops listening when closed
+  func onUpdated(
+    callback: @escaping (Self) -> Void
   ) -> AutoCloseable
 
   /// If you delete a message, you can restore its content together with the attached files using the ``restore(completion:)`` method.

--- a/Sources/Entities/Message.swift
+++ b/Sources/Entities/Message.swift
@@ -27,6 +27,7 @@ public protocol Message: CustomStringConvertible {
   /// Unique ID of the user who sent the message
   var userId: String { get }
   /// Any actions associated with the message, such as reactions, replies, or other interactive elements
+  @available(*, deprecated, message: "Use `Message.reactions` instead for accessing message reactions")
   var actions: [String: [String: [Action]]]? { get }
   /// Extra information added to the message giving additional context
   var meta: [String: JSONCodable]? { get }
@@ -57,7 +58,7 @@ public protocol Message: CustomStringConvertible {
   /// List of attached files to the given ``Message`` with their names, types, and sources
   var files: [File] { get }
   /// List of reactions attached to the given ``Message``
-  var reactions: [String: [Action]] { get }
+  var reactions: [MessageReaction] { get }
   /// Error associated with the message, if any
   var error: Error? { get }
 

--- a/Sources/Entities/MessageImpl.swift
+++ b/Sources/Entities/MessageImpl.swift
@@ -192,12 +192,12 @@ extension MessageImpl: Message {
     )
   }
 
-  public func createThreadWithResult(
+  public func createThread(
     text: String,
     params: SendTextParams = SendTextParams(),
     completion: ((Swift.Result<CreateThreadResult<ThreadChannelImpl, MessageImpl>, Error>) -> Void)? = nil
   ) {
-    target.createThreadWithResult(
+    target.createThread(
       text: text,
       params: params,
       completion: completion

--- a/Sources/Entities/MessageImpl.swift
+++ b/Sources/Entities/MessageImpl.swift
@@ -204,7 +204,7 @@ extension MessageImpl: Message {
     )
   }
 
-  public func removeThread(completion: ((Swift.Result<ChannelImpl?, Error>) -> Void)? = nil) {
+  public func removeThread(completion: ((Swift.Result<Void, Error>) -> Void)? = nil) {
     target.removeThread(
       completion: completion
     )

--- a/Sources/Entities/MessageImpl.swift
+++ b/Sources/Entities/MessageImpl.swift
@@ -77,7 +77,7 @@ extension MessageImpl: Message {
   public var hasThread: Bool { target.hasThread }
   public var type: String { target.type }
   public var files: [File] { target.files }
-  public var reactions: [String: [Action]] { target.reactions }
+  public var reactions: [MessageReaction] { target.reactions }
   public var textLinks: [TextLink]? { target.textLinks }
   public var error: Error? { target.error }
 

--- a/Sources/Entities/MessageImpl.swift
+++ b/Sources/Entities/MessageImpl.swift
@@ -48,8 +48,8 @@ public final class MessageImpl {
     )
   }
 
-  convenience init?(message: PubNubChat.Message?, chat: ChatImpl) {
-    if let message {
+  convenience init?(message: PubNubChat.Message?, chat: ChatImpl?) {
+    if let message, let chat = chat {
       self.init(message: message, chat: chat)
     } else {
       return nil
@@ -109,10 +109,14 @@ extension MessageImpl: Message {
     newText: String,
     completion: ((Swift.Result<MessageImpl, Error>) -> Void)? = nil
   ) {
-    target.editText(
-      newText: newText,
-      completion: completion
-    )
+    target.editText(newText: newText) {
+      switch $0 {
+      case let .success(message):
+        completion?(.success(MessageImpl(message: message.message, chat: message.chat)))
+      case let .failure(error):
+        completion?(.failure(error))
+      }
+    }
   }
 
   public func delete(
@@ -184,6 +188,18 @@ extension MessageImpl: Message {
       files: files,
       usersToMention: usersToMention,
       customPushData: customPushData,
+      completion: completion
+    )
+  }
+
+  public func createThreadWithResult(
+    text: String,
+    params: SendTextParams = SendTextParams(),
+    completion: ((Swift.Result<CreateThreadResult<ThreadChannelImpl, MessageImpl>, Error>) -> Void)? = nil
+  ) {
+    target.createThreadWithResult(
+      text: text,
+      params: params,
       completion: completion
     )
   }

--- a/Sources/Entities/MessageImpl.swift
+++ b/Sources/Entities/MessageImpl.swift
@@ -217,14 +217,11 @@ extension MessageImpl: Message {
   }
 
   public func onUpdated(callback: @escaping (MessageImpl) -> Void) -> AutoCloseable {
-    AutoCloseableImpl(
-      target.message.onUpdated { [weak self] in
-        if let message = $0 as? PubNubChat.Message, let self = self {
-          callback(MessageImpl(message: message, chat: self.chat))
-        }
-      },
-      owner: self
-    )
+    target.onUpdated { [weak self] in
+      if let self = self {
+        callback(MessageImpl(message: $0.message, chat: self.chat))
+      }
+    }
   }
 
   public func restore(completion: ((Swift.Result<MessageImpl, Error>) -> Void)? = nil) {

--- a/Sources/Entities/MessageImpl.swift
+++ b/Sources/Entities/MessageImpl.swift
@@ -216,6 +216,17 @@ extension MessageImpl: Message {
     }
   }
 
+  public func onUpdated(callback: @escaping (MessageImpl) -> Void) -> AutoCloseable {
+    AutoCloseableImpl(
+      target.message.onUpdated { [weak self] in
+        if let message = $0 as? PubNubChat.Message, let self = self {
+          callback(MessageImpl(message: message, chat: self.chat))
+        }
+      },
+      owner: self
+    )
+  }
+
   public func restore(completion: ((Swift.Result<MessageImpl, Error>) -> Void)? = nil) {
     target.restore {
       switch $0 {

--- a/Sources/Entities/MessageStream.swift
+++ b/Sources/Entities/MessageStream.swift
@@ -1,0 +1,32 @@
+//
+//  MessageStream.swift
+//
+//  Copyright (c) PubNub Inc.
+//  All rights reserved.
+//
+//  This source code is licensed under the license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+
+/// Namespace providing `AsyncStream`-based streaming methods for a ``Message``.
+public struct MessageStream<M: Message> {
+  let message: M
+
+  /// Emits the updated message entity whenever this message's content or reactions are modified.
+  ///
+  /// Async equivalent of ``Message/onUpdated(callback:)``.
+  ///
+  /// - Returns: An `AsyncStream` of updated messages
+  public func updates() -> AsyncStream<M> {
+    AsyncStream { continuation in
+      let autoCloseable = message.onUpdated {
+        continuation.yield($0)
+      }
+      continuation.onTermination = { _ in
+        autoCloseable.close()
+      }
+    }
+  }
+}

--- a/Sources/Entities/ThreadChannel.swift
+++ b/Sources/Entities/ThreadChannel.swift
@@ -16,7 +16,7 @@ import PubNubSDK
 ///
 /// ``ThreadChannel`` inherits all the functionalities provided by the ``Channel`` protocol, and include additional behaviors and properties specific to threaded conversations.
 /// This type allows for finer control and representation of threads within a parent channel.
-public protocol ThreadChannel: Channel {
+public protocol ThreadChannel: Channel where MessageType == ChatType.ChatThreadMessageType {
   /// Unique identifier of the main channel on which you create a subchannel (thread channel) and thread messages
   var parentChannelId: String { get }
   /// Message for which the thread was created

--- a/Sources/Entities/ThreadChannelImpl.swift
+++ b/Sources/Entities/ThreadChannelImpl.swift
@@ -151,16 +151,22 @@ extension ThreadChannelImpl: ThreadChannel {
     description: String? = nil,
     status: String? = nil,
     type: ChannelType? = nil,
-    completion: ((Swift.Result<ChannelImpl, Error>) -> Void)? = nil
+    completion: ((Swift.Result<ThreadChannelImpl, Error>) -> Void)? = nil
   ) {
     target.update(
       name: name,
       custom: custom,
       description: description,
       status: status,
-      type: type,
-      completion: completion
-    )
+      type: type
+    ) {
+      switch $0 {
+      case let .success(channel):
+        completion?(.success(ThreadChannelImpl(channel: channel.channel, chat: channel.chat)))
+      case let .failure(error):
+        completion?(.failure(error))
+      }
+    }
   }
 
   public func delete(soft: Bool = false, completion: ((Swift.Result<ChannelImpl?, Error>) -> Void)? = nil) {
@@ -289,6 +295,18 @@ extension ThreadChannelImpl: ThreadChannel {
     )
   }
 
+  public func sendText(
+    text: String,
+    params: SendTextParams = SendTextParams(),
+    completion: ((Swift.Result<Timetoken, Error>) -> Void)? = nil
+  ) {
+    target.sendText(
+      text: text,
+      params: params,
+      completion: completion
+    )
+  }
+
   public func invite(user: UserImpl, completion: ((Swift.Result<MembershipImpl, Error>) -> Void)? = nil) {
     target.invite(
       user: user,
@@ -359,20 +377,29 @@ extension ThreadChannelImpl: ThreadChannel {
     )
   }
 
-  public func getPinnedMessage(completion: ((Swift.Result<MessageImpl?, Error>) -> Void)? = nil) {
-    target.getPinnedMessage(
-      completion: completion
-    )
+  public func getPinnedMessage(completion: ((Swift.Result<ThreadMessageImpl?, Error>) -> Void)? = nil) {
+    target.getPinnedMessage {
+      switch $0 {
+      case let .success(message):
+        completion?(.success(ThreadMessageImpl(message: message?.message, chat: message?.chat)))
+      case let .failure(error):
+        completion?(.failure(error))
+      }
+    }
   }
 
   public func getMessage(
     timetoken: Timetoken,
-    completion: ((Swift.Result<MessageImpl?, Error>) -> Void)? = nil
+    completion: ((Swift.Result<ThreadMessageImpl?, Error>) -> Void)? = nil
   ) {
-    target.getMessage(
-      timetoken: timetoken,
-      completion: completion
-    )
+    target.getMessage(timetoken: timetoken) {
+      switch $0 {
+      case let .success(message):
+        completion?(.success(ThreadMessageImpl(message: message?.message, chat: message?.chat)))
+      case let .failure(error):
+        completion?(.failure(error))
+      }
+    }
   }
 
   public func registerForPush(completion: ((Swift.Result<Void, Error>) -> Void)? = nil) {

--- a/Sources/Entities/ThreadChannelImpl.swift
+++ b/Sources/Entities/ThreadChannelImpl.swift
@@ -489,6 +489,22 @@ extension ThreadChannelImpl: ThreadChannel {
     )
   }
 
+  public func getInvitees(
+    limit: Int? = nil,
+    page: PubNubHashedPage? = nil,
+    filter: String? = nil,
+    sort: [PubNub.MembershipSortField] = [],
+    completion: ((Swift.Result<(memberships: [MembershipImpl], page: PubNubHashedPage?), Error>) -> Void)? = nil
+  ) {
+    target.getInvitees(
+      limit: limit,
+      page: page,
+      filter: filter,
+      sort: sort,
+      completion: completion
+    )
+  }
+
   public func getUserSuggestions(
     text: String,
     limit: Int = 10,

--- a/Sources/Entities/ThreadChannelImpl.swift
+++ b/Sources/Entities/ThreadChannelImpl.swift
@@ -341,12 +341,14 @@ extension ThreadChannelImpl: ThreadChannel {
 
   public func join(
     custom: [String: JSONCodableScalar]? = nil,
-    callback: ((MessageImpl) -> Void)? = nil,
-    completion: ((Swift.Result<(membership: MembershipImpl, disconnect: AutoCloseable?), Error>) -> Void)? = nil
+    status: String? = nil,
+    type: String? = nil,
+    completion: ((Swift.Result<MembershipImpl, any Error>) -> Void)? = nil
   ) {
     target.join(
       custom: custom,
-      callback: callback,
+      status: status,
+      type: type,
       completion: completion
     )
   }
@@ -511,6 +513,30 @@ extension ThreadChannelImpl: ThreadChannel {
 
   public func onMessageReported(callback: @escaping (Report) -> Void) -> AutoCloseable {
     target.onMessageReported(callback: callback)
+  }
+
+  public func emitCustomEvent(
+    payload: [String: JSONCodable],
+    messageType: String? = nil,
+    storeInHistory: Bool = true,
+    completion: ((Swift.Result<Timetoken, Error>) -> Void)? = nil
+  ) {
+    target.emitCustomEvent(
+      payload: payload,
+      messageType: messageType,
+      storeInHistory: storeInHistory,
+      completion: completion
+    )
+  }
+
+  public func onCustomEvent(
+    messageType: String? = nil,
+    callback: @escaping (CustomEvent) -> Void
+  ) -> AutoCloseable {
+    target.onCustomEvent(
+      messageType: messageType,
+      callback: callback
+    )
   }
 
   public func createMessageDraft(

--- a/Sources/Entities/ThreadChannelImpl.swift
+++ b/Sources/Entities/ThreadChannelImpl.swift
@@ -94,6 +94,28 @@ extension ThreadChannelImpl: ThreadChannel {
     )
   }
 
+  public func onMessageReceived(callback: @escaping (ThreadMessageImpl) -> Void) -> AutoCloseable {
+    AutoCloseableImpl(
+      target.channel.onThreadMessageReceived { [weak self] in
+        if let self = self {
+          callback(ThreadMessageImpl(message: $0, chat: self.chat))
+        }
+      },
+      owner: self
+    )
+  }
+
+  public func onUpdated(callback: @escaping (ThreadChannelImpl) -> Void) -> AutoCloseable {
+    AutoCloseableImpl(
+      target.channel.onThreadChannelUpdated { [weak self] in
+        if let self = self {
+          callback(ThreadChannelImpl(channel: $0, chat: self.chat))
+        }
+      },
+      owner: self
+    )
+  }
+
   public func pinMessageToParentChannel(
     message: ThreadMessageImpl,
     completion: ((Swift.Result<ChannelImpl, Error>) -> Void)? = nil
@@ -248,7 +270,7 @@ extension ThreadChannelImpl: ThreadChannel {
     usePost: Bool = false,
     ttl: Int? = nil,
     quotedMessage: MessageImpl? = nil,
-    files: [InputFile]?,
+    files: [InputFile]? = nil,
     usersToMention: [String]? = nil,
     customPushData: [String: String]? = nil,
     completion: ((Swift.Result<Timetoken, Error>) -> Void)? = nil
@@ -391,7 +413,7 @@ extension ThreadChannelImpl: ThreadChannel {
     )
   }
 
-  public func streamReadReceipts(callback: @escaping ((ReadReceipt) -> Void)) -> AutoCloseable {
+  public func streamReadReceipts(callback: @escaping (([Timetoken: [String]]) -> Void)) -> AutoCloseable {
     target.streamReadReceipts(
       callback: callback
     )
@@ -469,6 +491,26 @@ extension ThreadChannelImpl: ThreadChannel {
     target.streamMessageReports(
       callback: callback
     )
+  }
+
+  public func onTypingChanged(callback: @escaping (([String]) -> Void)) -> AutoCloseable {
+    target.onTypingChanged(callback: callback)
+  }
+
+  public func onDeleted(callback: @escaping () -> Void) -> AutoCloseable {
+    target.onDeleted(callback: callback)
+  }
+
+  public func onReadReceiptReceived(callback: @escaping (ReadReceipt) -> Void) -> AutoCloseable {
+    target.onReadReceiptReceived(callback: callback)
+  }
+
+  public func onPresenceChanged(callback: @escaping (Set<String>) -> Void) -> AutoCloseable {
+    target.onPresenceChanged(callback: callback)
+  }
+
+  public func onMessageReported(callback: @escaping (Report) -> Void) -> AutoCloseable {
+    target.onMessageReported(callback: callback)
   }
 
   public func createMessageDraft(

--- a/Sources/Entities/ThreadChannelImpl.swift
+++ b/Sources/Entities/ThreadChannelImpl.swift
@@ -297,6 +297,20 @@ extension ThreadChannelImpl: ThreadChannel {
     )
   }
 
+  public func hasMember(userId: String, completion: ((Swift.Result<Bool, Error>) -> Void)? = nil) {
+    target.hasMember(
+      userId: userId,
+      completion: completion
+    )
+  }
+
+  public func getMember(userId: String, completion: ((Swift.Result<MembershipImpl?, Error>) -> Void)? = nil) {
+    target.getMember(
+      userId: userId,
+      completion: completion
+    )
+  }
+
   public func connect(callback: @escaping (MessageImpl) -> Void) -> AutoCloseable {
     target.connect(
       callback: callback
@@ -377,9 +391,25 @@ extension ThreadChannelImpl: ThreadChannel {
     )
   }
 
-  public func streamReadReceipts(callback: @escaping (([Timetoken: [String]]) -> Void)) -> AutoCloseable {
+  public func streamReadReceipts(callback: @escaping ((ReadReceipt) -> Void)) -> AutoCloseable {
     target.streamReadReceipts(
       callback: callback
+    )
+  }
+
+  public func fetchReadReceipts(
+    limit: Int? = nil,
+    page: PubNubHashedPage? = nil,
+    filter: String? = nil,
+    sort: [PubNub.MembershipSortField] = [],
+    completion: ((Swift.Result<(receipts: [ReadReceipt], page: PubNubHashedPage?), Error>) -> Void)? = nil
+  ) {
+    target.fetchReadReceipts(
+      limit: limit,
+      page: page,
+      filter: filter,
+      sort: sort,
+      completion: completion
     )
   }
 

--- a/Sources/Entities/ThreadChannelImpl.swift
+++ b/Sources/Entities/ThreadChannelImpl.swift
@@ -169,9 +169,8 @@ extension ThreadChannelImpl: ThreadChannel {
     }
   }
 
-  public func delete(soft: Bool = false, completion: ((Swift.Result<ChannelImpl?, Error>) -> Void)? = nil) {
+  public func delete(completion: ((Swift.Result<Void, Error>) -> Void)? = nil) {
     target.delete(
-      soft: soft,
       completion: completion
     )
   }

--- a/Sources/Entities/ThreadMessageImpl.swift
+++ b/Sources/Entities/ThreadMessageImpl.swift
@@ -85,7 +85,7 @@ extension ThreadMessageImpl: ThreadMessage {
   public var hasThread: Bool { target.hasThread }
   public var type: String { target.type }
   public var files: [File] { target.files }
-  public var reactions: [String: [Action]] { target.reactions }
+  public var reactions: [MessageReaction] { target.reactions }
   public var textLinks: [TextLink]? { target.textLinks }
   public var parentChannelId: String { target.message.parentChannelId }
   public var error: Error? { target.message.error }

--- a/Sources/Entities/ThreadMessageImpl.swift
+++ b/Sources/Entities/ThreadMessageImpl.swift
@@ -238,12 +238,12 @@ extension ThreadMessageImpl: ThreadMessage {
     )
   }
 
-  public func createThreadWithResult(
+  public func createThread(
     text: String,
     params: SendTextParams = SendTextParams(),
     completion: ((Swift.Result<CreateThreadResult<ThreadChannelImpl, MessageImpl>, Error>) -> Void)? = nil
   ) {
-    target.createThreadWithResult(
+    target.createThread(
       text: text,
       params: params,
       completion: completion

--- a/Sources/Entities/ThreadMessageImpl.swift
+++ b/Sources/Entities/ThreadMessageImpl.swift
@@ -50,8 +50,8 @@ public final class ThreadMessageImpl {
     )
   }
 
-  convenience init?(message: PubNubChat.ThreadMessage?, chat: ChatImpl) {
-    if let message {
+  convenience init?(message: PubNubChat.ThreadMessage?, chat: ChatImpl?) {
+    if let message, let chat = chat {
       self.init(message: message, chat: chat)
     } else {
       return nil
@@ -153,12 +153,16 @@ extension ThreadMessageImpl: ThreadMessage {
 
   public func editText(
     newText: String,
-    completion: ((Swift.Result<MessageImpl, Error>) -> Void)? = nil
+    completion: ((Swift.Result<ThreadMessageImpl, Error>) -> Void)? = nil
   ) {
-    target.editText(
-      newText: newText,
-      completion: completion
-    )
+    target.editText(newText: newText) {
+      switch $0 {
+      case let .success(message):
+        completion?(.success(ThreadMessageImpl(message: message.message, chat: message.chat)))
+      case let .failure(error):
+        completion?(.failure(error))
+      }
+    }
   }
 
   public func delete(
@@ -230,6 +234,18 @@ extension ThreadMessageImpl: ThreadMessage {
       files: files,
       usersToMention: usersToMention,
       customPushData: customPushData,
+      completion: completion
+    )
+  }
+
+  public func createThreadWithResult(
+    text: String,
+    params: SendTextParams = SendTextParams(),
+    completion: ((Swift.Result<CreateThreadResult<ThreadChannelImpl, MessageImpl>, Error>) -> Void)? = nil
+  ) {
+    target.createThreadWithResult(
+      text: text,
+      params: params,
       completion: completion
     )
   }

--- a/Sources/Entities/ThreadMessageImpl.swift
+++ b/Sources/Entities/ThreadMessageImpl.swift
@@ -108,6 +108,17 @@ extension ThreadMessageImpl: ThreadMessage {
     )
   }
 
+  public func onUpdated(callback: @escaping (ThreadMessageImpl) -> Void) -> AutoCloseable {
+    AutoCloseableImpl(
+      target.message.onThreadMessageUpdated { [weak self] in
+        if let self = self {
+          callback(ThreadMessageImpl(message: $0, chat: self.chat))
+        }
+      },
+      owner: self
+    )
+  }
+
   public func pinToParentChannel(completion: ((Swift.Result<ChannelImpl, Error>) -> Void)? = nil) {
     target.message.pinToParentChannel().async(
       caller: self

--- a/Sources/Entities/ThreadMessageImpl.swift
+++ b/Sources/Entities/ThreadMessageImpl.swift
@@ -250,7 +250,7 @@ extension ThreadMessageImpl: ThreadMessage {
     )
   }
 
-  public func removeThread(completion: ((Swift.Result<ChannelImpl?, Error>) -> Void)? = nil) {
+  public func removeThread(completion: ((Swift.Result<Void, Error>) -> Void)? = nil) {
     target.removeThread(
       completion: completion
     )

--- a/Sources/Entities/User+AsyncAwait.swift
+++ b/Sources/Entities/User+AsyncAwait.swift
@@ -179,6 +179,40 @@ public extension User {
     }
   }
 
+  /// Checks if the user is a member of a specific channel.
+  ///
+  /// - Parameter channelId: Unique identifier of the channel to check
+  /// - Returns: A `Bool` value indicating whether the user is a member of the specified channel
+  func isMemberOf(channelId: String) async throws -> Bool {
+    try await withCheckedThrowingContinuation { continuation in
+      isMemberOf(channelId: channelId) {
+        switch $0 {
+        case let .success(isMember):
+          continuation.resume(returning: isMember)
+        case let .failure(error):
+          continuation.resume(throwing: error)
+        }
+      }
+    }
+  }
+
+  /// Retrieves the user's membership for a specific channel.
+  ///
+  /// - Parameter channelId: Unique identifier of the channel
+  /// - Returns: The user's ``Membership`` for the specified channel, or `nil` if not a member
+  func getMembership(channelId: String) async throws -> ChatType.ChatMembershipType? {
+    try await withCheckedThrowingContinuation { continuation in
+      getMembership(channelId: channelId) {
+        switch $0 {
+        case let .success(membership):
+          continuation.resume(returning: membership)
+        case let .failure(error):
+          continuation.resume(throwing: error)
+        }
+      }
+    }
+  }
+
   /// Receives updates on a single User object.
   ///
   /// - Returns: An asynchronous stream that produces updates when the current ``User`` is edited or `nil` if the user was removed.

--- a/Sources/Entities/User+AsyncAwait.swift
+++ b/Sources/Entities/User+AsyncAwait.swift
@@ -15,6 +15,12 @@ import PubNubSDK
 /// Extension providing `async-await` support for ``User``.
 ///
 public extension User {
+
+  /// Namespace for `AsyncStream`-based streaming methods
+  var stream: UserStream<Self> {
+    UserStream(user: self)
+  }
+
   /// Receive updates when specific users are updated or removed.
   ///
   /// Emits the complete list of monitored users whenever any one of them changes, excluding any that were removed.
@@ -216,6 +222,7 @@ public extension User {
   /// Receives updates on a single User object.
   ///
   /// - Returns: An asynchronous stream that produces updates when the current ``User`` is edited or `nil` if the user was removed.
+  @available(*, deprecated, message: "Use `stream.updates()` and `stream.deletions()` instead")
   func streamUpdates() -> AsyncStream<ChatType.ChatUserType?> {
     AsyncStream { continuation in
       let autoCloseable = streamUpdates {

--- a/Sources/Entities/User+AsyncAwait.swift
+++ b/Sources/Entities/User+AsyncAwait.swift
@@ -104,16 +104,13 @@ public extension User {
     }
   }
 
-  /// Deletes the user. If soft deletion is enabled, the user's data is retained but marked as inactive.
-  ///
-  /// - Parameter soft: If true, the user is soft deleted, retaining their data but making them inactive
-  /// - Returns: Returns `nil` if the user was hard-deleted. Otherwise, an updated ``User`` instance with the status field set to `"deleted"`
-  func delete(soft: Bool = false) async throws -> ChatType.ChatUserType? {
-    try await withCheckedThrowingContinuation { continuation in
-      delete(soft: soft) {
+  /// Deletes the user.
+  func delete() async throws {
+    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+      delete {
         switch $0 {
-        case let .success(user):
-          continuation.resume(returning: user)
+        case .success:
+          continuation.resume()
         case let .failure(error):
           continuation.resume(throwing: error)
         }

--- a/Sources/Entities/User.swift
+++ b/Sources/Entities/User.swift
@@ -184,8 +184,49 @@ public protocol User: CustomStringConvertible {
   /// - Parameters:
   ///   - callback: A closure to be executed when detecting user changes. Takes a User object or `nil` if the user was removed
   /// - Returns: An ``AutoCloseable`` that you can use to stop receiving objects events by invoking its ``AutoCloseable/close()`` method
+  @available(*, deprecated, message: "Use `onUpdated(callback:)` and `onDeleted(callback:)` instead")
   func streamUpdates(
     callback: @escaping ((ChatType.ChatUserType?) -> Void)
+  ) -> AutoCloseable
+
+  /// Emits the updated user entity whenever this user's metadata is modified.
+  ///
+  /// - Parameter callback: A closure invoked with the updated ``User`` entity
+  /// - Returns: An ``AutoCloseable`` that stops listening when closed
+  func onUpdated(
+    callback: @escaping (ChatType.ChatUserType) -> Void
+  ) -> AutoCloseable
+
+  /// Emits an event whenever this user is permanently deleted.
+  ///
+  /// - Parameter callback: A closure invoked when the user is deleted
+  /// - Returns: An ``AutoCloseable`` that stops listening when closed
+  func onDeleted(
+    callback: @escaping () -> Void
+  ) -> AutoCloseable
+
+  /// Emits a mention whenever this user is mentioned in a message.
+  ///
+  /// - Parameter callback: A closure invoked with the ``Mention`` containing details about the mention
+  /// - Returns: An ``AutoCloseable`` that stops listening when closed
+  func onMentioned(
+    callback: @escaping (Mention) -> Void
+  ) -> AutoCloseable
+
+  /// Emits an invite whenever this user is invited to a channel.
+  ///
+  /// - Parameter callback: A closure invoked with the ``Invite`` containing details about the invitation
+  /// - Returns: An ``AutoCloseable`` that stops listening when closed
+  func onInvited(
+    callback: @escaping (Invite) -> Void
+  ) -> AutoCloseable
+
+  /// Emits a restriction whenever the moderation status changes for this user.
+  ///
+  /// - Parameter callback: A closure invoked with the ``Restriction`` containing the updated restriction details
+  /// - Returns: An ``AutoCloseable`` that stops listening when closed
+  func onRestrictionChanged(
+    callback: @escaping (Restriction) -> Void
   ) -> AutoCloseable
 
   /// Checks if the user is currently active.

--- a/Sources/Entities/User.swift
+++ b/Sources/Entities/User.swift
@@ -100,16 +100,14 @@ public protocol User: CustomStringConvertible {
     completion: ((Swift.Result<ChatType.ChatUserType, Error>) -> Void)?
   )
 
-  /// Deletes the user. If soft deletion is enabled, the user's data is retained but marked as inactive.
+  /// Deletes the user.
   ///
   /// - Parameters:
-  ///   - soft: If true, the user is soft deleted, retaining their data but making them inactive
   ///   - completion: The async `Result` of the method call
-  ///     - **Success**: For hard delete, the method returns `nil`. Otherwise, an updated ``User`` instance with the status field set to `"deleted"`
+  ///     - **Success**: A `Void` indicating a success
   ///     - **Failure**: An `Error` describing the failure
   func delete(
-    soft: Bool,
-    completion: ((Swift.Result<ChatType.ChatUserType?, Error>) -> Void)?
+    completion: ((Swift.Result<Void, Error>) -> Void)?
   )
 
   /// Retrieves a list of channels where the user is currently present.

--- a/Sources/Entities/User.swift
+++ b/Sources/Entities/User.swift
@@ -152,6 +152,30 @@ public protocol User: CustomStringConvertible {
     completion: ((Swift.Result<(memberships: [ChatType.ChatMembershipType], page: PubNubHashedPage?), Error>) -> Void)?
   )
 
+  /// Checks if the user is a member of a specific channel.
+  ///
+  /// - Parameters:
+  ///   - channelId: Unique identifier of the channel to check
+  ///   - completion: The async `Result` of the method call
+  ///     - **Success**: A `Bool` value indicating whether the user is a member of the specified channel
+  ///     - **Failure**: An `Error` describing the failure
+  func isMemberOf(
+    channelId: String,
+    completion: ((Swift.Result<Bool, Error>) -> Void)?
+  )
+
+  /// Retrieves the user's membership for a specific channel.
+  ///
+  /// - Parameters:
+  ///   - channelId: Unique identifier of the channel
+  ///   - completion: The async `Result` of the method call
+  ///     - **Success**: The user's ``Membership`` for the specified channel, or `nil` if not a member
+  ///     - **Failure**: An `Error` describing the failure
+  func getMembership(
+    channelId: String,
+    completion: ((Swift.Result<ChatType.ChatMembershipType?, Error>) -> Void)?
+  )
+
   /// Receives updates on a single User object.
   ///
   /// - Important: Keep a strong reference to the returned ``AutoCloseable`` object as long as you want to receive updates. If ``AutoCloseable`` is deallocated,

--- a/Sources/Entities/UserImpl.swift
+++ b/Sources/Entities/UserImpl.swift
@@ -224,7 +224,7 @@ extension UserImpl: User {
       limit: limit?.asKotlinInt,
       page: page?.transform(),
       filter: filter,
-      sort: sort.compactMap { $0.transform }
+      sort: sort.compactMap { $0.transform() }
     ).async(caller: self) { (result: FutureResult<UserImpl, MembershipsResponse>) in
       switch result.result {
       case let .success(response):

--- a/Sources/Entities/UserImpl.swift
+++ b/Sources/Entities/UserImpl.swift
@@ -295,6 +295,61 @@ extension UserImpl: User {
     )
   }
 
+  public func onUpdated(callback: @escaping (UserImpl) -> Void) -> AutoCloseable {
+    AutoCloseableImpl(
+      user.onUpdated { [weak self] in
+        if let self = self {
+          callback(UserImpl(user: $0, chat: self.chat))
+        }
+      },
+      owner: self
+    )
+  }
+
+  public func onDeleted(callback: @escaping () -> Void) -> AutoCloseable {
+    AutoCloseableImpl(
+      user.onDeleted { [weak self] in
+        if self != nil {
+          callback()
+        }
+      },
+      owner: self
+    )
+  }
+
+  public func onMentioned(callback: @escaping (Mention) -> Void) -> AutoCloseable {
+    AutoCloseableImpl(
+      user.onMentioned { [weak self] in
+        if self != nil {
+          callback($0.transform())
+        }
+      },
+      owner: self
+    )
+  }
+
+  public func onInvited(callback: @escaping (Invite) -> Void) -> AutoCloseable {
+    AutoCloseableImpl(
+      user.onInvited { [weak self] in
+        if self != nil {
+          callback($0.transform())
+        }
+      },
+      owner: self
+    )
+  }
+
+  public func onRestrictionChanged(callback: @escaping (Restriction) -> Void) -> AutoCloseable {
+    AutoCloseableImpl(
+      user.onRestrictionChanged { [weak self] in
+        if self != nil {
+          callback($0.transform())
+        }
+      },
+      owner: self
+    )
+  }
+
   public func active(completion: ((Swift.Result<Bool, Error>) -> Void)? = nil) {
     user.active().async(caller: self) { (result: FutureResult<UserImpl, Bool>) in
       switch result.result {

--- a/Sources/Entities/UserImpl.swift
+++ b/Sources/Entities/UserImpl.swift
@@ -244,6 +244,42 @@ extension UserImpl: User {
     }
   }
 
+  public func isMemberOf(
+    channelId: String,
+    completion: ((Swift.Result<Bool, Error>) -> Void)? = nil
+  ) {
+    user.isMemberOf(
+      channelId: channelId
+    ).async(caller: self) { (result: FutureResult<UserImpl, Bool>) in
+      switch result.result {
+      case let .success(isMember):
+        completion?(.success(isMember))
+      case let .failure(error):
+        completion?(.failure(error))
+      }
+    }
+  }
+
+  public func getMembership(
+    channelId: String,
+    completion: ((Swift.Result<MembershipImpl?, Error>) -> Void)? = nil
+  ) {
+    user.getMembership(
+      channelId: channelId
+    ).async(caller: self) { (result: FutureResult<UserImpl, PubNubChat.Membership?>) in
+      switch result.result {
+      case let .success(membership):
+        if let membership {
+          completion?(.success(MembershipImpl(membership: membership, chat: result.caller.chat)))
+        } else {
+          completion?(.success(nil))
+        }
+      case let .failure(error):
+        completion?(.failure(error))
+      }
+    }
+  }
+
   public func streamUpdates(callback: @escaping ((UserImpl?) -> Void)) -> AutoCloseable {
     AutoCloseableImpl(
       user.streamUpdates { [weak self] in

--- a/Sources/Entities/UserImpl.swift
+++ b/Sources/Entities/UserImpl.swift
@@ -171,15 +171,12 @@ extension UserImpl: User {
   }
 
   public func delete(
-    soft: Bool = false,
-    completion: ((Swift.Result<UserImpl?, Error>) -> Void)? = nil
+    completion: ((Swift.Result<Void, Error>) -> Void)? = nil
   ) {
-    user.delete(
-      soft: soft
-    ).async(caller: self) { (result: FutureResult<UserImpl, PubNubChat.User?>) in
+    user.delete().async(caller: self) { (result: FutureResult<UserImpl, PubNubChat.KotlinUnit>) in
       switch result.result {
-      case let .success(user):
-        completion?(.success(UserImpl(user: user, chat: result.caller.chat)))
+      case .success:
+        completion?(.success(()))
       case let .failure(error):
         completion?(.failure(error))
       }

--- a/Sources/Entities/UserStream.swift
+++ b/Sources/Entities/UserStream.swift
@@ -1,0 +1,97 @@
+//
+//  UserStream.swift
+//
+//  Copyright (c) PubNub Inc.
+//  All rights reserved.
+//
+//  This source code is licensed under the license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+
+/// Namespace providing `AsyncStream`-based streaming methods for a ``User``.
+public struct UserStream<U: User> {
+  let user: U
+
+  /// Emits the updated user entity whenever this user's metadata is modified.
+  ///
+  /// Async equivalent of ``User/onUpdated(callback:)``.
+  ///
+  /// - Returns: An `AsyncStream` of updated users
+  public func updates() -> AsyncStream<U.ChatType.ChatUserType> {
+    AsyncStream { continuation in
+      let autoCloseable = user.onUpdated {
+        continuation.yield($0)
+      }
+      continuation.onTermination = { _ in
+        autoCloseable.close()
+      }
+    }
+  }
+
+  /// Emits an event whenever this user is permanently deleted.
+  ///
+  /// Async equivalent of ``User/onDeleted(callback:)``.
+  ///
+  /// - Returns: An `AsyncStream` that yields `Void` on deletion
+  public func deletions() -> AsyncStream<Void> {
+    AsyncStream { continuation in
+      let autoCloseable = user.onDeleted {
+        continuation.yield(())
+        continuation.finish()
+      }
+      continuation.onTermination = { _ in
+        autoCloseable.close()
+      }
+    }
+  }
+
+  /// Emits a mention whenever this user is mentioned in a message.
+  ///
+  /// Async equivalent of ``User/onMentioned(callback:)``.
+  ///
+  /// - Returns: An `AsyncStream` of ``Mention`` values
+  public func mentions() -> AsyncStream<Mention> {
+    AsyncStream { continuation in
+      let autoCloseable = user.onMentioned {
+        continuation.yield($0)
+      }
+      continuation.onTermination = { _ in
+        autoCloseable.close()
+      }
+    }
+  }
+
+  /// Emits an invite whenever this user is invited to a channel.
+  ///
+  /// Async equivalent of ``User/onInvited(callback:)``.
+  ///
+  /// - Returns: An `AsyncStream` of ``Invite`` values
+  public func invites() -> AsyncStream<Invite> {
+    AsyncStream { continuation in
+      let autoCloseable = user.onInvited {
+        continuation.yield($0)
+      }
+      continuation.onTermination = { _ in
+        autoCloseable.close()
+      }
+    }
+  }
+
+  /// Emits a restriction whenever the moderation status changes for this user.
+  ///
+  /// Async equivalent of ``User/onRestrictionChanged(callback:)``.
+  ///
+  /// - Returns: An `AsyncStream` of ``Restriction`` values
+  public func restrictionChanges() -> AsyncStream<Restriction> {
+    AsyncStream { continuation in
+      let autoCloseable = user.onRestrictionChanged {
+        continuation.yield($0)
+      }
+      continuation.onTermination = { _ in
+        autoCloseable.close()
+      }
+    }
+  }
+}

--- a/Sources/Extensions/Dictionary.swift
+++ b/Sources/Extensions/Dictionary.swift
@@ -109,3 +109,14 @@ extension [PubNubSwiftChatSDK.ChannelType: Int64] {
     )
   }
 }
+
+extension [PubNubSwiftChatSDK.ChannelType: Bool] {
+  func transform() -> [PubNubChat.ChannelType: KotlinBoolean] {
+    ChatConfigurationKt.EmitReadReceiptEvents(
+      direct: self[.direct] ?? false,
+      group: self[.group] ?? false,
+      public: self[.public] ?? false,
+      unknown: self[.unknown] ?? false
+    )
+  }
+}

--- a/Sources/Extensions/PubNubChat+Transform.swift
+++ b/Sources/Extensions/PubNubChat+Transform.swift
@@ -94,3 +94,50 @@ extension [PubNubChat.ReadReceipt] {
     map { $0.transform() }
   }
 }
+
+extension PubNubChat.Mention {
+  func transform() -> Mention {
+    Mention(
+      messageTimetoken: Timetoken(messageTimetoken),
+      channelId: channelId,
+      parentChannelId: parentChannelId,
+      mentionedByUserId: mentionedByUserId
+    )
+  }
+}
+
+extension PubNubChat.Invite {
+  func transform() -> Invite {
+    Invite(
+      channelId: channelId,
+      channelType: channelType.transform(),
+      invitedByUserId: invitedByUserId,
+      invitationTimetoken: Timetoken(invitationTimetoken)
+    )
+  }
+}
+
+extension PubNubChat.Report {
+  func transform() -> Report {
+    Report(
+      reason: reason,
+      text: text,
+      messageTimetoken: messageTimetoken?.uint64Value,
+      reportedMessageChannelId: reportedMessageChannelId,
+      reportedUserId: reportedUserId,
+      autoModerationId: autoModerationId
+    )
+  }
+}
+
+extension PubNubChat.Restriction {
+  func transform() -> Restriction {
+    Restriction(
+      userId: userId,
+      channelId: channelId,
+      ban: ban,
+      mute: mute,
+      reason: reason
+    )
+  }
+}

--- a/Sources/Extensions/PubNubChat+Transform.swift
+++ b/Sources/Extensions/PubNubChat+Transform.swift
@@ -63,3 +63,34 @@ extension PubNubChat.EventContent.TextMessageContent {
     )
   }
 }
+
+extension PubNubChat.MessageReaction {
+  func transform() -> MessageReaction {
+    MessageReaction(
+      value: value,
+      isMine: isMine,
+      userIds: userIds
+    )
+  }
+}
+
+extension [PubNubChat.MessageReaction] {
+  func transform() -> [MessageReaction] {
+    map { $0.transform() }
+  }
+}
+
+extension PubNubChat.ReadReceipt {
+  func transform() -> ReadReceipt {
+    ReadReceipt(
+      userId: userId,
+      lastReadTimetoken: Timetoken(lastReadTimetoken)
+    )
+  }
+}
+
+extension [PubNubChat.ReadReceipt] {
+  func transform() -> [ReadReceipt] {
+    map { $0.transform() }
+  }
+}

--- a/Sources/MessageDraft/MessageDraft+AsyncAwait.swift
+++ b/Sources/MessageDraft/MessageDraft+AsyncAwait.swift
@@ -29,6 +29,7 @@ public extension MessageDraft {
   ///   - usePost: Use HTTP POST
   ///   - ttl: Defines if/how long (in hours) the message should be stored in Message Persistence
   /// - Returns: The `Timetoken` of the sent message
+  @available(*, deprecated, message: "Use `send(params:)` instead")
   @discardableResult
   func send(
     meta: [String: JSONCodable]? = nil,
@@ -42,6 +43,28 @@ public extension MessageDraft {
         shouldStore: shouldStore,
         usePost: usePost,
         ttl: ttl
+      ) {
+        switch $0 {
+        case let .success(timetoken):
+          continuation.resume(returning: timetoken)
+        case let .failure(error):
+          continuation.resume(throwing: error)
+        }
+      }
+    }
+  }
+
+  /// Send the ``MessageDraft``, along with its ``files`` and ``quotedMessage`` if any, on the ``channel``.
+  ///
+  /// - Parameter params: Additional parameters for sending, encapsulated in a ``SendTextParams`` object
+  /// - Returns: The `Timetoken` of the sent message
+  @discardableResult
+  func send(
+    params: SendTextParams = SendTextParams()
+  ) async throws -> Timetoken {
+    try await withCheckedThrowingContinuation { continuation in
+      send(
+        params: params
       ) {
         switch $0 {
         case let .success(timetoken):

--- a/Sources/MessageDraft/MessageDraft.swift
+++ b/Sources/MessageDraft/MessageDraft.swift
@@ -104,11 +104,24 @@ public protocol MessageDraft {
   ///   - completion: The async `Result` of the method call
   ///     - **Success**: The `Timetoken` of the sent message
   ///     - **Failure**: An `Error` describing the failure
+  @available(*, deprecated, message: "Use `send(params:completion:)` instead")
   func send(
     meta: [String: JSONCodable]?,
     shouldStore: Bool,
     usePost: Bool,
     ttl: Int?,
+    completion: ((Swift.Result<Timetoken, Error>) -> Void)?
+  )
+
+  /// Send the ``MessageDraft``, along with its ``files`` and ``quotedMessage`` if any, on the ``channel``.
+  ///
+  /// - Parameters:
+  ///   - params: Additional parameters for sending, encapsulated in a ``SendTextParams`` object
+  ///   - completion: The async `Result` of the method call
+  ///     - **Success**: The `Timetoken` of the sent message
+  ///     - **Failure**: An `Error` describing the failure
+  func send(
+    params: SendTextParams,
     completion: ((Swift.Result<Timetoken, Error>) -> Void)?
   )
 }

--- a/Sources/MessageDraft/MessageDraftImpl.swift
+++ b/Sources/MessageDraft/MessageDraftImpl.swift
@@ -137,6 +137,22 @@ extension MessageDraftImpl: MessageDraft {
       }
     }
   }
+
+  public func send(
+    params: SendTextParams = SendTextParams(),
+    completion: ((Swift.Result<Timetoken, Error>) -> Void)? = nil
+  ) {
+    messageDraft.send(
+      params: params.transform()
+    ).async(caller: self) { (result: FutureResult<MessageDraftImpl, PNPublishResult>) in
+      switch result.result {
+      case let .success(result):
+        completion?(.success(Timetoken(result.timetoken)))
+      case let .failure(error):
+        completion?(.failure(error))
+      }
+    }
+  }
 }
 
 class KMPMessageDraftChangeListener: PubNubChat.MessageDraftChangeListener {

--- a/Sources/Miscellaneous/Constants.swift
+++ b/Sources/Miscellaneous/Constants.swift
@@ -10,4 +10,4 @@
 
 import Foundation
 
-let pubNubSwiftChatSDKVersion: String = "0.34.0"
+let pubNubSwiftChatSDKVersion: String = "1.0.0"

--- a/Sources/Models/CreateThreadResult.swift
+++ b/Sources/Models/CreateThreadResult.swift
@@ -1,0 +1,19 @@
+//
+//  CreateThreadResult.swift
+//
+//  Copyright (c) PubNub Inc.
+//  All rights reserved.
+//
+//  This source code is licensed under the license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+
+/// Represents the result of creating a thread and sending the first reply.
+public struct CreateThreadResult<TC: ThreadChannel, M: Message> {
+  /// The ``ThreadChannel`` object representing the newly created thread
+  public var threadChannel: TC
+  /// The updated parent ``Message`` with `hasThread` set to `true`
+  public var parentMessage: M
+}

--- a/Sources/Models/CustomEvent.swift
+++ b/Sources/Models/CustomEvent.swift
@@ -1,0 +1,24 @@
+//
+//  CustomEvent.swift
+//
+//  Copyright (c) PubNub Inc.
+//  All rights reserved.
+//
+//  This source code is licensed under the license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import PubNubSDK
+
+/// Represents a custom event received on a channel.
+public struct CustomEvent {
+  /// The timetoken indicating when the event was published
+  public let timetoken: Timetoken
+  /// The ID of the user who emitted the event
+  public let userId: String
+  /// The custom message type used to categorize the event
+  public let type: String?
+  /// The custom event payload data
+  public let payload: [String: JSONCodable]
+}

--- a/Sources/Models/EmitEventMethod.swift
+++ b/Sources/Models/EmitEventMethod.swift
@@ -11,6 +11,7 @@
 import Foundation
 
 /// Enum representing the method used to emit an event in the chat system.
+@available(*, deprecated, message: "Use Channel.emitCustomEvent() and Channel.onCustomEvent(callback:) instead")
 public enum EmitEventMethod {
   /// Represents events emitted using the "signal" method, typically for lightweight real-time updates
   case signal

--- a/Sources/Models/EventContent.swift
+++ b/Sources/Models/EventContent.swift
@@ -15,6 +15,7 @@ import PubNubSDK
 /// Represents the content of various types of events emitted during chat operations.
 public class EventContent {
   /// Represents a report event, which is used to report a message or user to the admin.
+  @available(*, deprecated, message: "Use `Report` struct and `channel.onMessageReported(callback:)` instead")
   public class Report: EventContent, CustomStringConvertible {
     /// The text of the report, if provided
     public let text: String?
@@ -71,6 +72,7 @@ public class EventContent {
   }
 
   /// Represents a typing event that indicates whether a user is typing.
+  @available(*, deprecated, message: "Use `channel.onTypingChanged(callback:)` instead")
   public class Typing: EventContent, CustomStringConvertible {
     /// A boolean value indicating whether the user is typing (true) or not (false)
     public let value: Bool
@@ -90,6 +92,7 @@ public class EventContent {
   }
 
   /// Represents a receipt event, indicating that a message was read.
+  @available(*, deprecated, message: "Use `ReadReceipt` struct and `channel.onReadReceiptReceived(callback:)` instead")
   public class Receipt: EventContent, CustomStringConvertible {
     /// The timetoken of the message for which the receipt is being acknowledged
     public let messageTimetoken: Timetoken
@@ -109,6 +112,7 @@ public class EventContent {
   }
 
   /// Represents a mention event, which indicates that a user was mentioned in a message.
+  @available(*, deprecated, message: "Use `Mention` struct and `user.onMentioned(callback:)` instead")
   public class Mention: EventContent, CustomStringConvertible {
     /// The timetoken of the message in which the user was mentioned
     public let messageTimetoken: Timetoken
@@ -144,6 +148,7 @@ public class EventContent {
   }
 
   /// Represents an invite event, which is used when a user is invited to join a channel.
+  @available(*, deprecated, message: "Use `Invite` struct and `user.onInvited(callback:)` instead")
   public class Invite: EventContent, CustomStringConvertible {
     /// The type of the channel
     public let channelType: ChannelType
@@ -204,6 +209,7 @@ public class EventContent {
   }
 
   /// Represents a moderation event, which is triggered when a restriction is applied to a user.
+  @available(*, deprecated, message: "Use `Restriction` struct and `user.onRestrictionChanged(callback:)` instead")
   public class Moderation: EventContent, CustomStringConvertible {
     /// The ID of the channel where the moderation event occurred
     public let channelId: String
@@ -319,9 +325,9 @@ extension EventContent {
         reportedUserId: content.reportedUserId,
         autoModerationId: content.autoModerationId
       )
-    case let conent as PubNubChat.EventContent.Receipt:
+    case let content as PubNubChat.EventContent.Receipt:
       EventContent.Receipt(
-        messageTimetoken: Timetoken(conent.messageTimetoken)
+        messageTimetoken: Timetoken(content.messageTimetoken)
       )
     case let content as PubNubChat.EventContent.Mention:
       EventContent.Mention(

--- a/Sources/Models/EventContent.swift
+++ b/Sources/Models/EventContent.swift
@@ -15,7 +15,7 @@ import PubNubSDK
 /// Represents the content of various types of events emitted during chat operations.
 public class EventContent {
   /// Represents a report event, which is used to report a message or user to the admin.
-  @available(*, deprecated, message: "Use `Report` struct and `channel.onMessageReported(callback:)` instead")
+  @available(*, deprecated, message: "Use Channel.onMessageReported(callback:) instead")
   public class Report: EventContent, CustomStringConvertible {
     /// The text of the report, if provided
     public let text: String?
@@ -72,7 +72,7 @@ public class EventContent {
   }
 
   /// Represents a typing event that indicates whether a user is typing.
-  @available(*, deprecated, message: "Use `channel.onTypingChanged(callback:)` instead")
+  @available(*, deprecated, message: "Use Channel.startTyping(), Channel.stopTyping(), and Channel.onTypingChanged(callback:) instead")
   public class Typing: EventContent, CustomStringConvertible {
     /// A boolean value indicating whether the user is typing (true) or not (false)
     public let value: Bool
@@ -92,7 +92,7 @@ public class EventContent {
   }
 
   /// Represents a receipt event, indicating that a message was read.
-  @available(*, deprecated, message: "Use `ReadReceipt` struct and `channel.onReadReceiptReceived(callback:)` instead")
+  @available(*, deprecated, message: "Use Channel.onReadReceiptReceived(callback:) or channel.stream.readReceipts() instead")
   public class Receipt: EventContent, CustomStringConvertible {
     /// The timetoken of the message for which the receipt is being acknowledged
     public let messageTimetoken: Timetoken
@@ -112,7 +112,7 @@ public class EventContent {
   }
 
   /// Represents a mention event, which indicates that a user was mentioned in a message.
-  @available(*, deprecated, message: "Use `Mention` struct and `user.onMentioned(callback:)` instead")
+  @available(*, deprecated, message: "Use User.onMentioned(callback:) with Mention instead")
   public class Mention: EventContent, CustomStringConvertible {
     /// The timetoken of the message in which the user was mentioned
     public let messageTimetoken: Timetoken
@@ -148,7 +148,7 @@ public class EventContent {
   }
 
   /// Represents an invite event, which is used when a user is invited to join a channel.
-  @available(*, deprecated, message: "Use `Invite` struct and `user.onInvited(callback:)` instead")
+  @available(*, deprecated, message: "Use User.onInvited(callback:) with Invite instead")
   public class Invite: EventContent, CustomStringConvertible {
     /// The type of the channel
     public let channelType: ChannelType
@@ -179,6 +179,7 @@ public class EventContent {
   }
 
   /// Represents a custom event with arbitrary data.
+  @available(*, deprecated, message: "Use Channel.emitCustomEvent() and Channel.onCustomEvent(callback:) instead")
   public class Custom: EventContent, CustomStringConvertible {
     /// A map containing key-value pairs of custom data associated with the event
     public let data: [String: Any]
@@ -209,7 +210,7 @@ public class EventContent {
   }
 
   /// Represents a moderation event, which is triggered when a restriction is applied to a user.
-  @available(*, deprecated, message: "Use `Restriction` struct and `user.onRestrictionChanged(callback:)` instead")
+  @available(*, deprecated, message: "Use User.onRestrictionChanged(callback:) with Restriction instead")
   public class Moderation: EventContent, CustomStringConvertible {
     /// The ID of the channel where the moderation event occurred
     public let channelId: String
@@ -289,6 +290,7 @@ public class EventContent {
   }
 
   /// Represents a message with an unknown format, used to handle cases where the message format doesn't match known types.
+  @available(*, deprecated, message: "Will be removed from SDK in the future")
   public class UnknownMessageFormat: EventContent, CustomStringConvertible {
     /// The raw JSON element representing the message with the unknown format
     public let element: Any?

--- a/Sources/Models/Invite.swift
+++ b/Sources/Models/Invite.swift
@@ -1,0 +1,24 @@
+//
+//  Invite.swift
+//
+//  Copyright (c) PubNub Inc.
+//  All rights reserved.
+//
+//  This source code is licensed under the license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import PubNubSDK
+
+/// Represents an invite event delivered to a user.
+public struct Invite {
+  /// The channel the user is invited to
+  public let channelId: String
+  /// Type of the channel (direct, group, etc.)
+  public let channelType: ChannelType
+  /// User ID who sent the invitation
+  public let invitedByUserId: String
+  /// Timetoken of the invitation
+  public let invitationTimetoken: Timetoken
+}

--- a/Sources/Models/Mention.swift
+++ b/Sources/Models/Mention.swift
@@ -1,0 +1,24 @@
+//
+//  Mention.swift
+//
+//  Copyright (c) PubNub Inc.
+//  All rights reserved.
+//
+//  This source code is licensed under the license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import PubNubSDK
+
+/// Represents a mention event delivered to a user.
+public struct Mention {
+  /// The timetoken of the message containing the mention
+  public let messageTimetoken: Timetoken
+  /// The channel where the mention occurred
+  public let channelId: String
+  /// The parent channel if the mention is in a thread, otherwise `nil`
+  public let parentChannelId: String?
+  /// The user ID of the message author who created the mention
+  public let mentionedByUserId: String
+}

--- a/Sources/Models/MessageReaction.swift
+++ b/Sources/Models/MessageReaction.swift
@@ -1,0 +1,24 @@
+//
+//  MessageReaction.swift
+//
+//  Copyright (c) PubNub Inc.
+//  All rights reserved.
+//
+//  This source code is licensed under the license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+
+/// Represents a reaction attached to a message.
+public struct MessageReaction {
+  /// The emoji or reaction string (e.g., "👍", "❤️", "😂")
+  public let value: String
+  /// Whether the current user added this reaction
+  public let isMine: Bool
+  /// List of all user IDs who added this reaction
+  public let userIds: [String]
+
+  /// The number of users who added this reaction
+  public var count: Int { userIds.count }
+}

--- a/Sources/Models/ReadReceipt.swift
+++ b/Sources/Models/ReadReceipt.swift
@@ -1,0 +1,20 @@
+//
+//  ReadReceipt.swift
+//
+//  Copyright (c) PubNub Inc.
+//  All rights reserved.
+//
+//  This source code is licensed under the license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import PubNubSDK
+
+/// Represents a read receipt for a single user on a channel, indicating how far they have read.
+public struct ReadReceipt {
+  /// The user ID who read the messages
+  public let userId: String
+  /// The timetoken of the last message the user has read
+  public let lastReadTimetoken: Timetoken
+}

--- a/Sources/Models/Report.swift
+++ b/Sources/Models/Report.swift
@@ -1,0 +1,28 @@
+//
+//  Report.swift
+//
+//  Copyright (c) PubNub Inc.
+//  All rights reserved.
+//
+//  This source code is licensed under the license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import PubNubSDK
+
+/// Represents a report event indicating that a user has reported a message.
+public struct Report {
+  /// The reason for reporting the message
+  public let reason: String
+  /// The text of the reported message, if provided
+  public let text: String?
+  /// The timetoken of the message being reported, if applicable
+  public let messageTimetoken: Timetoken?
+  /// The channel ID where the reported message was sent, if applicable
+  public let reportedMessageChannelId: String?
+  /// The user ID of the user being reported
+  public let reportedUserId: String?
+  /// The ID of the auto moderation rule that triggered the report, if applicable
+  public let autoModerationId: String?
+}

--- a/Sources/Models/Restriction.swift
+++ b/Sources/Models/Restriction.swift
@@ -32,12 +32,18 @@ public enum RestrictionType: String {
   }
 }
 
-struct Restriction {
-  var userId: String
-  var channelId: String
-  var ban: Bool
-  var mute: Bool
-  var reason: String?
+/// Represents a restriction applied to a specific user.
+public struct Restriction {
+  /// The unique identifier of the ``User`` who is subject to the restriction
+  public let userId: String
+  /// The unique identifier of the channel where the restriction applies
+  public let channelId: String
+  /// Indicates whether the user is banned from the channel
+  public let ban: Bool
+  /// Indicates whether the user is muted in the channel
+  public let mute: Bool
+  /// An optional description or explanation for the restriction
+  public let reason: String?
 
   init(userId: String, channelId: String, ban: Bool, mute: Bool, reason: String? = nil) {
     self.userId = userId

--- a/Sources/Models/SendTextParams.swift
+++ b/Sources/Models/SendTextParams.swift
@@ -1,0 +1,51 @@
+//
+//  SendTextParams.swift
+//
+//  Copyright (c) PubNub Inc.
+//  All rights reserved.
+//
+//  This source code is licensed under the license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+import Foundation
+import PubNubChat
+import PubNubSDK
+
+/// Encapsulates the additional parameters for sending text messages.
+public struct SendTextParams {
+  /// Extra information added to the message giving additional context
+  public var meta: [String: JSONCodable]?
+  /// If true, the messages are stored in Message Persistence if enabled in Admin Portal
+  public var shouldStore: Bool
+  /// Use HTTP POST
+  public var usePost: Bool
+  /// Defines if/how long (in hours) the message should be stored in Message Persistence
+  public var ttl: Int?
+  /// Additional key-value pairs that will be added to the FCM and/or APNS push messages
+  public var customPushData: [String: String]?
+
+  public init(
+    meta: [String: JSONCodable]? = nil,
+    shouldStore: Bool = true,
+    usePost: Bool = false,
+    ttl: Int? = nil,
+    customPushData: [String: String]? = nil
+  ) {
+    self.meta = meta
+    self.shouldStore = shouldStore
+    self.usePost = usePost
+    self.ttl = ttl
+    self.customPushData = customPushData
+  }
+
+  func transform() -> PubNubChat.SendTextParams {
+    PubNubChat.SendTextParams(
+      meta: meta?.compactMapValues { $0.rawValue },
+      shouldStore: shouldStore,
+      usePost: usePost,
+      ttl: ttl?.asKotlinInt,
+      customPushData: customPushData
+    )
+  }
+}

--- a/Tests/AsyncAwait/BaseAsyncIntegrationTestCase.swift
+++ b/Tests/AsyncAwait/BaseAsyncIntegrationTestCase.swift
@@ -20,7 +20,7 @@ class BaseAsyncIntegrationTestCase: BaseIntegrationTestCase {
 
   override func tearDown() async throws {
     try await customTearDown()
-    _ = try await chat.deleteUser(id: chat.currentUser.id)
+    try await chat.deleteUser(id: chat.currentUser.id)
 
     chat = nil
 

--- a/Tests/AsyncAwait/ChannelAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/ChannelAsyncIntegrationTests.swift
@@ -316,6 +316,56 @@ class ChannelAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
     }
   }
 
+  func testChannelAsync_HasMember() async throws {
+    let someUser = try await chat.createUser(id: randomString())
+    let membership = try await channel.invite(user: someUser)
+    let hasMember = try await channel.hasMember(userId: someUser.id)
+
+    XCTAssertTrue(hasMember)
+
+    addTeardownBlock { [unowned self] in
+      _ = try? await chat.deleteUser(id: someUser.id)
+      _ = try? await membership.channel.leave()
+    }
+  }
+
+  func testChannelAsync_HasMember_NotMember() async throws {
+    let someUser = try await chat.createUser(id: randomString())
+    let hasMember = try await channel.hasMember(userId: someUser.id)
+
+    XCTAssertFalse(hasMember)
+
+    addTeardownBlock { [unowned self] in
+      _ = try? await chat.deleteUser(id: someUser.id)
+    }
+  }
+
+  func testChannelAsync_GetMember() async throws {
+    let someUser = try await chat.createUser(id: randomString())
+    let membership = try await channel.invite(user: someUser)
+    let retrievedMembership = try await channel.getMember(userId: someUser.id)
+
+    XCTAssertNotNil(retrievedMembership)
+    XCTAssertEqual(retrievedMembership?.user.id, someUser.id)
+    XCTAssertEqual(retrievedMembership?.channel.id, channel.id)
+
+    addTeardownBlock { [unowned self] in
+      _ = try? await chat.deleteUser(id: someUser.id)
+      _ = try? await membership.channel.leave()
+    }
+  }
+
+  func testChannelAsync_GetMember_NotMember() async throws {
+    let someUser = try await chat.createUser(user: UserImpl(chat: chat, id: randomString()))
+    let membership = try await channel.getMember(userId: someUser.id)
+
+    XCTAssertNil(membership)
+
+    addTeardownBlock { [unowned self] in
+      _ = try? await chat.deleteUser(id: someUser.id)
+    }
+  }
+
   func testChannelAsync_Connect() async throws {
     let expectation = XCTestExpectation(description: "Connect")
     expectation.assertForOverFulfill = true
@@ -440,14 +490,37 @@ class ChannelAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
 
   func testChannelAsync_StreamReadReceipts() async throws {
     let expectation = expectation(description: "StreamReadReceipts")
-    expectation.assertForOverFulfill = true
     expectation.expectedFulfillmentCount = 1
+    expectation.assertForOverFulfill = true
 
+    let joinResult = try await channel.join()
+    let membership = joinResult.membership
+    let currentUserId = chat.currentUser.id
+    let messageTimetoken = try await channel.sendText(text: "Read receipt test")
+
+    let task = Task {
+      for await readReceipt in channel.streamReadReceipts() {
+        XCTAssertEqual(readReceipt.userId, currentUserId)
+        XCTAssertEqual(readReceipt.lastReadTimetoken, messageTimetoken)
+        expectation.fulfill()
+      }
+    }
+
+    _ = try await membership.setLastReadMessageTimetoken(messageTimetoken)
+
+    await fulfillment(of: [expectation], timeout: 6)
+
+    addTeardownBlock {
+      task.cancel()
+    }
+  }
+
+  func testChannelAsync_FetchReadReceipts() async throws {
     let anotherUser = try await chat.createUser(user: UserImpl(chat: chat, id: randomString()))
-    try await Task.sleep(nanoseconds: 3_000_000_000)
-
     let membership = try await channel.invite(user: chat.currentUser)
+
     try await Task.sleep(nanoseconds: 1_000_000_000)
+
     let anotherMembership = try await channel.invite(user: anotherUser)
 
     let timetoken = try XCTUnwrap(membership.lastReadMessageTimetoken)
@@ -455,20 +528,16 @@ class ChannelAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
     let currentUserId = chat.currentUser.id
     let anotherUserId = anotherUser.id
 
-    let task = Task {
-      for await readReceipt in channel.streamReadReceipts() {
-        XCTAssertEqual(readReceipt[timetoken]?.count, 1)
-        XCTAssertEqual(readReceipt[timetoken]?.first, currentUserId)
-        XCTAssertEqual(readReceipt[secondTimetoken]?.count, 1)
-        XCTAssertEqual(readReceipt[secondTimetoken]?.first, anotherUserId)
-        expectation.fulfill()
-      }
-    }
+    let response = try await channel.fetchReadReceipts()
+    let readReceipt = response.receipts.first { $0.userId == chat.currentUser.id }
+    let secondReadReceipt = response.receipts.first { $0.userId == anotherUserId }
 
-    await fulfillment(of: [expectation], timeout: 6)
+    XCTAssertEqual(readReceipt?.userId, currentUserId)
+    XCTAssertEqual(readReceipt?.lastReadTimetoken, timetoken)
+    XCTAssertEqual(secondReadReceipt?.userId, anotherUserId)
+    XCTAssertEqual(readReceipt?.lastReadTimetoken, secondTimetoken)
 
     addTeardownBlock { [unowned self] in
-      task.cancel()
       _ = try? await chat.deleteUser(id: anotherUserId)
     }
   }

--- a/Tests/AsyncAwait/ChannelAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/ChannelAsyncIntegrationTests.swift
@@ -372,6 +372,7 @@ class ChannelAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
 
     XCTAssertEqual(membership.channel.id, channel.id)
     XCTAssertEqual(membership.user.id, chat.currentUser.id)
+    XCTAssertEqual(membership.status, "")
   }
 
   func testChannelAsync_Leave() async throws {
@@ -877,6 +878,32 @@ class ChannelAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
     addTeardownBlock {
       task.cancel()
       _ = try? await message?.delete()
+    }
+  }
+
+  func testChannelAsync_GetInvitees() async throws {
+    let someUser = try await chat.createUser(user: UserImpl(chat: chat, id: randomString()))
+    try await channel.inviteMultiple(users: [chat.currentUser, someUser])
+
+    let invitees = try await channel.getInvitees().memberships
+
+    let firstMatch = try XCTUnwrap(
+      invitees.first {
+        $0.user.id == chat.currentUser.id && $0.channel.id == channel.id
+      }
+    )
+    let secondMatch = try XCTUnwrap(
+      invitees.first {
+        $0.user.id == someUser.id && $0.channel.id == channel.id
+      }
+    )
+
+    XCTAssertEqual(invitees.count, 2)
+    XCTAssertNotNil(firstMatch)
+    XCTAssertNotNil(secondMatch)
+
+    addTeardownBlock { [unowned self] in
+      _ = try? await chat.deleteUser(id: someUser.id)
     }
   }
 

--- a/Tests/AsyncAwait/ChannelAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/ChannelAsyncIntegrationTests.swift
@@ -115,24 +115,20 @@ class ChannelAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
   }
 
   func testChannelAsync_WhoIsPresent() async throws {
-    // Keeps a strong reference to the returned AsyncStream to prevent it from being deallocated. If this object is not retained,
-    // the AsyncStream will be deallocated, which would cause the behavior being tested to fail.
-    let joinResult = try await channel.join()
-    debugPrint(joinResult)
+    channel.chat.pubNub.subscribe(to: [channel.id])
 
+    // Allow time for the subscription to register, ensuring the user appears as present on the channel
     try await Task.sleep(nanoseconds: 4_000_000_000)
-    let whoIsPresent = try await channel.whoIsPresent()
 
+    let whoIsPresent = try await channel.whoIsPresent()
     XCTAssertEqual(whoIsPresent.count, 1)
     XCTAssertEqual(whoIsPresent.first, chat.currentUser.id)
   }
 
   func testChannelAsync_WhoIsPresentWithLimitAndOffset() async throws {
-    // Keeps a strong reference to the returned AsyncStream to prevent it from being deallocated. If this object is not retained,
-    // the AsyncStream will be deallocated, which would cause the behavior being tested to fail.
-    let joinResult = try await channel.join()
-    debugPrint(joinResult)
+    channel.chat.pubNub.subscribe(to: [channel.id])
 
+    // Allow time for the subscription to register, ensuring the user appears as present on the channel
     try await Task.sleep(nanoseconds: 4_000_000_000)
 
     let whoIsPresentWithLimit = try await channel.whoIsPresent(limit: 10)
@@ -148,12 +144,11 @@ class ChannelAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
   }
 
   func testChannelAsync_IsPresent() async throws {
-    // Keeps a strong reference to the returned AsyncStream to prevent it from being deallocated. If this object is not retained,
-    // the AsyncStream will be deallocated, which would cause the behavior being tested to fail.
-    let joinResult = try await channel.join()
-    debugPrint(joinResult)
+    channel.chat.pubNub.subscribe(to: [channel.id])
 
+    // Allow time for the subscription to register, ensuring the user appears as present on the channel
     try await Task.sleep(nanoseconds: 4_000_000_000)
+
     let isPresent = try await channel.isPresent(userId: chat.currentUser.id)
     XCTAssertTrue(isPresent)
   }
@@ -387,28 +382,10 @@ class ChannelAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
   }
 
   func testChannelAsync_Join() async throws {
-    let expectation = XCTestExpectation(description: "Connect")
-    expectation.assertForOverFulfill = true
-    expectation.expectedFulfillmentCount = 1
+    let membership = try await channel.join()
 
-    let joinResult = try await channel.join()
-
-    XCTAssertEqual(joinResult.membership.channel.id, channel.id)
-    XCTAssertEqual(joinResult.membership.user.id, chat.currentUser.id)
-
-    let task = Task {
-      for await message in joinResult.messagesStream {
-        XCTAssertEqual(message.text, "This is a text")
-        XCTAssertEqual(message.channelId, channel.id)
-        expectation.fulfill()
-      }
-    }
-
-    try await Task.sleep(nanoseconds: 2_000_000_000)
-    try await channel.sendText(text: "This is a text")
-
-    await fulfillment(of: [expectation], timeout: 7)
-    addTeardownBlock { task.cancel() }
+    XCTAssertEqual(membership.channel.id, channel.id)
+    XCTAssertEqual(membership.user.id, chat.currentUser.id)
   }
 
   func testChannelAsync_Leave() async throws {
@@ -540,7 +517,7 @@ class ChannelAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
     XCTAssertEqual(readReceipt?.userId, currentUserId)
     XCTAssertEqual(readReceipt?.lastReadTimetoken, timetoken)
     XCTAssertEqual(secondReadReceipt?.userId, anotherUserId)
-    XCTAssertEqual(readReceipt?.lastReadTimetoken, secondTimetoken)
+    XCTAssertEqual(secondReadReceipt?.lastReadTimetoken, secondTimetoken)
 
     addTeardownBlock { [unowned self] in
       _ = try? await chat.deleteUser(id: anotherUserId)
@@ -637,11 +614,7 @@ class ChannelAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
     expectation.assertForOverFulfill = true
     expectation.expectedFulfillmentCount = 1
 
-    let task = Task {
-      for await message in channel.connect() {
-        debugPrint("Did receive message: \(message)")
-      }
-    }
+    channel.chat.pubNub.subscribe(to: [channel.id])
 
     let presenceStreamTask = Task {
       for await userIdentifiers in channel.streamPresence() where !userIdentifiers.isEmpty {
@@ -655,7 +628,6 @@ class ChannelAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
 
     addTeardownBlock {
       presenceStreamTask.cancel()
-      task.cancel()
     }
   }
 
@@ -712,6 +684,51 @@ class ChannelAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
       task.cancel()
       _ = try? await message?.delete()
     }
+  }
+
+  func testChannelAsync_Stream_CustomEvents() async throws {
+    let expectation = expectation(description: "Stream_CustomEvents")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    let task = Task {
+      for await event in channel.stream.customEvents() {
+        XCTAssertEqual(event.userId, chat.currentUser.id)
+        expectation.fulfill()
+      }
+    }
+
+    try await Task.sleep(nanoseconds: 2_000_000_000)
+    try await channel.emitCustomEvent(payload: ["key": "value"])
+
+    await fulfillment(of: [expectation], timeout: 10)
+    addTeardownBlock { task.cancel() }
+  }
+
+  func testChannelAsync_Stream_CustomEvents_WithMessageTypeFilter() async throws {
+    let expectation = expectation(description: "Stream_CustomEvents_Filtered")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    let task = Task {
+      for await event in channel.stream.customEvents(messageType: "myType") {
+        XCTAssertEqual(event.type, "myType")
+        XCTAssertEqual(event.userId, chat.currentUser.id)
+        expectation.fulfill()
+      }
+    }
+
+    try await Task.sleep(nanoseconds: 2_000_000_000)
+
+    // Emit with a different type first - should not trigger
+    try await channel.emitCustomEvent(payload: ["key": "other"], messageType: "otherType")
+    try await Task.sleep(nanoseconds: 1_000_000_000)
+
+    // Emit with the matching type - should trigger
+    try await channel.emitCustomEvent(payload: ["key": "value"], messageType: "myType")
+
+    await fulfillment(of: [expectation], timeout: 10)
+    addTeardownBlock { task.cancel() }
   }
 
   // MARK: - Stream Namespace Tests
@@ -804,11 +821,10 @@ class ChannelAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
     expectation.assertForOverFulfill = true
     expectation.expectedFulfillmentCount = 1
 
-    let connectTask = Task {
-      for await message in channel.connect() {
-        debugPrint("Did receive message: \(message)")
-      }
-    }
+    channel.chat.pubNub.subscribe(to: [channel.id])
+
+    // Allow time for the subscription to register, ensuring the user appears as present on the channel
+    try await Task.sleep(nanoseconds: 4_000_000_000)
 
     let presenceTask = Task {
       for await userIdentifiers in channel.stream.presenceChanges() where !userIdentifiers.isEmpty {
@@ -818,11 +834,10 @@ class ChannelAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
       }
     }
 
-    await fulfillment(of: [expectation], timeout: 5)
+    await fulfillment(of: [expectation], timeout: 6)
 
     addTeardownBlock {
       presenceTask.cancel()
-      connectTask.cancel()
     }
   }
 

--- a/Tests/AsyncAwait/ChannelAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/ChannelAsyncIntegrationTests.swift
@@ -47,24 +47,10 @@ class ChannelAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
 
   func testChannelAsync_Delete() async throws {
     let someChannel = try await chat.createChannel(id: randomString())
-    let removalResult = try await someChannel.delete(soft: false)
+    try await someChannel.delete()
     let retrievedChannel = try await chat.getChannel(channelId: someChannel.id)
 
-    XCTAssertNil(removalResult)
     XCTAssertNil(retrievedChannel)
-
-    addTeardownBlock { [unowned self] in
-      _ = try? await chat.deleteChannel(id: someChannel.id)
-    }
-  }
-
-  func testChannelAsync_SoftDelete() async throws {
-    let someChannel = try await chat.createChannel(id: randomString())
-    let removalResult = try await someChannel.delete(soft: true)
-    let retrievedChannel = try await chat.getChannel(channelId: someChannel.id)
-
-    XCTAssertNotNil(removalResult)
-    XCTAssertEqual(retrievedChannel?.id, someChannel.id)
 
     addTeardownBlock { [unowned self] in
       _ = try? await chat.deleteChannel(id: someChannel.id)

--- a/Tests/AsyncAwait/ChannelAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/ChannelAsyncIntegrationTests.swift
@@ -894,5 +894,24 @@ class ChannelAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
     }
   }
 
+  func testChannelAsync_SendTextWithParams() async throws {
+    let params = SendTextParams(
+      meta: ["x": 42, "y": "hello"],
+      shouldStore: true
+    )
+
+    let tt = try await channel.sendText(
+      text: "Params text",
+      params: params
+    )
+
+    try await Task.sleep(nanoseconds: 2_000_000_000)
+    let retrievedMessage = try await channel.getMessage(timetoken: tt)
+
+    XCTAssertEqual(retrievedMessage?.text, "Params text")
+    XCTAssertEqual(retrievedMessage?.meta?["x"]?.codableValue.rawValue as? Int, 42)
+    XCTAssertEqual(retrievedMessage?.meta?["y"]?.codableValue.rawValue as? String, "hello")
+  }
+
   // swiftlint:disable:next file_length
 }

--- a/Tests/AsyncAwait/ChannelAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/ChannelAsyncIntegrationTests.swift
@@ -490,28 +490,33 @@ class ChannelAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
 
   func testChannelAsync_StreamReadReceipts() async throws {
     let expectation = expectation(description: "StreamReadReceipts")
-    expectation.expectedFulfillmentCount = 1
     expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
 
-    let joinResult = try await channel.join()
-    let membership = joinResult.membership
+    let anotherUser = try await chat.createUser(user: UserImpl(chat: chat, id: randomString()))
+    let membership = try await channel.invite(user: chat.currentUser)
+    let anotherMembership = try await channel.invite(user: anotherUser)
+
+    let timetoken = try XCTUnwrap(membership.lastReadMessageTimetoken)
+    let secondTimetoken = try XCTUnwrap(anotherMembership.lastReadMessageTimetoken)
     let currentUserId = chat.currentUser.id
-    let messageTimetoken = try await channel.sendText(text: "Read receipt test")
+    let anotherUserId = anotherUser.id
 
     let task = Task {
       for await readReceipt in channel.streamReadReceipts() {
-        XCTAssertEqual(readReceipt.userId, currentUserId)
-        XCTAssertEqual(readReceipt.lastReadTimetoken, messageTimetoken)
+        XCTAssertEqual(readReceipt[timetoken]?.count, 1)
+        XCTAssertEqual(readReceipt[timetoken]?.first, currentUserId)
+        XCTAssertEqual(readReceipt[secondTimetoken]?.count, 1)
+        XCTAssertEqual(readReceipt[secondTimetoken]?.first, anotherUserId)
         expectation.fulfill()
       }
     }
 
-    _ = try await membership.setLastReadMessageTimetoken(messageTimetoken)
-
     await fulfillment(of: [expectation], timeout: 6)
 
-    addTeardownBlock {
+    addTeardownBlock { [unowned self] in
       task.cancel()
+      _ = try? await chat.deleteUser(id: anotherUserId)
     }
   }
 
@@ -694,6 +699,171 @@ class ChannelAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
         XCTAssertEqual(report.event.payload.reason, "reportReason")
         XCTAssertEqual(report.event.payload.text, "Some text")
         XCTAssertEqual(report.event.payload.reportedUserId, chat.currentUser.id)
+        expectation.fulfill()
+      }
+    }
+
+    try await Task.sleep(nanoseconds: 4_000_000_000)
+    try await message?.report(reason: "reportReason")
+
+    await fulfillment(of: [expectation], timeout: 10)
+
+    addTeardownBlock {
+      task.cancel()
+      _ = try? await message?.delete()
+    }
+  }
+
+  // MARK: - Stream Namespace Tests
+
+  func testChannelAsync_Stream_TypingChanges() async throws {
+    let expectation = expectation(description: "Stream_TypingChanges")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    let task = Task {
+      for await userIdentifiers in channel.stream.typingChanges() {
+        XCTAssertEqual(userIdentifiers.first, chat.currentUser.id)
+        expectation.fulfill()
+      }
+    }
+
+    try await Task.sleep(nanoseconds: 2_000_000_000)
+    try await channel.startTyping()
+
+    await fulfillment(of: [expectation], timeout: 3)
+    addTeardownBlock { task.cancel() }
+  }
+
+  func testChannelAsync_Stream_Messages() async throws {
+    let expectation = XCTestExpectation(description: "Stream_Messages")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    let task = Task {
+      for await message in channel.stream.messages() {
+        XCTAssertEqual(message.text, "This is a text")
+        XCTAssertEqual(message.channelId, channel.id)
+        expectation.fulfill()
+      }
+    }
+
+    try await Task.sleep(nanoseconds: 2_000_000_000)
+    try await channel.sendText(text: "This is a text")
+
+    await fulfillment(of: [expectation], timeout: 6)
+    addTeardownBlock { task.cancel() }
+  }
+
+  func testChannelAsync_Stream_Updates() async throws {
+    let expectation = expectation(description: "Stream_Updates")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    let task = Task {
+      for await receivedChannel in channel.stream.updates() {
+        XCTAssertEqual(receivedChannel.name, "NewName")
+        XCTAssertEqual(receivedChannel.status, "NewStatus")
+        expectation.fulfill()
+      }
+    }
+
+    try await Task.sleep(nanoseconds: 3_000_000_000)
+    _ = try await channel.update(name: "NewName", status: "NewStatus")
+
+    await fulfillment(of: [expectation], timeout: 6)
+    addTeardownBlock { task.cancel() }
+  }
+
+  func testChannelAsync_Stream_Deletions() async throws {
+    let someChannel = try await chat.createChannel(id: randomString())
+
+    let expectation = expectation(description: "Stream_Deletions")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    let task = Task {
+      for await _ in someChannel.stream.deletions() {
+        expectation.fulfill()
+      }
+    }
+
+    try await Task.sleep(nanoseconds: 3_000_000_000)
+    _ = try await someChannel.delete()
+
+    await fulfillment(of: [expectation], timeout: 6)
+
+    addTeardownBlock { [unowned self] in
+      task.cancel()
+      _ = try? await chat.deleteChannel(id: someChannel.id)
+    }
+  }
+
+  func testChannelAsync_Stream_PresenceChanges() async throws {
+    let expectation = expectation(description: "Stream_PresenceChanges")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    let connectTask = Task {
+      for await message in channel.connect() {
+        debugPrint("Did receive message: \(message)")
+      }
+    }
+
+    let presenceTask = Task {
+      for await userIdentifiers in channel.stream.presenceChanges() where !userIdentifiers.isEmpty {
+        XCTAssertEqual(userIdentifiers.count, 1)
+        XCTAssertEqual(userIdentifiers.first, chat.currentUser.id)
+        expectation.fulfill()
+      }
+    }
+
+    await fulfillment(of: [expectation], timeout: 5)
+
+    addTeardownBlock {
+      presenceTask.cancel()
+      connectTask.cancel()
+    }
+  }
+
+  func testChannelAsync_Stream_ReadReceipts() async throws {
+    let expectation = expectation(description: "Stream_ReadReceipts")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    let membership = try await channel.invite(user: chat.currentUser)
+    let currentUserId = chat.currentUser.id
+
+    let task = Task {
+      for await receipt in channel.stream.readReceipts() {
+        XCTAssertEqual(receipt.userId, currentUserId)
+        expectation.fulfill()
+      }
+    }
+
+    try await Task.sleep(nanoseconds: 3_000_000_000)
+
+    let tt = try await channel.sendText(text: "Read receipt test")
+    try await Task.sleep(nanoseconds: 2_000_000_000)
+    _ = try await membership.setLastReadMessageTimetoken(tt)
+
+    await fulfillment(of: [expectation], timeout: 10)
+    addTeardownBlock { task.cancel() }
+  }
+
+  func testChannelAsync_Stream_Reports() async throws {
+    let expectation = expectation(description: "Stream_Reports")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    let tt = try await channel.sendText(text: "Some text")
+    try await Task.sleep(nanoseconds: 2_000_000_000)
+    let message = try await channel.getMessage(timetoken: tt)
+
+    let task = Task {
+      for await report in channel.stream.reports() {
+        XCTAssertEqual(report.reason, "reportReason")
+        XCTAssertEqual(report.reportedUserId, chat.currentUser.id)
         expectation.fulfill()
       }
     }

--- a/Tests/AsyncAwait/ChannelGroupAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/ChannelGroupAsyncIntegrationTests.swift
@@ -69,23 +69,18 @@ class ChannelGroupAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
   func testChannelGroup_WhoIsPresent() async throws {
     try await channelGroup.add(channels: [channel, secondChannel])
 
-    let connectStream = channelGroup.connect()
-    let connectTask = Task {
-      for await message in connectStream {
-        debugPrint("Did receive message: \(message)")
-      }
-    }
+    channelGroup.chat.pubNub.subscribe(
+      to: [randomString()],
+      and: [channelGroup.id]
+    )
 
-    try await Task.sleep(nanoseconds: 3_000_000_000)
+    // Allow time for the subscription to register, ensuring the user appears as present on the channel group
+    try await Task.sleep(nanoseconds: 4_000_000_000)
+
     let whoIsPresentValue = try await channelGroup.whoIsPresent()
-
     XCTAssertEqual(whoIsPresentValue.count, 2)
     XCTAssertEqual(whoIsPresentValue[channel.id], [chat.currentUser.id])
     XCTAssertEqual(whoIsPresentValue[secondChannel.id], [chat.currentUser.id])
-
-    addTeardownBlock {
-      connectTask.cancel()
-    }
   }
 
   func testChannelGroup_StreamPresence() async throws {
@@ -139,6 +134,63 @@ class ChannelGroupAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
 
     addTeardownBlock {
       connectTask.cancel()
+    }
+
+    try await Task.sleep(nanoseconds: 4_000_000_000)
+    try await channel.sendText(text: "This is a text")
+
+    await fulfillment(of: [expectation], timeout: 6)
+  }
+
+  func testChannelGroup_Stream_PresenceChanges() async throws {
+    let expectation = expectation(description: "Stream_PresenceChanges")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    try await channelGroup.add(channels: [channel, secondChannel])
+
+    channelGroup.chat.pubNub.subscribe(
+      to: [randomString()],
+      and: [channelGroup.id]
+    )
+
+    // Allow time for the subscription to register, ensuring the user appears as present on the channel group
+    try await Task.sleep(nanoseconds: 4_000_000_000)
+
+    let presenceTask = Task { [unowned self] in
+      for await presenceData in channelGroup.stream.presenceChanges() where presenceData.count == 2 {
+        XCTAssertEqual(presenceData[channel.id], [chat.currentUser.id])
+        XCTAssertEqual(presenceData[secondChannel.id], [chat.currentUser.id])
+        expectation.fulfill()
+        break
+      }
+    }
+
+    addTeardownBlock {
+      presenceTask.cancel()
+    }
+
+    await fulfillment(of: [expectation], timeout: 7)
+  }
+
+  func testChannelGroup_Stream_Messages() async throws {
+    let expectation = XCTestExpectation(description: "Stream_Messages")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    try await channelGroup.add(channels: [channel, secondChannel])
+
+    let task = Task { [unowned self] in
+      for await message in channelGroup.stream.messages() {
+        XCTAssertEqual(message.text, "This is a text")
+        XCTAssertEqual(message.channelId, channel.id)
+        expectation.fulfill()
+        break
+      }
+    }
+
+    addTeardownBlock {
+      task.cancel()
     }
 
     try await Task.sleep(nanoseconds: 4_000_000_000)

--- a/Tests/AsyncAwait/ChatAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/ChatAsyncIntegrationTests.swift
@@ -90,7 +90,7 @@ class ChatAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
 
   func testChatAsync_Delete() async throws {
     let user = try await chat.createUser(id: randomString())
-    _ = try await chat.deleteUser(id: user.id)
+    try await chat.deleteUser(id: user.id)
     let retrievedUser = try await chat.getUser(userId: user.id)
 
     XCTAssertNil(
@@ -243,7 +243,7 @@ class ChatAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
 
   func testChatAsync_DeleteChannel() async throws {
     let channel = try await chat.createChannel(id: randomString())
-    _ = try await chat.deleteChannel(id: channel.id)
+    try await chat.deleteChannel(id: channel.id)
     let retrievedChannel = try await chat.getChannel(channelId: channel.id)
 
     XCTAssertNil(

--- a/Tests/AsyncAwait/ChatAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/ChatAsyncIntegrationTests.swift
@@ -129,12 +129,11 @@ class ChatAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
     let channelId = randomString()
     let channel = try await chat.createChannel(id: channelId, name: channelId)
 
-    // Keeps a strong reference to the returned AsyncStream to prevent it from being deallocated. If this object is not retained,
-    // the AsyncStream will be deallocated, which would cause the behavior being tested to fail.
-    let connectResult = channel.connect()
-    debugPrint(connectResult)
+    channel.chat.pubNub.subscribe(to: [channelId])
 
+    // Allow time for the subscription to register, ensuring the user appears as present on the channel
     try await Task.sleep(nanoseconds: 5_000_000_000)
+
     let channelIdentifiers = try await chat.wherePresent(userId: chat.currentUser.id)
     let expectedChannelIdentifiers = [channelId]
 
@@ -149,14 +148,9 @@ class ChatAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
     let channelId = randomString()
     let channel = try await chat.createChannel(id: channelId, name: channelId)
 
-    // Keeps a strong reference to the returned AsyncStream to prevent it from being deallocated. If this object is not retained,
-    // the AsyncStream will be deallocated, which would cause the behavior being tested to fail.
-    let connectResult = channel.connect()
-    let joinResult = try await channel.join()
+    channel.chat.pubNub.subscribe(to: [channelId])
 
-    debugPrint(connectResult)
-    debugPrint(joinResult)
-
+    // Allow time for the subscription to register, ensuring the user appears as present on the channel
     try await Task.sleep(nanoseconds: 3_000_000_000)
 
     let isPresent = try await chat.isPresent(userId: chat.currentUser.id, channelId: channelId)
@@ -290,11 +284,9 @@ class ChatAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
       name: "ChannelName"
     )
 
-    // Keeps a strong reference to the returned AsyncStream to prevent it from being deallocated. If this object is not retained,
-    // the AsyncStream will be deallocated, which would cause the behavior being tested to fail.
-    let joinValue = try await channel.join()
-    debugPrint(joinValue)
+    channel.chat.pubNub.subscribe(to: [channel.id])
 
+    // Allow time for the subscription to register, ensuring the user appears as present on the channel
     try await Task.sleep(nanoseconds: 4_000_000_000)
 
     let whoIsPresentValue = try await chat.whoIsPresent(channelId: channel.id)

--- a/Tests/AsyncAwait/MembershipAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/MembershipAsyncIntegrationTests.swift
@@ -139,6 +139,20 @@ class MembershipAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
     }
   }
 
+  func testMembershipAsync_Delete() async throws {
+    let someChannel = try await chat.createChannel(id: randomString())
+    let someMembership = try await someChannel.invite(user: chat.currentUser)
+
+    try await someMembership.delete()
+
+    let isMember = try await chat.currentUser.isMemberOf(channelId: someChannel.id)
+    XCTAssertFalse(isMember)
+
+    addTeardownBlock { [unowned self] in
+      _ = try? await chat.deleteChannel(id: someChannel.id)
+    }
+  }
+
   // MARK: - Stream Namespace Tests
 
   func testMembershipAsync_Stream_Updates() async throws {

--- a/Tests/AsyncAwait/MembershipAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/MembershipAsyncIntegrationTests.swift
@@ -45,12 +45,18 @@ class MembershipAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
 
   func testMembershipAsync_Update() async throws {
     let newCustom: [String: JSONCodableScalar] = ["a": 1, "b": "Lorem ipsum", "c": 3.557]
-    let updatedMembership = try await membership.update(custom: newCustom)
+    let updatedMembership = try await membership.update(
+      custom: newCustom,
+      status: "active",
+      type: "premium"
+    )
 
     XCTAssertEqual(
       newCustom.mapValues { $0.scalarValue },
       updatedMembership.custom?.mapValues { $0.scalarValue }
     )
+    XCTAssertEqual(updatedMembership.status, "active")
+    XCTAssertEqual(updatedMembership.type, "premium")
   }
 
   func testMembershipAsync_SetLastReadMessageTimetoken() async throws {

--- a/Tests/AsyncAwait/MembershipAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/MembershipAsyncIntegrationTests.swift
@@ -138,4 +138,60 @@ class MembershipAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
       task.cancel()
     }
   }
+
+  // MARK: - Stream Namespace Tests
+
+  func testMembershipAsync_Stream_Updates() async throws {
+    let expectation = expectation(description: "Stream_Updates")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    let expectedCustom: [String: JSONCodableScalar] = [
+      "a": 1,
+      "b": "Text"
+    ]
+
+    let task = Task {
+      for await updatedMembership in membership.stream.updates() {
+        XCTAssertEqual(updatedMembership.channel.id, membership.channel.id)
+        XCTAssertEqual(updatedMembership.user.id, membership.user.id)
+        XCTAssertEqual(updatedMembership.custom?.mapValues { $0.scalarValue }, expectedCustom.mapValues { $0.scalarValue })
+        expectation.fulfill()
+      }
+    }
+
+    try await Task.sleep(nanoseconds: 3_000_000_000)
+    _ = try await membership.update(custom: expectedCustom)
+
+    await fulfillment(of: [expectation], timeout: 6)
+
+    addTeardownBlock {
+      task.cancel()
+    }
+  }
+
+  func testMembershipAsync_Stream_Deletions() async throws {
+    let someChannel = try await chat.createChannel(id: randomString())
+    let someMembership = try await someChannel.invite(user: chat.currentUser)
+
+    let expectation = expectation(description: "Stream_Deletions")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    let task = Task {
+      for await _ in someMembership.stream.deletions() {
+        expectation.fulfill()
+      }
+    }
+
+    try await Task.sleep(nanoseconds: 3_000_000_000)
+    try await someChannel.leave()
+
+    await fulfillment(of: [expectation], timeout: 6)
+
+    addTeardownBlock { [unowned self] in
+      task.cancel()
+      _ = try? await chat.deleteChannel(id: someChannel.id)
+    }
+  }
 }

--- a/Tests/AsyncAwait/MembershipAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/MembershipAsyncIntegrationTests.swift
@@ -53,8 +53,9 @@ class MembershipAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
 
     XCTAssertEqual(
       newCustom.mapValues { $0.scalarValue },
-      updatedMembership.custom?.mapValues { $0.scalarValue }
+      updatedMembership.custom?.filter { newCustom.keys.contains($0.key) }.mapValues { $0.scalarValue }
     )
+
     XCTAssertEqual(updatedMembership.status, "active")
     XCTAssertEqual(updatedMembership.type, "premium")
   }
@@ -101,7 +102,10 @@ class MembershipAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
       for await updatedMembership in membership.streamUpdates() {
         XCTAssertEqual(updatedMembership?.channel.id, membership.channel.id)
         XCTAssertEqual(updatedMembership?.user.id, membership.user.id)
-        XCTAssertEqual(updatedMembership?.custom?.mapValues { $0.scalarValue }, expectedCustom.mapValues { $0.scalarValue })
+        XCTAssertEqual(
+          updatedMembership?.custom?.filter { expectedCustom.keys.contains($0.key) }.mapValues { $0.scalarValue },
+          expectedCustom.mapValues { $0.scalarValue }
+        )
         expectation.fulfill()
       }
     }
@@ -130,7 +134,10 @@ class MembershipAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
       for await receivedMembership in MembershipImpl.streamUpdatesOn(memberships: [membership]) {
         XCTAssertEqual(receivedMembership.first?.channel.id, membership.channel.id)
         XCTAssertEqual(receivedMembership.first?.user.id, membership.user.id)
-        XCTAssertEqual(receivedMembership.first?.custom?.mapValues { $0.scalarValue }, expectedCustom.mapValues { $0.scalarValue })
+        XCTAssertEqual(
+          receivedMembership.first?.custom?.filter { expectedCustom.keys.contains($0.key) }.mapValues { $0.scalarValue },
+          expectedCustom.mapValues { $0.scalarValue }
+        )
         expectation.fulfill()
       }
     }
@@ -175,7 +182,10 @@ class MembershipAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
       for await updatedMembership in membership.stream.updates() {
         XCTAssertEqual(updatedMembership.channel.id, membership.channel.id)
         XCTAssertEqual(updatedMembership.user.id, membership.user.id)
-        XCTAssertEqual(updatedMembership.custom?.mapValues { $0.scalarValue }, expectedCustom.mapValues { $0.scalarValue })
+        XCTAssertEqual(
+          updatedMembership.custom?.filter { expectedCustom.keys.contains($0.key) }.mapValues { $0.scalarValue },
+          expectedCustom.mapValues { $0.scalarValue }
+        )
         expectation.fulfill()
       }
     }

--- a/Tests/AsyncAwait/MessageAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/MessageAsyncIntegrationTests.swift
@@ -266,4 +266,41 @@ class MessageAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
       _ = try? await unwrappedMessage.delete()
     }
   }
+
+  // MARK: - Stream Namespace Tests
+
+  func testMessageAsync_Stream_Updates() async throws {
+    let expectation = expectation(description: "Stream_Updates")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    let timetoken = try await channel?.sendText(text: "Some text \(randomString())")
+    let unwrappedTimetoken = try XCTUnwrap(timetoken)
+
+    try await Task.sleep(nanoseconds: 3_000_000_000)
+    let message = try await channel.getMessage(timetoken: unwrappedTimetoken)
+    let unwrappedMessage = try XCTUnwrap(message)
+
+    let task = Task {
+      for await receivedMessage in unwrappedMessage.stream.updates() {
+        XCTAssertTrue(receivedMessage.hasUserReaction(reaction: "myReaction"))
+        XCTAssertEqual(receivedMessage.channelId, message?.channelId)
+        XCTAssertEqual(receivedMessage.userId, message?.userId)
+        expectation.fulfill()
+      }
+    }
+
+    try await Task.sleep(nanoseconds: 3_000_000_000)
+    _ = try await message?.toggleReaction(reaction: "myReaction")
+
+    await fulfillment(
+      of: [expectation],
+      timeout: 6
+    )
+
+    addTeardownBlock {
+      task.cancel()
+      _ = try? await unwrappedMessage.delete()
+    }
+  }
 }

--- a/Tests/AsyncAwait/MessageAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/MessageAsyncIntegrationTests.swift
@@ -147,6 +147,34 @@ class MessageAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
     }
   }
 
+  func testAsyncMessage_CreateThreadWithResult() async throws {
+    let params = SendTextParams(
+      meta: ["key": "value"],
+      shouldStore: true
+    )
+    let result = try await testMessage.createThreadWithResult(
+      text: "Thread reply with params",
+      params: params
+    )
+
+    XCTAssertTrue(result.parentMessage.hasThread)
+    XCTAssertEqual(result.threadChannel.parentChannelId, testMessage.channelId)
+
+    try await Task.sleep(nanoseconds: 4_000_000_000)
+
+    let threadChannelHistory = try await result.threadChannel.getHistory()
+    let retrievedThreadMessage = try XCTUnwrap(threadChannelHistory.messages.first)
+
+    XCTAssertEqual(retrievedThreadMessage.text, "Thread reply with params")
+    XCTAssertEqual(retrievedThreadMessage.meta?.count, 1)
+    XCTAssertEqual(retrievedThreadMessage.meta?["key"]?.stringOptional, "value")
+
+    addTeardownBlock { [unowned self] in
+      _ = try? await retrievedThreadMessage.delete()
+      _ = try? await testMessage?.removeThread()
+    }
+  }
+
   func testAsyncMessage_RemoveThread() async throws {
     let threadChannel = try await testMessage.createThread()
 

--- a/Tests/AsyncAwait/MessageAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/MessageAsyncIntegrationTests.swift
@@ -176,10 +176,12 @@ class MessageAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
     try await Task.sleep(nanoseconds: 3_000_000_000)
 
     let updatedMessage = try await testMessage.toggleReaction(reaction: ":+1")
-    let reaction = try XCTUnwrap(updatedMessage.reactions[":+1"]?.first)
-    let userId = reaction.uuid
+    let reaction = try XCTUnwrap(updatedMessage.reactions.first)
 
-    XCTAssertEqual(userId, chat.currentUser.id)
+    XCTAssertEqual(reaction.value, ":+1")
+    XCTAssertTrue(reaction.isMine)
+    XCTAssertEqual(reaction.count, 1)
+    XCTAssertTrue(reaction.userIds.contains(chat.currentUser.id))
   }
 
   func testAsyncMessage_Restore() async throws {

--- a/Tests/AsyncAwait/MessageAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/MessageAsyncIntegrationTests.swift
@@ -129,7 +129,7 @@ class MessageAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
   }
 
   func testAsyncMessage_CreateThreadWithParameters() async throws {
-    let threadChannel = try await testMessage.createThread(text: "This is reply in a thread")
+    let threadChannel = try await testMessage.createThread(text: "This is reply in a thread").threadChannel
     XCTAssertEqual(threadChannel.parentMessage.timetoken, testMessage.timetoken)
     XCTAssertEqual(threadChannel.parentChannelId, testMessage.channelId)
 
@@ -147,12 +147,12 @@ class MessageAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
     }
   }
 
-  func testAsyncMessage_CreateThreadWithResult() async throws {
+  func testAsyncMessage_CreateThread_WithResult() async throws {
     let params = SendTextParams(
       meta: ["key": "value"],
       shouldStore: true
     )
-    let result = try await testMessage.createThreadWithResult(
+    let result = try await testMessage.createThread(
       text: "Thread reply with params",
       params: params
     )

--- a/Tests/AsyncAwait/MessageDraftAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/MessageDraftAsyncIntegrationTests.swift
@@ -307,4 +307,21 @@ class MessageDraftIntegrationTests: BaseAsyncIntegrationTestCase {
     XCTAssertEqual(receivedQuotedMessage.timetoken, 17_296_737_530_374_172)
     XCTAssertEqual(receivedQuotedMessage.text, "Lorem ipsum")
   }
+
+  func testMessageDraft_SendWithParams() async throws {
+    let messageDraft = channel.createMessageDraft()
+    messageDraft.update(text: "Draft with params")
+
+    let params = SendTextParams(
+      meta: ["draft": "test"],
+      shouldStore: true
+    )
+
+    let timetoken = try await messageDraft.send(params: params)
+    try await Task.sleep(nanoseconds: 2_000_000_000)
+    let message = try await channel.getMessage(timetoken: timetoken)
+
+    XCTAssertEqual(message?.text, "Draft with params")
+    XCTAssertEqual(message?.meta?["draft"]?.stringOptional, "test")
+  }
 }

--- a/Tests/AsyncAwait/ThreadChannelAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/ThreadChannelAsyncIntegrationTests.swift
@@ -49,6 +49,82 @@ class ThreadChannelAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
     XCTAssertNotNil(pinnedMessage)
   }
 
+  func testThreadChannelAsync_Update() async throws {
+    let updatedThreadChannel = try await threadChannel.update(
+      name: "UpdatedName",
+      custom: ["key": "value"],
+      description: "UpdatedDescription",
+      status: "UpdatedStatus"
+    )
+
+    XCTAssertEqual(updatedThreadChannel.id, threadChannel.id)
+    XCTAssertEqual(updatedThreadChannel.name, "UpdatedName")
+    XCTAssertEqual(updatedThreadChannel.channelDescription, "UpdatedDescription")
+    XCTAssertEqual(updatedThreadChannel.status, "UpdatedStatus")
+  }
+
+  func testThreadChannelAsync_PinMessage() async throws {
+    try await Task.sleep(nanoseconds: 3_000_000_000)
+
+    let message = try await threadChannel.getHistory().messages.first
+    let unwrappedMessage = try XCTUnwrap(message)
+
+    let updatedThreadChannel = try await threadChannel.pinMessage(message: unwrappedMessage)
+    let pinnedMessage = try await updatedThreadChannel.getPinnedMessage()
+
+    XCTAssertNotNil(pinnedMessage)
+    XCTAssertEqual(pinnedMessage?.channelId, threadChannel.id)
+  }
+
+  func testThreadChannelAsync_UnpinMessage() async throws {
+    try await Task.sleep(nanoseconds: 3_000_000_000)
+
+    let message = try await threadChannel.getHistory().messages.first
+    let unwrappedMessage = try XCTUnwrap(message)
+
+    let channelWithPinnedMessage = try await threadChannel.pinMessage(message: unwrappedMessage)
+    let updatedThreadChannel = try await channelWithPinnedMessage.unpinMessage()
+    let pinnedMessage = try await updatedThreadChannel.getPinnedMessage()
+
+    XCTAssertNil(pinnedMessage)
+  }
+
+  func testThreadChannelAsync_GetHistory() async throws {
+    try await Task.sleep(nanoseconds: 3_000_000_000)
+
+    let history = try await threadChannel.getHistory()
+
+    XCTAssertEqual(history.messages.count, 1)
+    XCTAssertEqual(history.messages.first?.text, "Reply in a thread")
+    XCTAssertEqual(history.messages.first?.channelId, threadChannel.id)
+  }
+
+  func testThreadChannelAsync_GetMessage() async throws {
+    try await Task.sleep(nanoseconds: 3_000_000_000)
+
+    let historyMessage = try await threadChannel.getHistory().messages.first
+    let unwrappedMessage = try XCTUnwrap(historyMessage)
+    let message = try await threadChannel.getMessage(timetoken: unwrappedMessage.timetoken)
+
+    XCTAssertNotNil(message)
+    XCTAssertEqual(message?.text, "Reply in a thread")
+    XCTAssertEqual(message?.channelId, threadChannel.id)
+  }
+
+  func testThreadChannelAsync_GetPinnedMessage() async throws {
+    try await Task.sleep(nanoseconds: 3_000_000_000)
+
+    let message = try await threadChannel.getHistory().messages.first
+    let unwrappedMessage = try XCTUnwrap(message)
+
+    let updatedChannel = try await threadChannel.pinMessage(message: unwrappedMessage)
+    let pinnedMessage = try await updatedChannel.getPinnedMessage()
+
+    XCTAssertNotNil(pinnedMessage)
+    XCTAssertEqual(pinnedMessage?.text, "Reply in a thread")
+    XCTAssertEqual(pinnedMessage?.channelId, threadChannel.id)
+  }
+
   // MARK: - Stream Namespace Tests
 
   func testThreadChannelAsync_Stream_Messages() async throws {

--- a/Tests/AsyncAwait/ThreadChannelAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/ThreadChannelAsyncIntegrationTests.swift
@@ -48,4 +48,45 @@ class ThreadChannelAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
 
     XCTAssertNotNil(pinnedMessage)
   }
+
+  // MARK: - Stream Namespace Tests
+
+  func testThreadChannelAsync_Stream_Messages() async throws {
+    let expectation = expectation(description: "Stream_Messages")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    let task = Task {
+      for await threadMessage in threadChannel.stream.messages() {
+        XCTAssertEqual(threadMessage.text, "New thread reply")
+        XCTAssertEqual(threadMessage.channelId, threadChannel.id)
+        expectation.fulfill()
+      }
+    }
+
+    try await Task.sleep(nanoseconds: 2_000_000_000)
+    try await threadChannel.sendText(text: "New thread reply")
+
+    await fulfillment(of: [expectation], timeout: 6)
+    addTeardownBlock { task.cancel() }
+  }
+
+  func testThreadChannelAsync_Stream_Updates() async throws {
+    let expectation = expectation(description: "Stream_Updates")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    let task = Task {
+      for await updatedThreadChannel in threadChannel.stream.updates() {
+        XCTAssertEqual(updatedThreadChannel.name, "UpdatedThread")
+        expectation.fulfill()
+      }
+    }
+
+    try await Task.sleep(nanoseconds: 3_000_000_000)
+    _ = try await threadChannel.update(name: "UpdatedThread")
+
+    await fulfillment(of: [expectation], timeout: 6)
+    addTeardownBlock { task.cancel() }
+  }
 }

--- a/Tests/AsyncAwait/ThreadMessageAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/ThreadMessageAsyncIntegrationTests.swift
@@ -142,6 +142,17 @@ class ThreadMessageAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
     }
   }
 
+  func testThreadMessageAsync_Restore() async throws {
+    let message = try await threadMessage.delete(soft: true)
+
+    XCTAssertNotNil(message?.deleted)
+    XCTAssertTrue(message?.deleted ?? false)
+
+    let restoredMessage = try await message?.restore()
+    XCTAssertNotNil(restoredMessage)
+    XCTAssertFalse(restoredMessage?.deleted ?? true)
+  }
+
   func testThreadMessageAsync_ToggleReaction() async throws {
     let updateMessage = try await threadMessage.toggleReaction(reaction: ":+1")
     let reaction = try XCTUnwrap(updateMessage.reactions.first)

--- a/Tests/AsyncAwait/ThreadMessageAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/ThreadMessageAsyncIntegrationTests.swift
@@ -144,13 +144,12 @@ class ThreadMessageaAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
 
   func testThreadMessageAsync_ToggleReaction() async throws {
     let updateMessage = try await threadMessage.toggleReaction(reaction: ":+1")
-    let reaction = try XCTUnwrap(updateMessage.reactions[":+1"]?.first)
-    let userId = reaction.uuid
+    let reaction = try XCTUnwrap(updateMessage.reactions.first)
 
-    XCTAssertEqual(
-      userId,
-      chat.currentUser.id
-    )
+    XCTAssertEqual(reaction.value, ":+1")
+    XCTAssertTrue(reaction.isMine)
+    XCTAssertEqual(reaction.count, 1)
+    XCTAssertTrue(reaction.userIds.contains(chat.currentUser.id))
   }
 
   func testThreadMessageAsync_StreamUpdates() async throws {

--- a/Tests/AsyncAwait/ThreadMessageAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/ThreadMessageAsyncIntegrationTests.swift
@@ -14,7 +14,7 @@ import XCTest
 
 @testable import PubNubSwiftChatSDK
 
-class ThreadMessageaAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
+class ThreadMessageAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
   var channel: ChannelImpl!
   var threadChannel: ThreadChannelImpl!
   var threadMessage: ThreadMessageImpl!
@@ -230,5 +230,37 @@ class ThreadMessageaAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
     let pinnedMessage = try await updatedChannel.getPinnedMessage()
 
     XCTAssertNil(pinnedMessage)
+  }
+
+  // MARK: - Stream Namespace Tests
+
+  func testThreadMessageAsync_Stream_Updates() async throws {
+    let expectation = expectation(description: "Stream_Updates")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    try await Task.sleep(nanoseconds: 3_000_000_000)
+
+    let message = try await threadChannel.getHistory().messages.first
+    let unwrappedMessage = try XCTUnwrap(message)
+
+    let task = Task {
+      for await receivedMessage in threadMessage.stream.updates() {
+        XCTAssertTrue(receivedMessage.hasUserReaction(reaction: "myReaction"))
+        XCTAssertEqual(receivedMessage.channelId, unwrappedMessage.channelId)
+        XCTAssertEqual(receivedMessage.userId, unwrappedMessage.userId)
+        expectation.fulfill()
+      }
+    }
+
+    try await Task.sleep(nanoseconds: 3_000_000_000)
+    _ = try await unwrappedMessage.toggleReaction(reaction: "myReaction")
+
+    await fulfillment(of: [expectation], timeout: 6)
+
+    addTeardownBlock {
+      task.cancel()
+      _ = try? await unwrappedMessage.delete()
+    }
   }
 }

--- a/Tests/AsyncAwait/UserAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/UserAsyncIntegrationTests.swift
@@ -130,32 +130,16 @@ class UserAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
 
   func testUserAsync_Delete() async throws {
     let createdUser = try await chat.createUser(user: testableUser())
-    let deletedUser = try await createdUser.delete(soft: false)
-
-    XCTAssertNil(deletedUser)
+    try await createdUser.delete()
 
     addTeardownBlock { [unowned self] in
       _ = try? await chat.deleteUser(id: createdUser.id)
     }
   }
 
-  func testUserAsync_SoftDelete() async throws {
-    let createdUser = try await chat.createUser(user: testableUser())
-    let deletedUser = try await createdUser.delete(soft: true)
-
-    XCTAssertFalse(deletedUser?.active ?? true)
-    XCTAssertEqual(createdUser.id, deletedUser?.id)
-
-     addTeardownBlock { [unowned self] in
-      _ = try? await chat.deleteUser(id: createdUser.id)
-    }
-  }
-
   func testUserAsync_DeleteNotExistingUser() async throws {
     let someUser = testableUser()
-    let resultValue = try await someUser.delete(soft: false)
-
-    XCTAssertNil(resultValue)
+    try await someUser.delete()
   }
 
   func testUserAsync_WherePresent() async throws {

--- a/Tests/AsyncAwait/UserAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/UserAsyncIntegrationTests.swift
@@ -115,12 +115,11 @@ class UserAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
     let channelId = randomString()
     let createdChannel = try await chat.createChannel(id: channelId, name: channelId)
 
-    // Keeps a strong reference to the returned AsyncStream to prevent it from being deallocated. If this object is not retained,
-    // the AsyncStream will be deallocated, which would cause the behavior being tested to fail.
-    let connectResult = createdChannel.connect()
-    debugPrint(connectResult)
+    createdChannel.chat.pubNub.subscribe(to: [channelId])
 
+    // Allow time for the subscription to register, ensuring the user appears as present on the channel
     try await Task.sleep(nanoseconds: 4_000_000_000)
+
     let isPresent = try await chat.currentUser.isPresentOn(channelId: createdChannel.id)
     XCTAssertTrue(isPresent)
 
@@ -163,11 +162,9 @@ class UserAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
     let channelId = randomString()
     let channel = try await chat.createChannel(id: channelId, name: channelId)
 
-    // Keeps a strong reference to the returned AsyncStream to prevent it from being deallocated. If this object is not retained,
-    // the AsyncStream will be deallocated, which would cause the behavior being tested to fail.
-    let connectResult = channel.connect()
-    debugPrint(connectResult)
+    channel.chat.pubNub.subscribe(to: [channelId])
 
+    // Allow time for the subscription to register, ensuring the user appears as present on the channel
     try await Task.sleep(nanoseconds: 5_000_000_000)
 
     let channelIdentifiers = try await chat.currentUser.wherePresent()

--- a/Tests/AsyncAwait/UserAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/UserAsyncIntegrationTests.swift
@@ -332,4 +332,118 @@ class UserAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
       _ = try? await chat.deleteUser(id: secondUser.id)
     }
   }
+
+  // MARK: - Stream Namespace Tests
+
+  func testUserAsync_Stream_Updates() async throws {
+    let expectation = expectation(description: "Stream_Updates")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    let createdUser = try await chat.createUser(user: testableUser())
+
+    let task = Task {
+      for await updatedUser in createdUser.stream.updates() {
+        XCTAssertEqual(updatedUser.name, "NewName")
+        XCTAssertEqual(updatedUser.status, "NewStatus")
+        expectation.fulfill()
+      }
+    }
+
+    try await Task.sleep(nanoseconds: 3_000_000_000)
+
+    _ = try await createdUser.update(
+      name: "NewName",
+      status: "NewStatus"
+    )
+
+    await fulfillment(of: [expectation], timeout: 6)
+
+    addTeardownBlock { [unowned self] in
+      task.cancel()
+      _ = try? await chat.deleteUser(id: createdUser.id)
+    }
+  }
+
+  func testUserAsync_Stream_Deletions() async throws {
+    let expectation = expectation(description: "Stream_Deletions")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    let createdUser = try await chat.createUser(user: testableUser())
+
+    let task = Task {
+      for await _ in createdUser.stream.deletions() {
+        expectation.fulfill()
+      }
+    }
+
+    try await Task.sleep(nanoseconds: 3_000_000_000)
+    _ = try await createdUser.delete()
+
+    await fulfillment(of: [expectation], timeout: 6)
+
+    addTeardownBlock { [unowned self] in
+      task.cancel()
+      _ = try? await chat.deleteUser(id: createdUser.id)
+    }
+  }
+
+  func testUserAsync_Stream_Mentions() async throws {
+    let expectation = expectation(description: "Stream_Mentions")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    let channel = try await chat.createChannel(id: randomString())
+    _ = try await channel.invite(user: chat.currentUser)
+
+    let task = Task {
+      for await mention in chat.currentUser.stream.mentions() {
+        XCTAssertEqual(mention.channelId, channel.id)
+        expectation.fulfill()
+      }
+    }
+
+    try await Task.sleep(nanoseconds: 3_000_000_000)
+    _ = try await channel.sendText(
+      text: "Hello @\(chat.currentUser.id)",
+      usersToMention: [chat.currentUser.id]
+    )
+
+    await fulfillment(of: [expectation], timeout: 10)
+
+    addTeardownBlock { [unowned self] in
+      task.cancel()
+      _ = try? await chat.deleteChannel(id: channel.id)
+    }
+  }
+
+  func testUserAsync_Stream_Invites() async throws {
+    let expectation = expectation(description: "Stream_Invites")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    let someUser = try await chat.createUser(user: testableUser())
+    let channel = try await chat.createChannel(id: randomString())
+
+    let task = Task {
+      for await invite in someUser.stream.invites() {
+        XCTAssertEqual(invite.channelId, channel.id)
+        expectation.fulfill()
+      }
+    }
+
+    try await Task.sleep(nanoseconds: 3_000_000_000)
+    _ = try await channel.invite(user: someUser)
+
+    await fulfillment(of: [expectation], timeout: 10)
+
+    addTeardownBlock { [unowned self] in
+      task.cancel()
+      _ = try? await chat.deleteChannel(id: channel.id)
+      _ = try? await chat.deleteUser(id: someUser.id)
+    }
+  }
+
+  // swiftlint:disable:next file_length
 }

--- a/Tests/AsyncAwait/UserAsyncIntegrationTests.swift
+++ b/Tests/AsyncAwait/UserAsyncIntegrationTests.swift
@@ -197,6 +197,57 @@ class UserAsyncIntegrationTests: BaseAsyncIntegrationTestCase {
     }
   }
 
+  func testUserAsync_IsMemberOf() async throws {
+    let channel = try await chat.createChannel(id: randomString())
+    let membership = try await channel.invite(user: chat.currentUser)
+    let isMember = try await chat.currentUser.isMemberOf(channelId: channel.id)
+
+    XCTAssertTrue(isMember)
+
+    addTeardownBlock { [unowned self] in
+      _ = try? await chat.deleteChannel(id: channel.id)
+      _ = try? await membership.channel.leave()
+    }
+  }
+
+  func testUserAsync_IsMemberOf_NotMember() async throws {
+    let channel = try await chat.createChannel(id: randomString())
+    let isMember = try await chat.currentUser.isMemberOf(channelId: channel.id)
+
+    XCTAssertFalse(isMember)
+
+    addTeardownBlock { [unowned self] in
+      _ = try? await chat.deleteChannel(id: channel.id)
+    }
+  }
+
+  func testUserAsync_GetMembership() async throws {
+    let channel = try await chat.createChannel(id: randomString())
+    let membership = try await channel.invite(user: chat.currentUser)
+    let retrievedMembership = try await chat.currentUser.getMembership(channelId: channel.id)
+
+    XCTAssertNotNil(retrievedMembership)
+    XCTAssertEqual(retrievedMembership?.user.id, chat.currentUser.id)
+    XCTAssertEqual(retrievedMembership?.channel.id, channel.id)
+
+    addTeardownBlock { [unowned self] in
+      _ = try? await chat.deleteChannel(id: channel.id)
+      _ = try? await membership.channel.leave()
+    }
+  }
+
+  func testUserAsync_GetMembership_NotMember() async throws {
+    let channel = try await chat.createChannel(id: randomString())
+    let membership = try await chat.currentUser.getMembership(channelId: channel.id)
+
+    XCTAssertNil(membership)
+
+    addTeardownBlock { [unowned self] in
+      _ = try? await chat.deleteChannel(id: channel.id)
+      _ = try? await membership?.channel.leave()
+    }
+  }
+
   func testUserAsync_StreamUpdates() async throws {
     let expectation = expectation(description: "StreamUpdates")
     expectation.assertForOverFulfill = true

--- a/Tests/BaseClosureIntegrationTestCase.swift
+++ b/Tests/BaseClosureIntegrationTestCase.swift
@@ -23,7 +23,7 @@ class BaseClosureIntegrationTestCase: BaseIntegrationTestCase {
 
   override func tearDownWithError() throws {
     try customTearDownWithError()
-    try awaitResultValue { chat.deleteUser(id: chat.currentUser.id, completion: $0) }
+    try awaitResult { chat.deleteUser(id: chat.currentUser.id, completion: $0) }
 
     chat = nil
 

--- a/Tests/ChannelGroupIntegrationTests.swift
+++ b/Tests/ChannelGroupIntegrationTests.swift
@@ -43,13 +43,11 @@ final class ChannelGroupIntegrationTests: BaseClosureIntegrationTestCase {
     }
     try awaitResult {
       channel.delete(
-        soft: false,
         completion: $0
       )
     }
     try awaitResult {
       secondChannel.delete(
-        soft: false,
         completion: $0
       )
     }

--- a/Tests/ChannelGroupIntegrationTests.swift
+++ b/Tests/ChannelGroupIntegrationTests.swift
@@ -238,4 +238,77 @@ final class ChannelGroupIntegrationTests: BaseClosureIntegrationTestCase {
       closeable.close()
     }
   }
+
+  func testChannelGroup_OnPresenceChanged() throws {
+    let expectation = expectation(description: "OnPresenceChanged")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    try awaitResultValue {
+      channelGroup.add(
+        channels: [channel, secondChannel],
+        completion: $0
+      )
+    }
+
+    let presenceCloseable = channelGroup.onPresenceChanged { [unowned self] in
+      if $0.count == 2 {
+        XCTAssertEqual($0[channel.id], [chat.currentUser.id])
+        XCTAssertEqual($0[secondChannel.id], [chat.currentUser.id])
+        expectation.fulfill()
+      }
+    }
+
+    // Allow time for the subscription to register, ensuring the user appears as present on the channel group
+    DispatchQueue.global().asyncAfter(deadline: .now() + 2) { [weak self] in
+      self?.channel.chat.pubNub.subscribe(
+        to: [self?.randomString() ?? ""],
+        and: [self?.channelGroup.id ?? ""]
+      )
+    }
+
+    wait(
+      for: [expectation],
+      timeout: 7
+    )
+
+    addTeardownBlock {
+      presenceCloseable.close()
+    }
+  }
+
+  func testChannelGroup_OnMessageReceived() throws {
+    let expectation = XCTestExpectation(description: "OnMessageReceived")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    try awaitResultValue {
+      channelGroup.add(
+        channels: [channel, secondChannel],
+        completion: $0
+      )
+    }
+
+    let closeable = channelGroup.onMessageReceived { [unowned self] in
+      XCTAssertEqual($0.text, "This is a text")
+      XCTAssertEqual($0.channelId, channel.id)
+      expectation.fulfill()
+    }
+
+    try awaitResultValue(delay: 4) {
+      channel.sendText(
+        text: "This is a text",
+        completion: $0
+      )
+    }
+
+    wait(
+      for: [expectation],
+      timeout: 6
+    )
+
+    addTeardownBlock {
+      closeable.close()
+    }
+  }
 }

--- a/Tests/ChannelIntegrationTests.swift
+++ b/Tests/ChannelIntegrationTests.swift
@@ -201,11 +201,7 @@ class ChannelIntegrationTests: BaseClosureIntegrationTestCase {
   }
 
   func testChannel_WhoIsPresent() throws {
-    let joinValue = try awaitResultValue {
-      channel.join(
-        completion: $0
-      )
-    }
+    channel.chat.pubNub.subscribe(to: [channel.id])
 
     let whoIsPresentValue = try awaitResultValue(delay: 4) {
       channel.whoIsPresent(
@@ -215,18 +211,10 @@ class ChannelIntegrationTests: BaseClosureIntegrationTestCase {
 
     XCTAssertEqual(whoIsPresentValue.count, 1)
     XCTAssertEqual(whoIsPresentValue.first, chat.currentUser.id)
-
-    addTeardownBlock {
-      joinValue.disconnect?.close()
-    }
   }
 
   func testChannel_IsPresent() throws {
-    let joinValue = try awaitResultValue {
-      channel.join(
-        completion: $0
-      )
-    }
+    channel.chat.pubNub.subscribe(to: [channel.id])
 
     XCTAssertTrue(try awaitResultValue(delay: 3) {
       channel.isPresent(
@@ -234,10 +222,6 @@ class ChannelIntegrationTests: BaseClosureIntegrationTestCase {
         completion: $0
       )
     })
-
-    addTeardownBlock {
-      joinValue.disconnect?.close()
-    }
   }
 
   func testChannel_GetHistory() throws {
@@ -559,42 +543,18 @@ class ChannelIntegrationTests: BaseClosureIntegrationTestCase {
   }
 
   func testChannel_Join() throws {
-    let expectation = XCTestExpectation(description: "Connect")
-    expectation.assertForOverFulfill = true
-    expectation.expectedFulfillmentCount = 1
-
-    let joinValue = try awaitResultValue { [unowned self] in
+    let membership = try awaitResultValue {
       channel.join(
-        callback: {
-          XCTAssertEqual($0.text, "This is a text")
-          XCTAssertEqual($0.channelId, self.channel.id)
-          expectation.fulfill()
-        },
         completion: $0
       )
     }
 
-    XCTAssertEqual(joinValue.membership.channel.id, channel.id)
-    XCTAssertEqual(joinValue.membership.user.id, chat.currentUser.id)
-
-    try awaitResultValue(delay: 3) {
-      channel.sendText(
-        text: "This is a text",
-        completion: $0
-      )
-    }
-
-    wait(
-      for: [expectation],
-      timeout: 7
-    )
-    addTeardownBlock {
-      joinValue.disconnect?.close()
-    }
+    XCTAssertEqual(membership.channel.id, channel.id)
+    XCTAssertEqual(membership.user.id, chat.currentUser.id)
   }
 
   func testChannel_Leave() throws {
-    let joinValue = try awaitResultValue {
+    try awaitResultValue {
       channel.join(
         completion: $0
       )
@@ -611,10 +571,6 @@ class ChannelIntegrationTests: BaseClosureIntegrationTestCase {
         )
       }.memberships.isEmpty
     )
-
-    addTeardownBlock {
-      joinValue.disconnect?.close()
-    }
   }
 
   func testChannel_PinMessageGetPinnedMessage() throws {
@@ -923,10 +879,6 @@ class ChannelIntegrationTests: BaseClosureIntegrationTestCase {
     expectation.assertForOverFulfill = true
     expectation.expectedFulfillmentCount = 1
 
-    let connectCloseable = channel.connect(callback: {
-      debugPrint("Did receive message: \($0)")
-    })
-
     let presenceCloseable = channel.streamPresence { [unowned self] in
       if !$0.isEmpty {
         XCTAssertEqual($0.count, 1)
@@ -935,13 +887,17 @@ class ChannelIntegrationTests: BaseClosureIntegrationTestCase {
       }
     }
 
+    // Allow time for the subscription to register, ensuring the user appears as present on the channel
+    DispatchQueue.global().asyncAfter(deadline: .now() + 2) { [weak self] in
+      self?.channel.chat.pubNub.subscribe(to: [self?.channel.id ?? ""])
+    }
+
     wait(
       for: [expectation],
-      timeout: 5
+      timeout: 6
     )
     addTeardownBlock {
       presenceCloseable.close()
-      connectCloseable.close()
     }
   }
 
@@ -1163,9 +1119,10 @@ class ChannelIntegrationTests: BaseClosureIntegrationTestCase {
       }
     }
 
-    let connectCloseable = channel.connect(callback: {
-      debugPrint("Did receive message: \($0)")
-    })
+    // Allow time for the subscription to register, ensuring the user appears as present on the channel
+    DispatchQueue.global().asyncAfter(deadline: .now() + 2) { [weak self] in
+      self?.channel.chat.pubNub.subscribe(to: [self?.channel.id ?? ""])
+    }
 
     wait(
       for: [expectation],
@@ -1173,7 +1130,71 @@ class ChannelIntegrationTests: BaseClosureIntegrationTestCase {
     )
     addTeardownBlock {
       presenceCloseable.close()
-      connectCloseable.close()
+    }
+  }
+
+  func testChannel_OnCustomEvent() throws {
+    let expectation = expectation(description: "OnCustomEvent")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    let closeable = channel.onCustomEvent { [unowned self] event in
+      XCTAssertEqual(event.userId, chat.currentUser.id)
+      XCTAssertEqual(event.payload["key"]?.stringOptional, "value")
+      expectation.fulfill()
+    }
+
+    try awaitResultValue(delay: 2) {
+      channel.emitCustomEvent(
+        payload: ["key": "value"],
+        completion: $0
+      )
+    }
+
+    wait(
+      for: [expectation],
+      timeout: 10
+    )
+    addTeardownBlock {
+      closeable.close()
+    }
+  }
+
+  func testChannel_OnCustomEvent_WithMessageTypeFilter() throws {
+    let expectation = expectation(description: "OnCustomEvent_Filtered")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    let closeable = channel.onCustomEvent(messageType: "myType") { [unowned self] event in
+      XCTAssertEqual(event.payload["key"]?.stringOptional, "value")
+      XCTAssertEqual(event.userId, chat.currentUser.id)
+      expectation.fulfill()
+    }
+
+    // Emit with a different type first - should not trigger
+    try awaitResultValue(delay: 2) {
+      channel.emitCustomEvent(
+        payload: ["key": "other"],
+        messageType: "otherType",
+        completion: $0
+      )
+    }
+
+    // Emit with the matching type - should trigger
+    try awaitResultValue(delay: 1) {
+      channel.emitCustomEvent(
+        payload: ["key": "value"],
+        messageType: "myType",
+        completion: $0
+      )
+    }
+
+    wait(
+      for: [expectation],
+      timeout: 10
+    )
+    addTeardownBlock {
+      closeable.close()
     }
   }
 

--- a/Tests/ChannelIntegrationTests.swift
+++ b/Tests/ChannelIntegrationTests.swift
@@ -743,35 +743,51 @@ class ChannelIntegrationTests: BaseClosureIntegrationTestCase {
     expectation.assertForOverFulfill = true
     expectation.expectedFulfillmentCount = 1
 
-    let joinResult = try awaitResultValue { channel.join(completion: $0) }
-    let membership = joinResult.membership
-    let currentUserId = chat.currentUser.id
-
-    let messageTimetoken = try awaitResultValue {
-      channel.sendText(
-        text: "Read receipt test",
+    let anotherUser = try awaitResultValue {
+      chat.createUser(
+        user: UserImpl(chat: chat, id: randomString()),
+        completion: $0
+      )
+    }
+    let membership = try awaitResultValue(delay: 3) {
+      channel.invite(
+        user: chat.currentUser,
+        completion: $0
+      )
+    }
+    let anotherMembership = try awaitResultValue(delay: 1) {
+      channel.invite(
+        user: anotherUser,
         completion: $0
       )
     }
 
-    let closeable = channel.streamReadReceipts { readReceipt in
-      XCTAssertEqual(readReceipt.userId, currentUserId)
-      XCTAssertEqual(readReceipt.lastReadTimetoken, messageTimetoken)
+    let timetoken = try XCTUnwrap(membership.lastReadMessageTimetoken)
+    let secondTimetoken = try XCTUnwrap(anotherMembership.lastReadMessageTimetoken)
+    let currentUserId = chat.currentUser.id
+    let anotherUserId = anotherUser.id
+
+    let closeable = channel.streamReadReceipts {
+      XCTAssertEqual($0[timetoken]?.count, 1)
+      XCTAssertEqual($0[timetoken]?.first, currentUserId)
+      XCTAssertEqual($0[secondTimetoken]?.count, 1)
+      XCTAssertEqual($0[secondTimetoken]?.first, anotherUserId)
       expectation.fulfill()
     }
 
-    _ = try awaitResultValue(delay: 1) {
-      membership.setLastReadMessageTimetoken(
-        messageTimetoken,
-        completion: $0
-      )
-    }
+    wait(
+      for: [expectation],
+      timeout: 6
+    )
 
-    wait(for: [expectation], timeout: 6)
-
-    addTeardownBlock {
+    addTeardownBlock { [unowned self] in
       closeable.close()
-      joinResult.disconnect?.close()
+      try awaitResult {
+        chat.deleteUser(
+          id: anotherUserId,
+          completion: $0
+        )
+      }
     }
   }
 
@@ -1015,6 +1031,189 @@ class ChannelIntegrationTests: BaseClosureIntegrationTestCase {
     addTeardownBlock { [unowned self] in
       closeable.close()
       try awaitResult { message?.delete(completion: $0) }
+    }
+  }
+
+  // MARK: - Entity-first streaming API tests
+
+  func testChannel_OnUpdated() throws {
+    let expectation = expectation(description: "OnUpdated")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    let closeable = channel.onUpdated { updatedChannel in
+      XCTAssertEqual(updatedChannel.name, "NewName")
+      XCTAssertEqual(updatedChannel.status, "NewStatus")
+      expectation.fulfill()
+    }
+
+    try awaitResultValue(delay: 3) {
+      channel.update(
+        name: "NewName",
+        status: "NewStatus",
+        completion: $0
+      )
+    }
+
+    wait(
+      for: [expectation],
+      timeout: 6
+    )
+    addTeardownBlock {
+      closeable.close()
+    }
+  }
+
+  func testChannel_OnDeleted() throws {
+    let expectation = expectation(description: "OnDeleted")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    let channelToDelete = try awaitResultValue {
+      chat.createChannel(
+        id: randomString(),
+        completion: $0
+      )
+    }
+
+    let closeable = channelToDelete.onDeleted {
+      expectation.fulfill()
+    }
+
+    try awaitResultValue(delay: 3) {
+      channelToDelete.delete(
+        soft: false,
+        completion: $0
+      )
+    }
+
+    wait(
+      for: [expectation],
+      timeout: 6
+    )
+    addTeardownBlock {
+      closeable.close()
+    }
+  }
+
+  func testChannel_OnMessageReceived() throws {
+    let expectation = XCTestExpectation(description: "OnMessageReceived")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    let closeable = channel.onMessageReceived { [unowned self] in
+      XCTAssertEqual($0.text, "This is a text")
+      XCTAssertEqual($0.channelId, channel.id)
+      expectation.fulfill()
+    }
+
+    try awaitResultValue(delay: 3) {
+      channel.sendText(
+        text: "This is a text",
+        completion: $0
+      )
+    }
+
+    wait(
+      for: [expectation],
+      timeout: 6
+    )
+    addTeardownBlock {
+      closeable.close()
+    }
+  }
+
+  func testChannel_OnTypingChanged() throws {
+    let expectation = expectation(description: "OnTypingChanged")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    let closeable = channel.onTypingChanged { [unowned self] typingUsers in
+      if !typingUsers.isEmpty {
+        XCTAssertTrue(typingUsers.contains(chat.currentUser.id))
+        expectation.fulfill()
+      }
+    }
+
+    try awaitResultValue(delay: 3) {
+      channel.startTyping(
+        completion: $0
+      )
+    }
+
+    wait(
+      for: [expectation],
+      timeout: 6
+    )
+    addTeardownBlock {
+      closeable.close()
+    }
+  }
+
+  func testChannel_OnPresenceChanged() throws {
+    let expectation = expectation(description: "OnPresenceChanged")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    let presenceCloseable = channel.onPresenceChanged { [unowned self] userIds in
+      if !userIds.isEmpty {
+        XCTAssertEqual(userIds.count, 1)
+        XCTAssertEqual(userIds.first, chat.currentUser.id)
+        expectation.fulfill()
+      }
+    }
+
+    let connectCloseable = channel.connect(callback: {
+      debugPrint("Did receive message: \($0)")
+    })
+
+    wait(
+      for: [expectation],
+      timeout: 5
+    )
+    addTeardownBlock {
+      presenceCloseable.close()
+      connectCloseable.close()
+    }
+  }
+
+  func testChannel_OnReadReceiptReceived() throws {
+    let expectation = expectation(description: "OnReadReceiptReceived")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    let membership = try awaitResultValue(delay: 3) {
+      channel.invite(
+        user: chat.currentUser,
+        completion: $0
+      )
+    }
+
+    let closeable = channel.onReadReceiptReceived { receipt in
+      XCTAssertEqual(receipt.userId, membership.user.id)
+      expectation.fulfill()
+    }
+
+    let timetoken = try awaitResultValue(delay: 3) {
+      channel.sendText(
+        text: "Test message",
+        completion: $0
+      )
+    }
+
+    try awaitResultValue(delay: 1) {
+      membership.setLastReadMessageTimetoken(
+        timetoken,
+        completion: $0
+      )
+    }
+
+    wait(
+      for: [expectation],
+      timeout: 10
+    )
+    addTeardownBlock {
+      closeable.close()
     }
   }
 

--- a/Tests/ChannelIntegrationTests.swift
+++ b/Tests/ChannelIntegrationTests.swift
@@ -66,7 +66,6 @@ class ChannelIntegrationTests: BaseClosureIntegrationTestCase {
     }
     try awaitResult {
       someChannel.delete(
-        soft: false,
         completion: $0
       )
     }
@@ -78,39 +77,6 @@ class ChannelIntegrationTests: BaseClosureIntegrationTestCase {
         )
       }
     )
-
-    addTeardownBlock { [unowned self] in
-      try awaitResult {
-        chat.deleteChannel(
-          id: someChannel.id,
-          completion: $0
-        )
-      }
-    }
-  }
-
-  func testChannel_SoftDelete() throws {
-    let someChannel = try awaitResultValue {
-      chat.createChannel(
-        id: randomString(),
-        completion: $0
-      )
-    }
-
-    try awaitResult {
-      someChannel.delete(
-        soft: true,
-        completion: $0
-      )
-    }
-    let retrievedChannel = try awaitResultValue {
-      chat.getChannel(
-        channelId: someChannel.id,
-        completion: $0
-      )
-    }
-
-    XCTAssertEqual(retrievedChannel?.id, someChannel.id)
 
     addTeardownBlock { [unowned self] in
       try awaitResult {
@@ -1034,9 +1000,8 @@ class ChannelIntegrationTests: BaseClosureIntegrationTestCase {
       expectation.fulfill()
     }
 
-    try awaitResultValue(delay: 3) {
+    try awaitResult(delay: 3) {
       channelToDelete.delete(
-        soft: false,
         completion: $0
       )
     }

--- a/Tests/ChannelIntegrationTests.swift
+++ b/Tests/ChannelIntegrationTests.swift
@@ -110,7 +110,6 @@ class ChannelIntegrationTests: BaseClosureIntegrationTestCase {
       )
     }
 
-    XCTAssertFalse(retrievedChannel?.active ?? true)
     XCTAssertEqual(retrievedChannel?.id, someChannel.id)
 
     addTeardownBlock { [unowned self] in
@@ -744,51 +743,35 @@ class ChannelIntegrationTests: BaseClosureIntegrationTestCase {
     expectation.assertForOverFulfill = true
     expectation.expectedFulfillmentCount = 1
 
-    let anotherUser = try awaitResultValue {
-      chat.createUser(
-        user: UserImpl(chat: chat, id: randomString()),
-        completion: $0
-      )
-    }
-    let membership = try awaitResultValue(delay: 3) {
-      channel.invite(
-        user: chat.currentUser,
-        completion: $0
-      )
-    }
-    let anotherMembership = try awaitResultValue(delay: 1) {
-      channel.invite(
-        user: anotherUser,
-        completion: $0
-      )
-    }
-
-    let timetoken = try XCTUnwrap(membership.lastReadMessageTimetoken)
-    let secondTimetoken = try XCTUnwrap(anotherMembership.lastReadMessageTimetoken)
+    let joinResult = try awaitResultValue { channel.join(completion: $0) }
+    let membership = joinResult.membership
     let currentUserId = chat.currentUser.id
-    let anotherUserId = anotherUser.id
 
-    let closeable = channel.streamReadReceipts {
-      XCTAssertEqual($0[timetoken]?.count, 1)
-      XCTAssertEqual($0[timetoken]?.first, currentUserId)
-      XCTAssertEqual($0[secondTimetoken]?.count, 1)
-      XCTAssertEqual($0[secondTimetoken]?.first, anotherUserId)
+    let messageTimetoken = try awaitResultValue {
+      channel.sendText(
+        text: "Read receipt test",
+        completion: $0
+      )
+    }
+
+    let closeable = channel.streamReadReceipts { readReceipt in
+      XCTAssertEqual(readReceipt.userId, currentUserId)
+      XCTAssertEqual(readReceipt.lastReadTimetoken, messageTimetoken)
       expectation.fulfill()
     }
 
-    wait(
-      for: [expectation],
-      timeout: 6
-    )
+    _ = try awaitResultValue(delay: 1) {
+      membership.setLastReadMessageTimetoken(
+        messageTimetoken,
+        completion: $0
+      )
+    }
 
-    addTeardownBlock { [unowned self] in
+    wait(for: [expectation], timeout: 6)
+
+    addTeardownBlock {
       closeable.close()
-      try awaitResult {
-        chat.deleteUser(
-          id: anotherUserId,
-          completion: $0
-        )
-      }
+      joinResult.disconnect?.close()
     }
   }
 

--- a/Tests/ChannelIntegrationTests.swift
+++ b/Tests/ChannelIntegrationTests.swift
@@ -990,8 +990,6 @@ class ChannelIntegrationTests: BaseClosureIntegrationTestCase {
     }
   }
 
-  // MARK: - Entity-first streaming API tests
-
   func testChannel_OnUpdated() throws {
     let expectation = expectation(description: "OnUpdated")
     expectation.assertForOverFulfill = true
@@ -1236,6 +1234,32 @@ class ChannelIntegrationTests: BaseClosureIntegrationTestCase {
     addTeardownBlock {
       closeable.close()
     }
+  }
+
+  func testChannel_SendTextWithParams() throws {
+    let params = SendTextParams(
+      meta: ["x": 42, "y": "hello"],
+      shouldStore: true
+    )
+
+    let tt = try awaitResultValue {
+      channel.sendText(
+        text: "Params text",
+        params: params,
+        completion: $0
+      )
+    }
+
+    let retrievedMessage = try awaitResultValue(delay: 2) {
+      channel.getMessage(
+        timetoken: tt,
+        completion: $0
+      )
+    }
+
+    XCTAssertEqual(retrievedMessage?.text, "Params text")
+    XCTAssertEqual(retrievedMessage?.meta?["x"]?.codableValue.rawValue as? Int, 42)
+    XCTAssertEqual(retrievedMessage?.meta?["y"]?.codableValue.rawValue as? String, "hello")
   }
 
   // swiftlint:disable:next file_length

--- a/Tests/ChannelIntegrationTests.swift
+++ b/Tests/ChannelIntegrationTests.swift
@@ -517,6 +517,7 @@ class ChannelIntegrationTests: BaseClosureIntegrationTestCase {
 
     XCTAssertEqual(membership.channel.id, channel.id)
     XCTAssertEqual(membership.user.id, chat.currentUser.id)
+    XCTAssertEqual(membership.status, "")
   }
 
   func testChannel_Leave() throws {
@@ -1198,6 +1199,56 @@ class ChannelIntegrationTests: BaseClosureIntegrationTestCase {
     )
     addTeardownBlock {
       closeable.close()
+    }
+  }
+
+  func testChannel_GetInvitees() throws {
+    let someUser = UserImpl(
+      chat: chat,
+      id: randomString()
+    )
+
+    try awaitResultValue {
+      chat.createUser(
+        user: someUser,
+        completion: $0
+      )
+    }
+
+    try awaitResultValue {
+      channel.inviteMultiple(
+        users: [chat.currentUser, someUser],
+        completion: $0
+      )
+    }
+
+    let invitees = try XCTUnwrap(
+      awaitResultValue {
+        channel.getInvitees(
+          completion: $0
+        )
+      }.memberships
+    )
+
+    let firstMatch = try XCTUnwrap(
+      invitees.first {
+        $0.user.id == chat.currentUser.id && $0.channel.id == channel.id
+      }
+    )
+    let secondMatch = try XCTUnwrap(
+      invitees.first {
+        $0.user.id == someUser.id && $0.channel.id == channel.id
+      }
+    )
+
+    XCTAssertEqual(invitees.count, 2)
+    XCTAssertNotNil(firstMatch)
+    XCTAssertNotNil(secondMatch)
+
+    addTeardownBlock { [unowned self] in
+      try awaitResult {
+        chat.deleteUser(id: someUser.id, completion: $0)
+      }
     }
   }
 

--- a/Tests/ChatIntegrationTests.swift
+++ b/Tests/ChatIntegrationTests.swift
@@ -269,15 +269,10 @@ class ChatIntegrationTests: BaseClosureIntegrationTestCase {
   func testChat_IsPresent() throws {
     let channelId = randomString()
     let channel = try awaitResultValue { chat.createChannel(id: channelId, name: channelId, completion: $0) }
-    let closeable = channel.connect(callback: { _ in })
 
-    let joinValue = try awaitResultValue {
-      channel.join(
-        completion: $0
-      )
-    }
+    channel.chat.pubNub.subscribe(to: [channelId])
 
-    XCTAssertTrue(try awaitResultValue(delay: 3) {
+    XCTAssertTrue(try awaitResultValue(delay: 4) {
       chat.isPresent(
         userId: chat.currentUser.id,
         channelId: channelId,
@@ -286,9 +281,6 @@ class ChatIntegrationTests: BaseClosureIntegrationTestCase {
     })
 
     addTeardownBlock { [unowned self] in
-      joinValue.disconnect?.close()
-      closeable.close()
-
       try awaitResult {
         chat.deleteChannel(
           id: channelId,
@@ -551,11 +543,9 @@ class ChatIntegrationTests: BaseClosureIntegrationTestCase {
         completion: $0
       )
     }
-    let joinValue = try awaitResultValue {
-      channel.join(
-        completion: $0
-      )
-    }
+
+    channel.chat.pubNub.subscribe(to: [channel.id])
+
     let whoIsPresentValue = try awaitResultValue(delay: 4) {
       chat.whoIsPresent(
         channelId: channel.id,
@@ -567,7 +557,6 @@ class ChatIntegrationTests: BaseClosureIntegrationTestCase {
     XCTAssertEqual(whoIsPresentValue.first, chat.currentUser.id)
 
     addTeardownBlock { [unowned self] in
-      joinValue.disconnect?.close()
       try awaitResult {
         chat.deleteChannel(
           id: channel.id,

--- a/Tests/ChatIntegrationTests.swift
+++ b/Tests/ChatIntegrationTests.swift
@@ -215,7 +215,7 @@ class ChatIntegrationTests: BaseClosureIntegrationTestCase {
         completion: $0
       )
     }
-    try awaitResultValue {
+    try awaitResult {
       chat.deleteUser(
         id: user.id,
         completion: $0
@@ -509,7 +509,7 @@ class ChatIntegrationTests: BaseClosureIntegrationTestCase {
         completion: $0
       )
     }
-    try awaitResultValue {
+    try awaitResult {
       chat.deleteChannel(
         id: channel.id,
         completion: $0

--- a/Tests/MembershipIntegrationTests.swift
+++ b/Tests/MembershipIntegrationTests.swift
@@ -185,4 +185,82 @@ final class MembershipTests: BaseClosureIntegrationTestCase {
       closeable.close()
     }
   }
+
+  // MARK: - Entity-first streaming API tests
+
+  func testMembership_OnUpdated() throws {
+    let expectation = expectation(description: "OnUpdated")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    let expectedCustom: [String: JSONCodableScalar] = [
+      "a": 1,
+      "b": "Text"
+    ]
+
+    let closeable = membership.onUpdated { [unowned self] updatedMembership in
+      XCTAssertEqual(updatedMembership.channel.id, membership.channel.id)
+      XCTAssertEqual(updatedMembership.user.id, membership.user.id)
+      XCTAssertEqual(updatedMembership.custom?.mapValues { $0.scalarValue }, expectedCustom.mapValues { $0.scalarValue })
+      expectation.fulfill()
+    }
+
+    try awaitResultValue(delay: 3) {
+      membership.update(
+        custom: expectedCustom,
+        completion: $0
+      )
+    }
+
+    wait(
+      for: [expectation],
+      timeout: 6
+    )
+    addTeardownBlock {
+      closeable.close()
+    }
+  }
+
+  func testMembership_OnDeleted() throws {
+    let expectation = expectation(description: "OnDeleted")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    let anotherChannel = try awaitResultValue {
+      chat.createChannel(
+        id: randomString(),
+        completion: $0
+      )
+    }
+    let anotherMembership = try awaitResultValue {
+      anotherChannel.invite(
+        user: chat.currentUser,
+        completion: $0
+      )
+    }
+
+    let closeable = anotherMembership.onDeleted {
+      expectation.fulfill()
+    }
+
+    try awaitResultValue(delay: 3) {
+      anotherChannel.leave(
+        completion: $0
+      )
+    }
+
+    wait(
+      for: [expectation],
+      timeout: 6
+    )
+    addTeardownBlock { [unowned self] in
+      closeable.close()
+      try awaitResult {
+        chat.deleteChannel(
+          id: anotherChannel.id,
+          completion: $0
+        )
+      }
+    }
+  }
 }

--- a/Tests/MembershipIntegrationTests.swift
+++ b/Tests/MembershipIntegrationTests.swift
@@ -186,8 +186,6 @@ final class MembershipTests: BaseClosureIntegrationTestCase {
     }
   }
 
-  // MARK: - Entity-first streaming API tests
-
   func testMembership_OnUpdated() throws {
     let expectation = expectation(description: "OnUpdated")
     expectation.assertForOverFulfill = true

--- a/Tests/MembershipIntegrationTests.swift
+++ b/Tests/MembershipIntegrationTests.swift
@@ -119,6 +119,45 @@ final class MembershipTests: BaseClosureIntegrationTestCase {
     )
   }
 
+  func testMembership_Delete() throws {
+    let someChannel = try awaitResultValue {
+      chat.createChannel(
+        id: randomString(),
+        completion: $0
+      )
+    }
+    let someMembership = try awaitResultValue {
+      someChannel.invite(
+        user: chat.currentUser,
+        completion: $0
+      )
+    }
+
+    try awaitResult {
+      someMembership.delete(
+        completion: $0
+      )
+    }
+
+    let isMember = try awaitResultValue {
+      chat.currentUser.isMemberOf(
+        channelId: someChannel.id,
+        completion: $0
+      )
+    }
+
+    XCTAssertFalse(isMember)
+
+    addTeardownBlock { [unowned self] in
+      try awaitResult {
+        chat.deleteChannel(
+          id: someChannel.id,
+          completion: $0
+        )
+      }
+    }
+  }
+
   func testMembership_StreamUpdates() throws {
     let expectation = expectation(description: "MembershipStreamUpdates")
     expectation.assertForOverFulfill = true

--- a/Tests/MembershipIntegrationTests.swift
+++ b/Tests/MembershipIntegrationTests.swift
@@ -73,6 +73,8 @@ final class MembershipTests: BaseClosureIntegrationTestCase {
     let newValue = try awaitResultValue {
       membership.update(
         custom: newCustom,
+        status: "active",
+        type: "premium",
         completion: $0
       )
     }
@@ -80,6 +82,8 @@ final class MembershipTests: BaseClosureIntegrationTestCase {
       newCustom.mapValues { $0.scalarValue },
       newValue.custom?.mapValues { $0.scalarValue }
     )
+    XCTAssertEqual(newValue.status, "active")
+    XCTAssertEqual(newValue.type, "premium")
   }
 
   func testMembership_SetLastReadMessageTimetoken() throws {

--- a/Tests/MembershipIntegrationTests.swift
+++ b/Tests/MembershipIntegrationTests.swift
@@ -78,10 +78,12 @@ final class MembershipTests: BaseClosureIntegrationTestCase {
         completion: $0
       )
     }
+
     XCTAssertEqual(
       newCustom.mapValues { $0.scalarValue },
-      newValue.custom?.mapValues { $0.scalarValue }
+      newValue.custom?.filter { newCustom.keys.contains($0.key) }.mapValues { $0.scalarValue }
     )
+
     XCTAssertEqual(newValue.status, "active")
     XCTAssertEqual(newValue.type, "premium")
   }
@@ -175,7 +177,10 @@ final class MembershipTests: BaseClosureIntegrationTestCase {
     let closeable = membership.streamUpdates { [unowned self] membership in
       XCTAssertEqual(membership?.channel.id, self.membership.channel.id)
       XCTAssertEqual(membership?.user.id, self.membership.user.id)
-      XCTAssertEqual(membership?.custom?.mapValues { $0.scalarValue }, expectedCustom.mapValues { $0.scalarValue })
+      XCTAssertEqual(
+        membership?.custom?.filter { expectedCustom.keys.contains($0.key) }.mapValues { $0.scalarValue },
+        expectedCustom.mapValues { $0.scalarValue }
+      )
       expectation.fulfill()
     }
 
@@ -209,7 +214,10 @@ final class MembershipTests: BaseClosureIntegrationTestCase {
       let receivedMembership = $0[0]
       XCTAssertEqual(receivedMembership.channel.id, membership.channel.id)
       XCTAssertEqual(receivedMembership.user.id, membership.user.id)
-      XCTAssertEqual(receivedMembership.custom?.mapValues { $0.scalarValue }, expectedCustom.mapValues { $0.scalarValue })
+      XCTAssertEqual(
+        receivedMembership.custom?.filter { expectedCustom.keys.contains($0.key) }.mapValues { $0.scalarValue },
+        expectedCustom.mapValues { $0.scalarValue }
+      )
       expectation.fulfill()
     }
 
@@ -242,7 +250,10 @@ final class MembershipTests: BaseClosureIntegrationTestCase {
     let closeable = membership.onUpdated { [unowned self] updatedMembership in
       XCTAssertEqual(updatedMembership.channel.id, membership.channel.id)
       XCTAssertEqual(updatedMembership.user.id, membership.user.id)
-      XCTAssertEqual(updatedMembership.custom?.mapValues { $0.scalarValue }, expectedCustom.mapValues { $0.scalarValue })
+      XCTAssertEqual(
+        updatedMembership.custom?.filter { expectedCustom.keys.contains($0.key) }.mapValues { $0.scalarValue },
+        expectedCustom.mapValues { $0.scalarValue }
+      )
       expectation.fulfill()
     }
 

--- a/Tests/MessageDraftIntegrationTests.swift
+++ b/Tests/MessageDraftIntegrationTests.swift
@@ -354,4 +354,31 @@ class MessageDraftIntegrationTests: BaseClosureIntegrationTestCase {
     XCTAssertEqual(receivedQuotedMessage.timetoken, 17_296_737_530_374_172)
     XCTAssertEqual(receivedQuotedMessage.text, "Lorem ipsum")
   }
+
+  func testMessageDraft_SendWithParams() throws {
+    let messageDraft = channel.createMessageDraft()
+    messageDraft.update(text: "Draft with params")
+
+    let params = SendTextParams(
+      meta: ["draft": "test"],
+      shouldStore: true
+    )
+
+    let timetoken = try awaitResultValue {
+      messageDraft.send(
+        params: params,
+        completion: $0
+      )
+    }
+
+    let message = try awaitResultValue(delay: 2) {
+      channel.getMessage(
+        timetoken: timetoken,
+        completion: $0
+      )
+    }
+
+    XCTAssertEqual(message?.text, "Draft with params")
+    XCTAssertEqual(message?.meta?["draft"]?.stringOptional, "test")
+  }
 }

--- a/Tests/MessageIntegrationTests.swift
+++ b/Tests/MessageIntegrationTests.swift
@@ -300,6 +300,49 @@ final class MessageIntegrationTests: BaseClosureIntegrationTestCase {
     }
   }
 
+  func testMessage_CreateThreadWithResult() throws {
+    let params = SendTextParams(
+      meta: ["key": "value"],
+      shouldStore: true
+    )
+
+    let result = try awaitResultValue {
+      testMessage.createThreadWithResult(
+        text: "Thread reply with params",
+        params: params,
+        completion: $0
+      )
+    }
+
+    XCTAssertTrue(result.parentMessage.hasThread)
+    XCTAssertEqual(result.threadChannel.parentChannelId, testMessage.channelId)
+
+    let threadChannelHistory = try awaitResultValue(delay: 4) {
+      result.threadChannel.getHistory(
+        completion: $0
+      )
+    }
+
+    let retrievedThreadMessage = try XCTUnwrap(threadChannelHistory.messages.first)
+
+    XCTAssertEqual(retrievedThreadMessage.text, "Thread reply with params")
+    XCTAssertEqual(retrievedThreadMessage.meta?.count, 1)
+    XCTAssertEqual(retrievedThreadMessage.meta?["key"]?.stringOptional, "value")
+
+    addTeardownBlock { [unowned self] in
+      try awaitResult {
+        retrievedThreadMessage.delete(
+          completion: $0
+        )
+      }
+      try awaitResult {
+        testMessage.removeThread(
+          completion: $0
+        )
+      }
+    }
+  }
+
   func testMessage_RemoveThread() throws {
     let threadChannel = try awaitResultValue {
       testMessage.createThread(
@@ -479,8 +522,6 @@ final class MessageIntegrationTests: BaseClosureIntegrationTestCase {
 
     XCTAssertTrue(restoredMessage.actions?.isEmpty ?? false)
   }
-
-  // MARK: - Entity-first streaming API tests
 
   func testMessage_OnUpdated() throws {
     let expectation = expectation(description: "OnUpdated")

--- a/Tests/MessageIntegrationTests.swift
+++ b/Tests/MessageIntegrationTests.swift
@@ -480,5 +480,51 @@ final class MessageIntegrationTests: BaseClosureIntegrationTestCase {
     XCTAssertTrue(restoredMessage.actions?.isEmpty ?? false)
   }
 
+  // MARK: - Entity-first streaming API tests
+
+  func testMessage_OnUpdated() throws {
+    let expectation = expectation(description: "OnUpdated")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    let timetoken = try awaitResultValue {
+      channel?.sendText(
+        text: "Some text \(randomString())",
+        completion: $0
+      )
+    }
+    let message = try XCTUnwrap(
+      awaitResultValue(delay: 3) {
+        channel.getMessage(
+          timetoken: timetoken,
+          completion: $0
+        )
+      }
+    )
+
+    let closeable = message.onUpdated {
+      XCTAssertTrue($0.hasUserReaction(reaction: "myReaction"))
+      XCTAssertEqual($0.channelId, message.channelId)
+      XCTAssertEqual($0.userId, message.userId)
+      expectation.fulfill()
+    }
+
+    try awaitResultValue(delay: 3) {
+      message.toggleReaction(
+        reaction: "myReaction",
+        completion: $0
+      )
+    }
+
+    wait(
+      for: [expectation],
+      timeout: 6
+    )
+    addTeardownBlock { [unowned self] in
+      closeable.close()
+      try awaitResult { message.delete(completion: $0) }
+    }
+  }
+
   // swiftlint:disable:next file_length
 }

--- a/Tests/MessageIntegrationTests.swift
+++ b/Tests/MessageIntegrationTests.swift
@@ -359,10 +359,12 @@ final class MessageIntegrationTests: BaseClosureIntegrationTestCase {
       )
     }
 
-    let reaction = try XCTUnwrap(result.reactions[":+1"]?.first)
-    let userId = reaction.uuid
+    let reaction = try XCTUnwrap(result.reactions.first)
 
-    XCTAssertEqual(userId, chat.currentUser.id)
+    XCTAssertEqual(reaction.value, ":+1")
+    XCTAssertTrue(reaction.isMine)
+    XCTAssertEqual(reaction.count, 1)
+    XCTAssertTrue(reaction.userIds.contains(chat.currentUser.id))
   }
 
   func testMessage_StreamUpdates() throws {

--- a/Tests/MessageIntegrationTests.swift
+++ b/Tests/MessageIntegrationTests.swift
@@ -274,7 +274,7 @@ final class MessageIntegrationTests: BaseClosureIntegrationTestCase {
         text: "This is reply in a thread",
         completion: $0
       )
-    }
+    }.threadChannel
 
     let threadChannelHistory = try awaitResultValue(delay: 4) {
       threadChannel.getHistory(
@@ -300,14 +300,14 @@ final class MessageIntegrationTests: BaseClosureIntegrationTestCase {
     }
   }
 
-  func testMessage_CreateThreadWithResult() throws {
+  func testMessage_CreateThread_WithResult() throws {
     let params = SendTextParams(
       meta: ["key": "value"],
       shouldStore: true
     )
 
     let result = try awaitResultValue {
-      testMessage.createThreadWithResult(
+      testMessage.createThread(
         text: "Thread reply with params",
         params: params,
         completion: $0

--- a/Tests/ThreadChannelIntegrationTests.swift
+++ b/Tests/ThreadChannelIntegrationTests.swift
@@ -64,6 +64,140 @@ class ThreadChannelIntegrationTests: BaseClosureIntegrationTestCase {
     try awaitResult { threadChannel.delete(completion: $0) }
   }
 
+  func testThreadChannel_Update() throws {
+    let updatedThreadChannel = try awaitResultValue {
+      threadChannel.update(
+        name: "UpdatedName",
+        custom: ["key": "value"],
+        description: "UpdatedDescription",
+        status: "UpdatedStatus",
+        completion: $0
+      )
+    }
+
+    XCTAssertEqual(updatedThreadChannel.id, threadChannel.id)
+    XCTAssertEqual(updatedThreadChannel.name, "UpdatedName")
+    XCTAssertEqual(updatedThreadChannel.channelDescription, "UpdatedDescription")
+    XCTAssertEqual(updatedThreadChannel.status, "UpdatedStatus")
+  }
+
+  func testThreadChannel_PinMessage() throws {
+    let message = try XCTUnwrap(
+      awaitResultValue(delay: 3) {
+        threadChannel.getHistory(
+          completion: $0
+        )
+      }.messages.first
+    )
+
+    let updatedThreadChannel = try awaitResultValue {
+      threadChannel.pinMessage(
+        message: message,
+        completion: $0
+      )
+    }
+
+    let pinnedMessage = try awaitResultValue {
+      updatedThreadChannel.getPinnedMessage(
+        completion: $0
+      )
+    }
+
+    XCTAssertNotNil(pinnedMessage)
+    XCTAssertEqual(pinnedMessage?.channelId, threadChannel.id)
+  }
+
+  func testThreadChannel_UnpinMessage() throws {
+    let message = try XCTUnwrap(
+      awaitResultValue(delay: 3) {
+        threadChannel.getHistory(
+          completion: $0
+        )
+      }.messages.first
+    )
+
+    let channelWithPinnedMessage = try awaitResultValue {
+      threadChannel.pinMessage(
+        message: message,
+        completion: $0
+      )
+    }
+
+    let updatedThreadChannel = try awaitResultValue {
+      channelWithPinnedMessage.unpinMessage(
+        completion: $0
+      )
+    }
+
+    let pinnedMessage = try awaitResultValue {
+      updatedThreadChannel.getPinnedMessage(
+        completion: $0
+      )
+    }
+
+    XCTAssertNil(pinnedMessage)
+  }
+
+  func testThreadChannel_GetHistory() throws {
+    let history = try awaitResultValue(delay: 3) {
+      threadChannel.getHistory(
+        completion: $0
+      )
+    }
+
+    XCTAssertEqual(history.messages.count, 1)
+    XCTAssertEqual(history.messages.first?.text, "Reply in a thread")
+    XCTAssertEqual(history.messages.first?.channelId, threadChannel.id)
+  }
+
+  func testThreadChannel_GetMessage() throws {
+    let historyMessage = try XCTUnwrap(
+      awaitResultValue(delay: 3) {
+        threadChannel.getHistory(
+          completion: $0
+        )
+      }.messages.first
+    )
+
+    let message = try awaitResultValue {
+      threadChannel.getMessage(
+        timetoken: historyMessage.timetoken,
+        completion: $0
+      )
+    }
+
+    XCTAssertNotNil(message)
+    XCTAssertEqual(message?.text, "Reply in a thread")
+    XCTAssertEqual(message?.channelId, threadChannel.id)
+  }
+
+  func testThreadChannel_GetPinnedMessage() throws {
+    let message = try XCTUnwrap(
+      awaitResultValue(delay: 3) {
+        threadChannel.getHistory(
+          completion: $0
+        )
+      }.messages.first
+    )
+
+    let updatedChannel = try awaitResultValue {
+      threadChannel.pinMessage(
+        message: message,
+        completion: $0
+      )
+    }
+
+    let pinnedMessage = try awaitResultValue {
+      updatedChannel.getPinnedMessage(
+        completion: $0
+      )
+    }
+
+    XCTAssertNotNil(pinnedMessage)
+    XCTAssertEqual(pinnedMessage?.text, "Reply in a thread")
+    XCTAssertEqual(pinnedMessage?.channelId, threadChannel.id)
+  }
+
   func testThreadChannel_PinMessageToParentChannel() throws {
     let message = try XCTUnwrap(
       awaitResultValue(delay: 3) {

--- a/Tests/ThreadMessageIntegrationTests.swift
+++ b/Tests/ThreadMessageIntegrationTests.swift
@@ -228,13 +228,12 @@ class ThreadMessageIntegrationTests: BaseClosureIntegrationTestCase {
       )
     }
 
-    let reaction = try XCTUnwrap(result.reactions[":+1"]?.first)
-    let userId = reaction.uuid
+    let reaction = try XCTUnwrap(result.reactions.first)
 
-    XCTAssertEqual(
-      userId,
-      chat.currentUser.id
-    )
+    XCTAssertEqual(reaction.value, ":+1")
+    XCTAssertTrue(reaction.isMine)
+    XCTAssertEqual(reaction.count, 1)
+    XCTAssertTrue(reaction.userIds.contains(chat.currentUser.id))
   }
 
   func testThreadMessage_StreamUpdates() throws {

--- a/Tests/ThreadMessageIntegrationTests.swift
+++ b/Tests/ThreadMessageIntegrationTests.swift
@@ -220,6 +220,27 @@ class ThreadMessageIntegrationTests: BaseClosureIntegrationTestCase {
     XCTAssertEqual((error as? ChatError)?.message, "There is no thread to be deleted.")
   }
 
+  func testThreadMessage_Restore() throws {
+    let message = try awaitResultValue {
+      threadMessage.delete(
+        soft: true,
+        completion: $0
+      )
+    }
+
+    XCTAssertNotNil(message?.deleted)
+    XCTAssertTrue(message?.deleted ?? false)
+
+    let restoredMessage = try awaitResultValue {
+      message?.restore(
+        completion: $0
+      )
+    }
+
+    XCTAssertNotNil(restoredMessage)
+    XCTAssertFalse(restoredMessage.deleted)
+  }
+
   func testThreadMessage_ToggleReaction() throws {
     let result = try awaitResultValue {
       threadMessage.toggleReaction(

--- a/Tests/UserIntegrationTests.swift
+++ b/Tests/UserIntegrationTests.swift
@@ -147,46 +147,11 @@ final class UserIntegrationTests: BaseClosureIntegrationTestCase {
         completion: $0
       )
     }
-    let deletedUser = try awaitResultValue {
+    try awaitResult {
       createdUser.delete(
-        soft: false,
         completion: $0
       )
     }
-
-    XCTAssertNil(deletedUser)
-
-    addTeardownBlock { [unowned self] in
-      try awaitResult {
-        chat.deleteUser(
-          id: createdUser.id,
-          completion: $0
-        )
-      }
-    }
-  }
-
-  func testUser_SoftDelete() throws {
-    let createdUser = try awaitResultValue {
-      chat.createUser(
-        user: testableUser(),
-        completion: $0
-      )
-    }
-    let deletedUser = try awaitResultValue {
-      createdUser.delete(
-        soft: true,
-        completion: $0
-      )
-    }
-
-    XCTAssertFalse(
-      deletedUser?.active ?? true
-    )
-    XCTAssertEqual(
-      createdUser.id,
-      deletedUser?.id
-    )
 
     addTeardownBlock { [unowned self] in
       try awaitResult {
@@ -200,9 +165,7 @@ final class UserIntegrationTests: BaseClosureIntegrationTestCase {
 
   func testUser_DeleteNotExistingUser() throws {
     let someUser = testableUser()
-    let resultValue = try awaitResultValue { someUser.delete(soft: false, completion: $0) }
-
-    XCTAssertNil(resultValue)
+    try awaitResult { someUser.delete(completion: $0) }
   }
 
   func testUser_WherePresent() throws {
@@ -448,9 +411,8 @@ final class UserIntegrationTests: BaseClosureIntegrationTestCase {
       expectation.fulfill()
     }
 
-    try awaitResultValue(delay: 3) {
+    try awaitResult(delay: 3) {
       createdUser.delete(
-        soft: false,
         completion: $0
       )
     }

--- a/Tests/UserIntegrationTests.swift
+++ b/Tests/UserIntegrationTests.swift
@@ -393,8 +393,6 @@ final class UserIntegrationTests: BaseClosureIntegrationTestCase {
     }
   }
 
-  // MARK: - Entity-first streaming API tests
-
   func testUser_OnUpdated() throws {
     let expectation = expectation(description: "OnUpdated")
     expectation.assertForOverFulfill = true

--- a/Tests/UserIntegrationTests.swift
+++ b/Tests/UserIntegrationTests.swift
@@ -392,4 +392,85 @@ final class UserIntegrationTests: BaseClosureIntegrationTestCase {
       }
     }
   }
+
+  // MARK: - Entity-first streaming API tests
+
+  func testUser_OnUpdated() throws {
+    let expectation = expectation(description: "OnUpdated")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    let createdUser = try awaitResultValue {
+      chat.createUser(
+        user: testableUser(),
+        completion: $0
+      )
+    }
+    let closeable = createdUser.onUpdated { user in
+      XCTAssertEqual(user.name, "NewName")
+      XCTAssertEqual(user.status, "NewStatus")
+      expectation.fulfill()
+    }
+
+    try awaitResultValue(delay: 3) {
+      createdUser.update(
+        name: "NewName",
+        status: "NewStatus",
+        completion: $0
+      )
+    }
+
+    wait(
+      for: [expectation],
+      timeout: 6
+    )
+    addTeardownBlock { [unowned self] in
+      closeable.close()
+      try awaitResult {
+        chat.deleteUser(
+          id: createdUser.id,
+          completion: $0
+        )
+      }
+    }
+  }
+
+  func testUser_OnDeleted() throws {
+    let expectation = expectation(description: "OnDeleted")
+    expectation.assertForOverFulfill = true
+    expectation.expectedFulfillmentCount = 1
+
+    let createdUser = try awaitResultValue {
+      chat.createUser(
+        user: testableUser(),
+        completion: $0
+      )
+    }
+    let closeable = createdUser.onDeleted {
+      expectation.fulfill()
+    }
+
+    try awaitResultValue(delay: 3) {
+      createdUser.delete(
+        soft: false,
+        completion: $0
+      )
+    }
+
+    wait(
+      for: [expectation],
+      timeout: 6
+    )
+    addTeardownBlock { [unowned self] in
+      closeable.close()
+      try awaitResult {
+        chat.deleteUser(
+          id: createdUser.id,
+          completion: $0
+        )
+      }
+    }
+  }
+
+  // swiftlint:disable:next file_length
 }


### PR DESCRIPTION
refactor(channel): refactor join to only set membership

BREAKING CHANGES: `Channel.join()` now only creates membership without subscribing or setting `lastReadMessageTimetoken`. Previous `join()` signature removed along with `JoinResult` type.

refactor(message): change reactions type

BREAKING CHANGES: `Message.reactions` changed from `[String: [Action]]` to `[MessageReaction]` with `isMine`, `userIds`, `count` per reaction.

refactor(message): simplify removeThread return type

BREAKING CHANGES: `Message.removeThread()` completion now returns `Void` instead of a tuple of remove result and optional channel.

refactor(channel): remove soft delete from delete

BREAKING CHANGES: `Channel.delete()` and `Chat.deleteChannel()` now permanently delete. The `soft` parameter is removed.

refactor(user): remove soft delete from delete

BREAKING CHANGES: `User.delete()` and `Chat.deleteUser()` now permanently delete. The `soft` parameter is removed.

feat(entities): add entity-first streaming API

All entities now expose `onXxx(callback:)` closure-based methods and a `stream` property with `AsyncStream`-based equivalents, replacing the previous `connect()`/`streamUpdates()` pattern.

feat(channel): add onMessageReceived and onTypingChanged

Added `Channel.onMessageReceived()` and `Channel.onTypingChanged()`, replacing deprecated `connect()` and `getTyping()`.

feat(channel): add sendText with SendTextParams

Added `Channel.sendText(text:params:completion:)` with new `SendTextParams` struct. Previous multi-param `sendText()` overload is deprecated.

feat(channel): add custom event support

Added `Channel.emitCustomEvent()` and `Channel.onCustomEvent()` for publishing and listening to custom events with message type filtering.

feat(channel): add getInvitees method

Added `Channel.getInvitees()` to return channel members with pending (invited) status.

feat(channel): add hasMember and getMember

Added `Channel.hasMember()` and `Channel.getMember()` membership-oriented convenience methods.

feat(channel-group): add onMessageReceived and onPresenceChanged

Added `ChannelGroup.onMessageReceived()` and `ChannelGroup.onPresenceChanged()`, replacing deprecated `connect()` and `streamPresence()`.

feat(user): add onUpdated, onDeleted, onMentioned, onInvited, onRestrictionChanged

Added `User.onUpdated()`, `User.onDeleted()`, `User.onMentioned()`, `User.onInvited()`, `User.onRestrictionChanged()`, replacing deprecated `streamUpdates()`.

feat(user): add isMemberOf and getMembership

Added `User.isMemberOf()` and `User.getMembership()` membership-oriented convenience methods.

feat(membership): add onUpdated and onDeleted

Added `Membership.onUpdated()` and `Membership.onDeleted()`, replacing deprecated `streamUpdates()`.

feat(membership): add status and type to update

`Membership.update()` now accepts optional `status` and `type` parameters alongside `custom`.

feat(membership): add delete method

Added `Membership.delete()` for deleting a membership relationship.

feat(message): add onUpdated

Added `Message.onUpdated()`, replacing deprecated `streamUpdates()` for listening to message edits and reaction changes.

feat(message): add createThread with SendTextParams

Added `Message.createThread(text:params:completion:)` returning `CreateThreadResult` with thread channel and updated parent message.

feat(thread-channel): add type-safe overrides

`ThreadChannelImpl` returns typed `ThreadChannelImpl` and `ThreadMessageImpl` from `update()`, `getMessage()`, `getPinnedMessage()`, `getHistory()` instead of base types.

feat(thread-channel): add onMessageReceived and onUpdated

Added `ThreadChannelImpl.onMessageReceived()` and `ThreadChannelImpl.onUpdated()`, returning typed `ThreadMessageImpl` and `ThreadChannelImpl` instead of base types.

feat(thread-message): add type-safe overrides

`ThreadMessageImpl` returns typed `ThreadMessageImpl` from `editText()`, `toggleReaction()`, `restore()` instead of base types.

feat(thread-message): add onUpdated

Added `ThreadMessageImpl.onUpdated()`, returning typed `ThreadMessageImpl` for thread message updates.

feat(config): add emitReadReceiptEvents option

Added `ChatConfiguration.emitReadReceiptEvents` as `[ChannelType: Bool]` for per-channel-type control over read receipt event emission. Defaults to `true` except for `.public` channels.

refactor(chat): deprecate emitEvent and listenForEvents

`Chat.emitEvent()` and `Chat.listenForEvents()` deprecated. Replaced by entity-level methods like `Channel.emitCustomEvent()` and `User.onMentioned()`.